### PR TITLE
some additional performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -29,19 +29,14 @@ class ACFinder {
         if (startState == null) {
             return Collections.emptyList();
         }
-        moveFrom(startState, 0, task, new ArrayMembership());
 
-        // each iteration removes a Step and adds zero or more new ones
-        while (task.stepsRemain()) {
-            tryStep(task);
-        }
+        moveFrom(startState, 0, task, new ArrayMembership());
 
         return task.getMatchedRules();
     }
 
     // remove a step from the work queue and see if there's a transition
-    private static void tryStep(final ACTask task) {
-        final ACStep step = task.nextStep();
+    private static void tryStep(final ACTask task, final ACStep step) {
         final Field field = task.event.fields.get(step.fieldIndex);
 
         // if we can step from where we are to the new field without violating array consistency
@@ -99,7 +94,7 @@ class ACFinder {
         tryMustNotExistMatch(fromState, task, fieldIndex, arrayMembership);
 
         while (fieldIndex < task.fieldCount) {
-            task.addStep(fieldIndex++, fromState, arrayMembership);
+            tryStep(task, new ACStep(fieldIndex++, fromState, arrayMembership));
         }
     }
 

--- a/src/main/software/amazon/event/ruler/ACTask.java
+++ b/src/main/software/amazon/event/ruler/ACTask.java
@@ -1,10 +1,8 @@
 package software.amazon.event.ruler;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Queue;
 
 /**
  * Represents the state of an Array-Consistent rule-finding project.
@@ -18,9 +16,6 @@ class ACTask {
     // the rules, if we find any
     private final HashSet<Object> rules = new HashSet<>();
 
-    // Steps queued up for processing
-    private final Queue<ACStep> stepQueue = new ArrayDeque<>();
-
     // the state machine
     private final GenericMachine<?> machine;
 
@@ -32,21 +27,6 @@ class ACTask {
 
     NameState startState() {
         return machine.getStartState();
-    }
-
-    ACStep nextStep() {
-        return stepQueue.remove();
-    }
-
-    /*
-     *  Add a step to the queue for later consideration
-     */
-    void addStep(final int fieldIndex, final NameState nameState, final ArrayMembership membershipSoFar) {
-        stepQueue.add(new ACStep(fieldIndex, nameState, membershipSoFar));
-    }
-
-    boolean stepsRemain() {
-        return !stepQueue.isEmpty();
     }
 
     List<Object> getMatchedRules() {

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -12,6 +12,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -812,7 +813,7 @@ class ByteMachine {
         Set<NameState> nextNameStates = new HashSet<>(pattern.getValues().size());
         for (String value : pattern.getValues()) {
             NameState matchPattern = findMatchPattern(getParser().parse(pattern.type(), value), pattern);
-            if (matchPattern != null) {
+            if (Objects.nonNull(matchPattern)) {
                 nextNameStates.add(matchPattern);
             }
         }

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -12,7 +12,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -810,9 +809,13 @@ class ByteMachine {
 
     private NameState findAnythingButPattern(AnythingBut pattern) {
 
-        Set<NameState> nextNameStates = pattern.getValues().stream().
-                map(value -> findMatchPattern(getParser().parse(pattern.type(), value), pattern)).
-                filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<NameState> nextNameStates = new HashSet<>(pattern.getValues().size());
+        for (String value : pattern.getValues()) {
+            NameState matchPattern = findMatchPattern(getParser().parse(pattern.type(), value), pattern);
+            if (matchPattern != null) {
+                nextNameStates.add(matchPattern);
+            }
+        }
         if (!nextNameStates.isEmpty()) {
             assert nextNameStates.size() == 1 : "nextNameStates.size() == 1";
             return nextNameStates.iterator().next();

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -12,7 +12,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -813,7 +812,7 @@ class ByteMachine {
         Set<NameState> nextNameStates = new HashSet<>(pattern.getValues().size());
         for (String value : pattern.getValues()) {
             NameState matchPattern = findMatchPattern(getParser().parse(pattern.type(), value), pattern);
-            if (Objects.nonNull(matchPattern)) {
+            if (matchPattern != null) {
                 nextNameStates.add(matchPattern);
             }
         }

--- a/src/main/software/amazon/event/ruler/ByteMap.java
+++ b/src/main/software/amazon/event/ruler/ByteMap.java
@@ -4,7 +4,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -194,7 +193,7 @@ class ByteMap {
     Set<ByteTransition> getTransitions() {
         Set<ByteTransition> result = new HashSet<>(map.values().size());
         for (ByteTransition transition : map.values()) {
-            if (Objects.nonNull(transition)) {
+            if (transition != null) {
                 result.add(transition);
             }
         }

--- a/src/main/software/amazon/event/ruler/ByteMap.java
+++ b/src/main/software/amazon/event/ruler/ByteMap.java
@@ -4,10 +4,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 
@@ -193,7 +191,9 @@ class ByteMap {
      * @return All transitions contained in this map.
      */
     Set<ByteTransition> getTransitions() {
-        return map.values().stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<ByteTransition> result = new HashSet<>(map.values());
+        result.remove(null);
+        return result;
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/ByteMap.java
+++ b/src/main/software/amazon/event/ruler/ByteMap.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -191,8 +192,12 @@ class ByteMap {
      * @return All transitions contained in this map.
      */
     Set<ByteTransition> getTransitions() {
-        Set<ByteTransition> result = new HashSet<>(map.values());
-        result.remove(null);
+        Set<ByteTransition> result = new HashSet<>(map.values().size());
+        for (ByteTransition transition : map.values()) {
+            if (Objects.nonNull(transition)) {
+                result.add(transition);
+            }
+        }
         return result;
     }
 

--- a/src/main/software/amazon/event/ruler/Patterns.java
+++ b/src/main/software/amazon/event/ruler/Patterns.java
@@ -1,8 +1,8 @@
 package software.amazon.event.ruler;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * The Patterns deal pre-processing of rules for the eventual matching against events.
@@ -50,12 +50,11 @@ public class Patterns implements Cloneable  {
     }
 
     public static AnythingBut anythingButMatch(final String anythingBut) {
-        return new AnythingBut(Stream.of(anythingBut).collect(Collectors.toSet()), false);
+        return new AnythingBut(Collections.singleton(anythingBut), false);
     }
 
     public static AnythingBut anythingButMatch(final double anythingBut) {
-        return new AnythingBut(Stream.of(anythingBut).map(ComparableNumber::generate).collect(Collectors.toSet()),
-                true);
+        return new AnythingBut(Collections.singleton(ComparableNumber.generate(anythingBut)), true);
     }
 
     public static AnythingBut anythingButMatch(final Set<String> anythingButs) {
@@ -63,8 +62,11 @@ public class Patterns implements Cloneable  {
     }
 
     public static AnythingBut anythingButNumberMatch(final Set<Double> anythingButs) {
-        return new AnythingBut(anythingButs.stream().map(ComparableNumber::generate).collect(Collectors.toSet()),
-                true);
+        Set<String> normalizedNumbers = new HashSet<>(anythingButs.size());
+        for (Double d : anythingButs) {
+            normalizedNumbers.add(ComparableNumber.generate(d));
+        }
+        return new AnythingBut(normalizedNumbers, true);
     }
 
     public static ValuePatterns anythingButPrefix(final String prefix) {

--- a/src/main/software/amazon/event/ruler/Range.java
+++ b/src/main/software/amazon/event/ruler/Range.java
@@ -1,9 +1,7 @@
 package software.amazon.event.ruler;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * Represents a range of numeric values to match against.
@@ -56,20 +54,26 @@ public class Range extends Patterns {
     public static Range lessThan(final double val) {
         return new Range(-Constants.FIVE_BILLION, false, val, true);
     }
+
     public static Range lessThanOrEqualTo(final double val) {
         return new Range(-Constants.FIVE_BILLION, false, val, false);
     }
+
     public static Range greaterThan(final double val) {
         return new Range(val, true, Constants.FIVE_BILLION, false);
     }
+
     public static Range greaterThanOrEqualTo(final double val) {
         return new Range(val, false, Constants.FIVE_BILLION, false);
     }
+
     public static Range between(final double bottom, final boolean openBottom, final double top, final boolean openTop) {
         return new Range(bottom, openBottom, top, openTop);
     }
 
-    private static Range deepCopy(final Range range) { return new Range(range); }
+    private static Range deepCopy(final Range range) {
+        return new Range(range);
+    }
 
     /**
      * This is necessitated by the fact that we do range comparisons of numbers, fixed-length strings of digits, and
@@ -77,30 +81,37 @@ public class Range extends Patterns {
      *  "for all digits between '3' and 'C'". This is for that.
      *
      * @param first Start one digit higher than this, for example '4'
-     * @param last Stop one digit lower than this 'B'
-     * @return The digit list, for example [ '4, '5', '6', '7', '8', '9', '9', 'A' ] (with 'B' for longDigitSequence)
+     * @param last Stop one digit lower than this, for example 'B'
+     * @return The digit list, for example [ '4', '5', '6', '7', '8', '9', '9', 'A' ] (with 'B' for longDigitSequence)
      */
-    static List<Byte> digitSequence(byte first, byte last, boolean includeFirst, boolean includeLast) {
-        assert first <= last && first <= 'F'&& first >= '0'&& last <= 'F' && last >= '0';
+    static byte[] digitSequence(byte first, byte last, boolean includeFirst, boolean includeLast) {
+        assert first <= last && first <= 'F' && first >= '0' && last <= 'F';
         assert !((first == last) && !includeFirst && !includeLast);
 
-        final List<Byte> bytes = new ArrayList<>();
-        int i = 0;
-        while (Constants.HEX_DIGITS[i] < first) {
-            i++;
-        }
+        int i = getHexByteIndex(first);
+        int j = getHexByteIndex(last);
 
         if ((!includeFirst) && (i < (Constants.HEX_DIGITS.length - 1))) {
             i++;
         }
-        while (Constants.HEX_DIGITS[i] < last) {
-            bytes.add(Constants.HEX_DIGITS[i++]);
-        }
+
         if (includeLast) {
-            bytes.add(Constants.HEX_DIGITS[i]);
+            j++;
         }
 
+        byte[] bytes = new byte[j - i];
+
+        System.arraycopy(Constants.HEX_DIGITS, i, bytes, 0, j - i);
+
         return bytes;
+    }
+
+    private static int getHexByteIndex(byte value) {
+        // ['0'-'9'] maps to [0-9] indexes
+        if (value >= 48 && value <= 57)
+            return value - 48;
+        // ['A'-'F'] maps to [10-15] indexes
+        return (value - 65) + 10;
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/Range.java
+++ b/src/main/software/amazon/event/ruler/Range.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
  *  implementation, the number of digits in the top and bottom of the range is the same.
  */
 public class Range extends Patterns {
-
     /**
      * Bottom and top of the range. openBottom true means we're looking for > bottom, false means >=
      *  Similarly, openTop true means we're looking for < top, false means <= top.
@@ -20,6 +19,8 @@ public class Range extends Patterns {
     final boolean openTop;
 
     final boolean isCIDR;
+
+    private static final int HEX_DIGIT_A_DECIMAL_VALUE = 10;
 
     private Range(final double bottom, final boolean openBottom, final double top, final boolean openTop) {
         super(MatchType.NUMERIC_RANGE);
@@ -108,11 +109,11 @@ public class Range extends Patterns {
 
     private static int getHexByteIndex(byte value) {
         // ['0'-'9'] maps to [0-9] indexes
-        if (value >= 48 && value <= 57) {
-            return value - 48;
+        if (value >= '0' && value <= '9') {
+            return value - '0';
         }
         // ['A'-'F'] maps to [10-15] indexes
-        return (value - 65) + 10;
+        return (value - 'A') + HEX_DIGIT_A_DECIMAL_VALUE;
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/Range.java
+++ b/src/main/software/amazon/event/ruler/Range.java
@@ -108,8 +108,9 @@ public class Range extends Patterns {
 
     private static int getHexByteIndex(byte value) {
         // ['0'-'9'] maps to [0-9] indexes
-        if (value >= 48 && value <= 57)
+        if (value >= 48 && value <= 57) {
             return value - 48;
+        }
         // ['A'-'F'] maps to [10-15] indexes
         return (value - 65) + 10;
     }

--- a/src/main/software/amazon/event/ruler/ShortcutTransition.java
+++ b/src/main/software/amazon/event/ruler/ShortcutTransition.java
@@ -2,8 +2,6 @@ package software.amazon.event.ruler;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 // Shortcut transition is designed mainly for exactly match by its memory consuming because the exactly match is always
 // in the last byte of value, while it will take a lots of memory if we build a traverse path byte by byte.
@@ -81,7 +79,7 @@ public class ShortcutTransition extends SingleByteTransition {
 
     @Override
     public Set<ShortcutTransition> getShortcuts() {
-        return Stream.of(this).collect(Collectors.toSet());
+        return Collections.singleton(this);
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/SingleByteTransition.java
+++ b/src/main/software/amazon/event/ruler/SingleByteTransition.java
@@ -2,8 +2,6 @@ package software.amazon.event.ruler;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a singular ByteTransition. This is in contrast to a compound ByteTransition that represents
@@ -43,7 +41,7 @@ abstract class SingleByteTransition extends ByteTransition {
         if (match == null) {
             return Collections.emptySet();
         }
-        return Stream.of(match).collect(Collectors.toSet());
+        return Collections.singleton(match);
     }
 
     /**
@@ -53,7 +51,7 @@ abstract class SingleByteTransition extends ByteTransition {
      */
     @Override
     Set<SingleByteTransition> expand() {
-        return Stream.of(this).collect(Collectors.toSet());
+        return Collections.singleton(this);
     }
 
     @Override

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -1,5 +1,6 @@
 package software.amazon.event.ruler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -9,6 +10,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -482,6 +484,66 @@ public class Benchmarks {
         bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
         bm.run(citylots2);
         System.out.println("COMBO events/sec: " + String.format("%.1f", bm.getEPS()));
+    }
+
+    // make sure we can handle nasty deep events
+    @Test
+    public void DeepEventBenchmark() throws Exception {
+
+        // how many levels deep we want to go
+        int maxLevel = 100;
+        // we create a rule every time the number of events is a multiple of this number
+        int ruleEveryNEvents = 10;
+
+        ObjectMapper m = new ObjectMapper();
+
+        Map<String, Object> root = new HashMap<>();
+
+        Map<String, Object> ruleRoot = new HashMap<>();
+
+        List<String> deepEvents = new ArrayList<>();
+        List<String> deepRules = new ArrayList<>();
+        List<Integer> deepExpected = new ArrayList<>();
+
+        Map<String, Object> currentLevel = root;
+        Map<String, Object> currentRule = ruleRoot;
+
+        for (int i = 0; i < maxLevel; i++) {
+            currentLevel.put("numeric" + i, i * i);
+            currentLevel.put("string" + i, "value" + i);
+
+
+            if (i % ruleEveryNEvents == 0) {
+                currentRule.put("string" + i, Collections.singletonList("value" + i));
+                deepRules.add(m.writeValueAsString(ruleRoot));
+                currentRule.remove("string" + i);
+                // all the events generated below this point will match this rule.
+                deepExpected.add(maxLevel - i);
+            }
+
+            deepEvents.add(m.writeValueAsString(root));
+
+            HashMap<String, Object> newLevel = new HashMap<>();
+            currentLevel.put("level" + i, newLevel);
+            currentLevel = newLevel;
+
+            HashMap<String, Object> newRuleLevel = new HashMap<>();
+            currentRule.put("level" + i, newRuleLevel);
+            currentRule = newRuleLevel;
+        }
+
+        // warm up
+        Benchmarker bm = new Benchmarker();
+        bm.addRules(deepRules.toArray(new String[0]), deepExpected.stream().mapToInt(Integer::intValue).toArray());
+        bm.run(deepEvents);
+
+        // exercise
+        bm = new Benchmarker();
+        bm.addRules(deepRules.toArray(new String[0]), deepExpected.stream().mapToInt(Integer::intValue).toArray());
+        bm.run(deepEvents);
+
+        System.out.println("DEEP EXACT events/sec: " + String.format("%.1f", bm.getEPS()));
+
     }
 
     private final List<String> citylots2 = new ArrayList<>();

--- a/src/test/software/amazon/event/ruler/CIDRTest.java
+++ b/src/test/software/amazon/event/ruler/CIDRTest.java
@@ -61,39 +61,40 @@ public class CIDRTest {
     @Test
     public void TestDigitSequence() {
 
-        List<Byte> l = Range.digitSequence((byte) '4', (byte) 'C', false, false);
-        byte[] wanted = { '5', '6', '7', '8', '9', 'A', 'B' };
+        byte[] l = Range.digitSequence((byte) '4', (byte) 'C', false, false);
+        byte[] wanted = {'5', '6', '7', '8', '9', 'A', 'B'};
         for (int i = 0; i < wanted.length; i++) {
-            assertEquals(wanted[i], (byte) l.get(i));
+            assertEquals(wanted[i], l[i]);
         }
         l = Range.digitSequence((byte) '4', (byte) 'C', true, false);
-        byte[] wanted2 = { '4', '5', '6', '7', '8', '9', 'A', 'B' };
+        byte[] wanted2 = {'4', '5', '6', '7', '8', '9', 'A', 'B'};
         for (int i = 0; i < wanted2.length; i++) {
-            assertEquals(wanted2[i], (byte) l.get(i));
+            assertEquals(wanted2[i], l[i]);
         }
         l = Range.digitSequence((byte) '4', (byte) 'C', false, true);
-        byte[] wanted3 = { '5', '6', '7', '8', '9', 'A', 'B', 'C' };
+        byte[] wanted3 = {'5', '6', '7', '8', '9', 'A', 'B', 'C'};
         for (int i = 0; i < wanted3.length; i++) {
-            assertEquals(wanted3[i], (byte) l.get(i));
+            assertEquals(wanted3[i], l[i]);
         }
         l = Range.digitSequence((byte) '4', (byte) 'C', true, true);
-        byte[] wanted4 = { '4', '5', '6', '7', '8', '9', 'A', 'B', 'C' };
+        byte[] wanted4 = {'4', '5', '6', '7', '8', '9', 'A', 'B', 'C'};
         for (int i = 0; i < wanted4.length; i++) {
-            assertEquals(wanted4[i], (byte) l.get(i));
+            assertEquals(wanted4[i], l[i]);
         }
 
-        Byte F = (byte) 'F';
+        byte F = (byte) 'F';
         try {
-            List<Byte> got;
+            byte[] got;
             got = Range.digitSequence((byte) 'F', (byte) 'F', false, true);
-            assertEquals(1, got.size());
-            assertEquals(F, got.get(0));
+            assertEquals(1, got.length);
+            assertEquals(F, got[0]);
             Range.digitSequence((byte) 'F', (byte) 'F', true, false);
-            assertEquals(1, got.size());
-            assertEquals(F, got.get(0));
+            assertEquals(1, got.length);
+            assertEquals(F, got[0]);
         } catch (RuntimeException e) {
             fail("Blew up on F-F seq");
         }
+
     }
 
     @Test


### PR DESCRIPTION
### Issue #25 :

### Description of changes:

Following up on the clues from the numeric benchmark slow speed I tested Tim comment about the recursion on ACTask instead of the stepQueue approach (witch is a big issue when we have millions of steps, and the ArrayDeque needs to grow), and indeed we got a nice speed bump by getting rid of the queue and going down using recursion instead. 

there are 3 individual items addresed here 
* remove stepQueue from ACTask and make it recursive instead
* remove Stream.of().collect(Collectors.toSet()) to create a one element sets, that is  very slow compared to Collections.singleton(). ( around 6 times better )
* another small optimization related with getting slices of hex digits used on the Range class ( around 4 times better )

togheter these changes made the numeric benchmark performance go up by around 60%

#### Benchmark / Performance:

```
BEFORE:

Reading citylots2
Read 213068 events
EXACT events/sec: 256708.4
WILDCARD events/sec: 200063.8
PREFIX events/sec: 297581.0
SUFFIX events/sec: 296339.4
EQUALS_IGNORE_CASE events/sec: 256399.5
NUMERIC events/sec: 3476.8
ANYTHING-BUT events/sec: 160806.0
COMBO events/sec: 3466.1
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 10579
Events/sec: 20140.7
 Rules/sec: 140984.6
Before: 212.3
After: 3029.5
Per rule: -7042
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2055
Events/sec: 103682.7
Before: 216.3
After: 1749.4
Per rule: -3832
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 1064
Events/sec: 200251.9
 Rules/sec: 729317345.9
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 14695
Events/sec: 14499.4
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 9711
Events/sec: 21940.9
 Rules/sec: 153586.2


AFTER:

Reading citylots2
Read 213068 events
EXACT events/sec: 273164.1
WILDCARD events/sec: 201007.5
PREFIX events/sec: 307901.7
SUFFIX events/sec: 307901.7
EQUALS_IGNORE_CASE events/sec: 271078.9
NUMERIC events/sec: 5424.3
ANYTHING-BUT events/sec: 172944.8
COMBO events/sec: 5280.0
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 9846
Events/sec: 21640.1
 Rules/sec: 151480.4
Before: 182.9
After: 3029.5
Per rule: -7116
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2211
Events/sec: 96367.3
Before: 216.3
After: 1749.4
Per rule: -3832
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 1066
Events/sec: 199876.2
 Rules/sec: 727949020.6
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 10880
Events/sec: 19583.5
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 9087
Events/sec: 23447.6
 Rules/sec: 164132.9


```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
