### PR TITLE
Changing pom.xml to allow to maven publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't
@@ -30,12 +30,15 @@
   <url>https://github.com/aws/event-ruler/</url>
 
   <properties>
+    <jdk.version>1.8</jdk.version>
     <jackson.version>2.13.3</jackson.version>
     <jsr.version>3.0.2</jsr.version>
     <junit.version>4.13.2</junit.version>
-    <compiler.plugin.version>3.10.1</compiler.plugin.version>
+    <compiler.plugin.version>3.8.0</compiler.plugin.version>
     <javadoc.plugin.version>3.4.1</javadoc.plugin.version>
     <source.plugin.version>3.2.1</source.plugin.version>
+    <gpg.plugin.version>3.0.1</gpg.plugin.version>
+    <staging.plugin.version>1.6.8</staging.plugin.version>
     <checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
     <spotbugs.plugin.version>4.7.2.0</spotbugs.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -107,8 +110,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler.plugin.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
@@ -144,7 +147,7 @@
         <version>${checkstyle.plugin.version}</version>
         <configuration>
           <configLocation>${basedir}/config/checkstyle/checkstyle.xml</configLocation>
-          <encoding>UTF-8</encoding>
+          <encoding>${project.build.sourceEncoding}</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>false</failsOnError>
           <linkXRef>false</linkXRef>
@@ -188,8 +191,34 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${source.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${javadoc.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>${gpg.plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -203,12 +232,11 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <version>${staging.plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>sonatype-nexus-staging</serverId>
+              <serverId>ossrh</serverId>
               <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
 
   <properties>
     <jdk.version>1.8</jdk.version>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
     <jsr.version>3.0.2</jsr.version>
     <junit.version>4.13.2</junit.version>
-    <compiler.plugin.version>3.8.0</compiler.plugin.version>
+    <compiler.plugin.version>3.10.1</compiler.plugin.version>
     <javadoc.plugin.version>3.4.1</javadoc.plugin.version>
     <source.plugin.version>3.2.1</source.plugin.version>
     <gpg.plugin.version>3.0.1</gpg.plugin.version>


### PR DESCRIPTION
Changes are based on internal process. There's a gpg key & passphrase invovled. Will check with security on how that should work with all contributors seperately. For now, any internal amazon employee with admin permissions on this repo can publish via EventRuler profile. Steps will be :

1. Run `mvn deploy -Ppublishing` from the pkg
2. Visit staging repos via the user listed in https://issues.sonatype.org/browse/OSSRH-84940
3. Review the staged repo (esp the signatures)
4. Release
5. Validate that version is available to all via https://repo1.maven.org/maven2/software/amazon/event/ruler/event-ruler/ (can take few mins)
6. Announce on github & elsewhere

This is related to https://github.com/aws/event-ruler/issues/27

NOTE: Some other pkg version needed to be downgraded just to make different dependencies work well with each other. Expecting to gradually move all of these back up over time. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
