### PR TITLE
Splitting benchmark for numbers and complex arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,10 +688,11 @@ prefix-match, suffix-match, equals-ignore-case-match, wildcard-match, numeric-ma
 counts the matches, yields the following on a 2019 MacBook:
 
 Events are processed at over 220K/second except for:
- - equals-ignore-case matches, which are processed at over 180K/second.
+ - equals-ignore-case matches, which are processed at over 200K/second.
  - wildcard matches, which are processed at over 170K/second.
- - anything-but matches, which are processed at over 110K/second.
- - numeric matches, which are processed at over 2.5K/second.
+ - anything-but matches, which are processed at over 150K/second.
+ - numeric matches, which are processed at over 120K/second.
+ - complex array matches, which are processed at over 2.5K/second.
 
 ### Suggestions for better performance
 

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -184,7 +184,7 @@ public class Benchmarks {
     };
     private final int[] EQUALS_IGNORE_CASE_MATCHES = { 131, 211, 1758, 825, 116386 };
 
-    private final String[] NUMERIC_RULES = {
+    private final String[] COMPLEX_ARRAYS_RULES = {
       "{\n" +
               "  \"geometry\": {\n" +
               "    \"type\": [ \"Polygon\" ],\n" +
@@ -223,7 +223,48 @@ public class Benchmarks {
               "  }\n" +
               "}"
     };
-    private final int[] NUMERIC_MATCHES = { 227, 2, 149444, 64368, 127485 };
+    private final int[] COMPLEX_ARRAYS_MATCHES = { 227, 2, 149444, 64368, 127485 };
+
+    private final String[] NUMERIC_RULES = {
+            "{\n" +
+                    "  \"geometry\": {\n" +
+                    "    \"type\": [ \"Polygon\" ],\n" +
+                    "    \"firstCoordinates\": {\n" +
+                    "      \"x\": [ { \"numeric\": [ \"=\", -122.42916360922355 ] } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}",
+            "{\n" +
+                    "  \"geometry\": {\n" +
+                    "    \"type\": [ \"MultiPolygon\" ],\n" +
+                    "    \"firstCoordinates\": {\n" +
+                    "      \"z\": [ { \"numeric\": [ \"=\", 0 ] } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}",
+            "{\n" +
+                    "  \"geometry\": {\n" +
+                    "    \"firstCoordinates\": {\n" +
+                    "      \"x\": [ { \"numeric\": [ \"<\", -122.41600944012424 ] } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}",
+            "{\n" +
+                    "  \"geometry\": {\n" +
+                    "    \"firstCoordinates\": {\n" +
+                    "      \"x\": [ { \"numeric\": [ \">\", -122.41600944012424 ] } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}",
+            "{\n" +
+                    "  \"geometry\": {\n" +
+                    "    \"firstCoordinates\": {\n" +
+                    "      \"x\": [ { \"numeric\": [ \">\",  -122.46471267081272, \"<\", -122.4063085128395 ] } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}"
+    };
+    private final int[] NUMERIC_MATCHES = { 8, 120, 148943, 64120, 127053 };
 
     private final String[] ANYTHING_BUT_RULES = {
       "{\n" +
@@ -476,10 +517,28 @@ public class Benchmarks {
 
         bm = new Benchmarker();
 
+        bm.addRules(COMPLEX_ARRAYS_RULES, COMPLEX_ARRAYS_MATCHES);
+        bm.run(citylots2);
+        System.out.println("COMPLEX_ARRAYS events/sec: " + String.format("%.1f", bm.getEPS()));
+
+        // skips complex arrays matchers because their slowness can hide improvements
+        // and regressions for other matchers. Remove this once we find ways to make
+        // arrays fast enough to others matchers
+        bm = new Benchmarker();
+
         bm.addRules(NUMERIC_RULES, NUMERIC_MATCHES);
         bm.addRules(EXACT_RULES, EXACT_MATCHES);
         bm.addRules(PREFIX_RULES, PREFIX_MATCHES);
         bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
+        bm.run(citylots2);
+        System.out.println("PARTIAL_COMBO events/sec: " + String.format("%.1f", bm.getEPS()));
+
+        bm = new Benchmarker();
+        bm.addRules(NUMERIC_RULES, NUMERIC_MATCHES);
+        bm.addRules(EXACT_RULES, EXACT_MATCHES);
+        bm.addRules(PREFIX_RULES, PREFIX_MATCHES);
+        bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
+        bm.addRules(COMPLEX_ARRAYS_RULES, COMPLEX_ARRAYS_MATCHES);
         bm.run(citylots2);
         System.out.println("COMBO events/sec: " + String.format("%.1f", bm.getEPS()));
     }


### PR DESCRIPTION


### Issue #, if available: https://github.com/aws/event-ruler/issues/25

### Description of changes:

As part of https://github.com/aws/event-ruler/issues/25 realized that numeric matchers are orders of magnitude slow not because  of inherent issue within the matcher specific  code, but instead because the benchmarks were stressed while checking for complex arrays (don't have a better term for this yet, think "json arrays within arrays within ..." )

After splitting the matchers into two and introducing a second PARTIAL_COMBO benchmark, I was able to identify a regression I would have introduced within the ByteMachine.java for numeric ranges.

As part of this change we're also changing the citylots2.json.gz file and adding a new `firstCoordinates` key for numeric matching only. I tried other existing properties first but as none of them have floating points or large numbers, the benchmarks results were not matching my expectations. No licensing concerns with the modification of the dataset as the original citylots data was under public domain and the citylots2 dataset was created as part of this library. 


#### Benchmark / Performance (for source code changes):

```
Reading citylots2
Read 213068 events
EXACT events/sec: 213495.0
WILDCARD events/sec: 176526.9
PREFIX events/sec: 201387.5
SUFFIX events/sec: 226909.5
EQUALS_IGNORE_CASE events/sec: 197102.7
NUMERIC events/sec: 123804.8
ANYTHING-BUT events/sec: 139625.2
COMPLEX_ARRAYS events/sec: 1973.4
PARTIAL_COMBO events/sec: 72079.8
COMBO events/sec: 1178.5
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 12807
Events/sec: 16636.8
 Rules/sec: 116457.9
Before: 175.0
After: 1559.8
Per rule: -3462
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2763
Events/sec: 77114.7
Before: 223.0
After: 1410.1
Per rule: -2967
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 1195
Events/sec: 178299.6
 Rules/sec: 649367076.2
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 21613
Events/sec: 9858.3
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 11904
Events/sec: 17898.9
 Rules/sec: 125292.0

Process finished with exit code 0

```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
