### PR TITLE
Minor version bump 1.0.4 for CVE-2022-42003

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't


### PR DESCRIPTION
While we're not affected by the CVE, many websites show potential CVE exposure like https://mvnrepository.com/artifact/software.amazon.event.ruler/event-ruler/1.0.3

This can discourage adopters (know of at least one case).

### Issue #, if available: N/A

### Description of changes:

Just version bump. No further changes. [Prior patch](https://github.com/aws/event-ruler/commit/5a71e034337c84f49d5d8186065ebfa6e5bab983) helped resolved the CVE

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
