### PR TITLE
Adding suffix to JsonRuleCompiler

### DIFF
--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -370,6 +370,16 @@ public class JsonRuleCompiler {
                 barf(parser, "Only one key allowed in match expression");
             }
             return pattern;
+        } else if (Constants.SUFFIX_MATCH.equals(matchTypeName)) {
+            final JsonToken suffixToken = parser.nextToken();
+            if (suffixToken != JsonToken.VALUE_STRING) {
+                barf(parser, "suffix match pattern must be a string");
+            }
+            final Patterns pattern = Patterns.suffixMatch(parser.getText() + '"'); // note no beginning quote
+            if (parser.nextToken() != JsonToken.END_OBJECT) {
+                barf(parser, "Only one key allowed in match expression");
+            }
+            return pattern;
         } else if (Constants.NUMERIC.equals(matchTypeName)) {
             final JsonToken numericalExpressionToken = parser.nextToken();
             if (numericalExpressionToken != JsonToken.START_ARRAY) {

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -93,6 +93,9 @@ public class JsonRuleCompilerTest {
         j = "{\"a\": [ { \"prefix\": \"child\" } ] }";
         assertNull("Good prefix should parse", JsonRuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"suffix\": \"child\" } ] }";
+        assertNull("Good suffix should parse", RuleCompiler.check(j));
+
         j = "{\"a\": [ { \"anything-but\": \"child\" } ] }";
         assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
 
@@ -132,10 +135,13 @@ public class JsonRuleCompilerTest {
         String[] badPatternTypes = {
                 "{\"a\": [ { \"exactly\": 33 } ] }",
                 "{\"a\": [ { \"prefix\": \"child\", \"foo\": [] } ] }",
-                "{\"a\": [ { \"foo\": \"child\" } ] }",
-                "{\"a\": [ { \"cidr\": \"foo\" } ] }",
                 "{\"a\": [ { \"prefix\": 3 } ] }",
                 "{\"a\": [ { \"prefix\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"suffix\": \"child\", \"foo\": [] } ] }",
+                "{\"a\": [ { \"suffix\": 3 } ] }",
+                "{\"a\": [ { \"suffix\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"foo\": \"child\" } ] }",
+                "{\"a\": [ { \"cidr\": \"foo\" } ] }",
                 "{\"a\": [ { \"anything-but\": \"child\", \"foo\": [] } ] }",
                 "{\"a\": [ { \"anything-but\": [1, 2 3] } ] }",
                 "{\"a\": [ { \"anything-but\": \"child\", \"foo\": [] } ] }",

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -103,6 +103,9 @@ public class RuleCompilerTest {
         j = "{\"a\": [ { \"prefix\": \"child\" } ] }";
         assertNull("Good prefix should parse", RuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"suffix\": \"child\" } ] }";
+        assertNull("Good suffix should parse", RuleCompiler.check(j));
+
         j = "{\"a\": [ { \"anything-but\": \"child\" } ] }";
         assertNull("Good anything-but should parse", RuleCompiler.check(j));
 
@@ -142,10 +145,13 @@ public class RuleCompilerTest {
         String[] badPatternTypes = {
                 "{\"a\": [ { \"exactly\": 33 } ] }",
                 "{\"a\": [ { \"prefix\": \"child\", \"foo\": [] } ] }",
-                "{\"a\": [ { \"foo\": \"child\" } ] }",
-                "{\"a\": [ { \"cidr\": \"foo\" } ] }",
                 "{\"a\": [ { \"prefix\": 3 } ] }",
                 "{\"a\": [ { \"prefix\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"suffix\": \"child\", \"foo\": [] } ] }",
+                "{\"a\": [ { \"suffix\": 3 } ] }",
+                "{\"a\": [ { \"suffix\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"foo\": \"child\" } ] }",
+                "{\"a\": [ { \"cidr\": \"foo\" } ] }",
                 "{\"a\": [ { \"anything-but\": \"child\", \"foo\": [] } ] }",
                 "{\"a\": [ { \"anything-but\": [1, 2 3] } ] }",
                 "{\"a\": [ { \"anything-but\": \"child\", \"foo\": [] } ] }",


### PR DESCRIPTION
### Description of changes:
JsonRuleCompiler is used for $or support. Right now, you can't have $or's with suffix matches.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
