### PR TITLE
Correcting naming of the package to aws/event-ruler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ To send us a pull request, please:
    3. Where possible stay consistent with the current code-style, patterns, and documentation language.
    4. Any changes (however minor, major, or ground-breaking) are welcomed, though reviewing them in isolation of any other changes helps us review them faster.
 3. Ensure local tests pass. Add new tests for any functionality you add / changed.
-4. Ensure there are no performance regressions by running [Benchmark Tests](https://github.com/aws/amazon-event-ruler/blob/main/src/test/software/amazon/event/ruler/Benchmarks.java).
-5. Commit to your fork using clear commit messages. [PULL_REQUEST_TEMPLATE.md](https://github.com/aws/amazon-event-ruler/blob/main/.github/PULL_REQUEST_TEMPLATE.md) shows the template we follow.
+4. Ensure there are no performance regressions by running [Benchmark Tests](https://github.com/aws/event-ruler/blob/main/src/test/software/amazon/event/ruler/Benchmarks.java).
+5. Commit to your fork using clear commit messages. [PULL_REQUEST_TEMPLATE.md](https://github.com/aws/event-ruler/blob/main/.github/PULL_REQUEST_TEMPLATE.md) shows the template we follow.
 6. Send us a pull request, answering any default questions in the pull request interface.
 7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
@@ -56,7 +56,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 ## Governance
 
-This project has governance model can be found in [GOVERNANCE.md](https://github.com/aws/amazon-event-ruler/blob/main/GOVERNANCE.md).
+This project has governance model can be found in [GOVERNANCE.md](https://github.com/aws/event-ruler/blob/main/GOVERNANCE.md).
 
 ## Security issue notifications
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Amazon Event Ruler
+# Event Ruler
 
-Amazon Event Ruler (called Ruler in rest of the doc for brevity) is a Java library 
+Event Ruler (called Ruler in rest of the doc for brevity) is a Java library 
 that allows matching **Rules** to **Events**. An event is a list of fields, which 
 may be given as name/value pairs or as a JSON object.  A rule associates event 
 field names with lists of possible values.  There are two reasons to use Ruler:

--- a/pom.xml
+++ b/pom.xml
@@ -18,16 +18,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>software.amazon.event.ruler</groupId>
-  <artifactId>amazon-event-ruler</artifactId>
-  <name>Amazon Event Ruler</name>
+  <artifactId>event-ruler</artifactId>
+  <name>Event Ruler</name>
   <version>1.0.0</version>
-  <description>Amazon Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
+  <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't
     depend on the number of Rules. 2/ Customers like the JSON "query language" for expressing rules.
 
   </description>
-  <url>https://github.com/aws/amazon-event-ruler/</url>
+  <url>https://github.com/aws/event-ruler/</url>
 
   <properties>
     <jackson.version>2.13.3</jackson.version>


### PR DESCRIPTION


### Issue #, if available:

### Description of changes:

based on the advice from OSS / Marketing folks as aws/amazon-event-ruler is confusing and not aws/event-ruler was a small and simple change.

Personally like the smaller name.

#### Benchmark / Performance (for source code changes):

N/A. Only text  and config changes. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
