### PR TITLE
Updating documentation to explain duplicate key deserialization behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,8 +682,31 @@ This behaviour may change in future version (to avoid any confusions) and should
 #### Caveat: JSON parsing and duplicate keys
 
 Events or Rules containing duplicate JSON keys are invalid. When duplicate keys are passed Ruler 
-will only consider the final value in the document order. This means following two rules
-will compile to the same internal representation.
+will only consider the final value in the document order. 
+
+This means following two rules will compile to the same internal representation.
+
+```javascript
+## has duplicate keys
+{
+  "source": ["aws.s3"],
+  "source": ["aws.sns"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail":  {
+      "eventSource": ["s3.amazonaws.com"],
+      "eventSource": ["sns.amazonaws.com"]
+  }
+}
+
+## has unique keys
+{
+  "source": ["aws.sns"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail": { "eventSource": ["sns.amazonaws.com"] }
+}
+```
+
+Similarly, following two *events* will be treated the same
 
 ```javascript
 ## has duplicate keys

--- a/README.md
+++ b/README.md
@@ -679,11 +679,11 @@ It also means that these rules will match against following two events :
 
 This behaviour may change in future version (to avoid any confusions) and should not be relied upon.
 
-#### Caveat: JSON parsing and duplicate Keys
+#### Caveat: JSON parsing and duplicate keys
 
-When Ruler deserializes Events or Rules containing duplicate JSON keys, it will only consider the
-final value in the document order. This means following two rules will compile to the same
-internal representation.
+Events or Rules containing duplicate JSON keys as invalid. When duplicate keys are passed Ruler 
+will only consider the final value in the document order. This means following two rules
+will compile to the same internal representation.
 
 ```javascript
 ## has duplicate keys

--- a/README.md
+++ b/README.md
@@ -691,9 +691,11 @@ will compile to the same internal representation.
   "source": ["aws.s3"],
   "source": ["aws.sns"],
   "detail-type": ["AWS API Call via CloudTrail"],
-  "detail": [
-    { "eventSource": ["s3.amazonaws.com"] },
-    { "eventSource": ["sns.amazonaws.com"] }
+  "detail":  [
+    {
+      "eventSource": ["s3.amazonaws.com"],
+      "eventSource": ["sns.amazonaws.com"]
+    }
   ]
 }
 

--- a/README.md
+++ b/README.md
@@ -679,6 +679,36 @@ It also means that these rules will match against following two events :
 
 This behaviour may change in future version (to avoid any confusions) and should not be relied upon.
 
+#### Caveat: JSON parsing and duplicate Keys
+
+When Ruler deserializes Events or Rules containing duplicate JSON keys, it will only consider the
+final value in the document order. This means following two rules will compile to the same
+internal representation.
+
+```javascript
+## has duplicate keys
+{
+  "source": ["aws.s3"],
+  "source": ["aws.sns"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail": [
+    { "eventSource": ["s3.amazonaws.com"] },
+    { "eventSource": ["sns.amazonaws.com"] }
+  ]
+}
+
+## has unique keys
+{
+  "source": ["aws.sns"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail": [
+    { "eventSource": ["sns.amazonaws.com"] }
+  ]
+}
+```
+
+This behaviour will change in future version (to avoid any confusions) and should not be relied upon.
+
 ## Performance
 
 We measure Ruler's performance by compiling multiple rules into a Machine and matching events provided as JSON strings.

--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ This behaviour may change in future version (to avoid any confusions) and should
 Events or Rules containing duplicate JSON keys are invalid. When duplicate keys are passed Ruler 
 will only consider the final value in the document order. 
 
-This means following two rules will compile to the same internal representation.
+This means following two rules will match the same events.
 
 ```javascript
 ## has duplicate keys

--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ This behaviour may change in future version (to avoid any confusions) and should
 
 #### Caveat: JSON parsing and duplicate keys
 
-Events or Rules containing duplicate JSON keys as invalid. When duplicate keys are passed Ruler 
+Events or Rules containing duplicate JSON keys are invalid. When duplicate keys are passed Ruler 
 will only consider the final value in the document order. This means following two rules
 will compile to the same internal representation.
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
   <version>1.0.0</version>
+  <packaging>jar</packaging>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't
@@ -30,7 +31,7 @@
   <url>https://github.com/aws/event-ruler/</url>
 
   <properties>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
     <jsr.version>3.0.2</jsr.version>
     <junit.version>4.13.2</junit.version>
     <compiler.plugin.version>3.10.1</compiler.plugin.version>

--- a/src/test/software/amazon/event/ruler/RulerTest.java
+++ b/src/test/software/amazon/event/ruler/RulerTest.java
@@ -568,6 +568,13 @@ public class RulerTest {
                 "    { \"eventSource\": \"sns.amazonaws.com\" }\n" +
                 "  ]\n" +
                 "}";
+        String eventsWithIgnoredKeys = "{\n" +
+                "  \"source\": \"aws.s3\",\n" +
+                "  \"detail-type\": \"AWS API Call via CloudTrail\",\n" +
+                "  \"detail\": [\n" +
+                "    { \"eventSource\": \"s3.amazonaws.com\" }\n" +
+                "  ]\n" +
+                "}";
         String[] eventsWithDuplicateKeys = {
                 "{\n" +
                         "  \"source\": \"aws.s3\",\n" +
@@ -602,6 +609,11 @@ public class RulerTest {
                 "  \"detail-type\": [\"AWS API Call via CloudTrail\"],\n" +
                 "  \"detail\":  { \"eventSource\": [\"sns.amazonaws.com\"] }\n" +
                 "}";
+        String ruleWithIgnoredKeys = "{\n" +
+                "  \"source\": [\"aws.s3\"],\n" +
+                "  \"detail-type\": [\"AWS API Call via CloudTrail\"],\n" +
+                "  \"detail\":  { \"eventSource\": [\"s3.amazonaws.com\"] }\n" +
+                "}";
         String[] rulesWithDuplicateKeys = {
                 "{\n" +
                         "  \"source\": [\"aws.s3\"],\n" +
@@ -631,15 +643,18 @@ public class RulerTest {
                         "}"
         };
 
-        Ruler.matchesRule(eventsWithUniqueKeys, ruleWithUniqueKeys);
+        assertTrue(Ruler.matchesRule(eventsWithUniqueKeys, ruleWithUniqueKeys));
+        assertFalse(Ruler.matchesRule(eventsWithIgnoredKeys, ruleWithUniqueKeys));
+        assertFalse(Ruler.matchesRule(eventsWithUniqueKeys, ruleWithIgnoredKeys));
 
         for(String event: eventsWithDuplicateKeys) {
-            Ruler.matchesRule(event, ruleWithUniqueKeys);
+            assertTrue(Ruler.matchesRule(event, ruleWithUniqueKeys));
+            assertFalse(Ruler.matchesRule(eventsWithIgnoredKeys, ruleWithUniqueKeys));
         }
 
         for(String rule: rulesWithDuplicateKeys) {
-            Ruler.matchesRule(eventsWithUniqueKeys, rule);
+            assertTrue(Ruler.matchesRule(eventsWithUniqueKeys, rule));
+            assertFalse(Ruler.matchesRule(eventsWithUniqueKeys, ruleWithIgnoredKeys));
         }
-
     }
 }


### PR DESCRIPTION


### Issue #, if available: https://github.com/aws/event-ruler/issues/22

### Description of changes:
This minor change is related to
https://github.com/aws/event-ruler/issues/22.
Would like to make sure there's at least something in the document
on the expected behaviour.

In future, this section can be updated with recommendation to
move to better APIs.

Also updating the pom.xml to make it easier to release changes. Going
forward, we'll enforce version bumps for key changes.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
