### PR TITLE
Fix scm url in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/aws/aws-secretsmanager-jdbc.git</url>
+    <url>https://github.com/aws/event-ruler.git</url>
   </scm>
 
   <developers>


### PR DESCRIPTION
### Issue #, if available: N/A

### Description of changes:

The `project.scm.url` value in `pom.xml` is pointing to another repository

#### Benchmark / Performance (for source code changes):

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
