### PR TITLE
use fastdoubleparser to improve double parsing speed

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
+import static com.fasterxml.jackson.core.io.NumberInput.parseDouble;
 import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 import static software.amazon.event.ruler.MatchType.EXACT;
 import static software.amazon.event.ruler.MatchType.EXISTS;
@@ -85,7 +86,7 @@ class ByteMachine {
         boolean fieldValueIsNumeric = false;
         if (hasNumeric.get() > 0) {
             try {
-                final double numerically = Double.parseDouble(valString);
+                final double numerically = parseDouble(valString);
                 valString = ComparableNumber.generate(numerically);
                 fieldValueIsNumeric = true;
             } catch (Exception e) {


### PR DESCRIPTION
### Description of changes:

as part of the latest updated jackson-databind that recently uptaked the fast double parser into it, we can now take advantage of this to improve our double parsing speed (that we happens very often). 

more information about the performance gains from the faster double parser can be found on the original issue at https://github.com/FasterXML/jackson-core/issues/577#issuecomment-1162596956

I can see that in my machine this change helps with the performance, so hopefully we can get some more information from other people results and decide if we want to merge. 

thanks!. 

#### Benchmark / Performance:

### Original
```
Reading citylots2
Read 213068 events
EXACT events/sec: 242674.3
WILDCARD events/sec: 190579.6
PREFIX events/sec: 275994.8
SUFFIX events/sec: 278520.3
EQUALS_IGNORE_CASE events/sec: 247465.7
NUMERIC events/sec: 154062.2
ANYTHING-BUT events/sec: 161171.0
COMPLEX_ARRAYS events/sec: 5052.0
PARTIAL_COMBO events/sec: 109942.2
COMBO events/sec: 3000.0
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 10197
Events/sec: 20895.2
 Rules/sec: 146266.2
Before: 225.2
After: 3056.0
Per rule: -7077
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2011
Events/sec: 105951.3
Before: 236.5
After: 1278.9
Per rule: -2605
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 1340
Events/sec: 159006.0
 Rules/sec: 579099743.3
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 11256
Events/sec: 18929.3
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 9501
Events/sec: 22425.8
 Rules/sec: 156980.9
DEEP EXACT events/sec: 14285.7
```

### Changes
```
Reading citylots2
Read 213068 events
EXACT events/sec: 247465.7
WILDCARD events/sec: 184155.6
PREFIX events/sec: 282583.6
SUFFIX events/sec: 274218.8
EQUALS_IGNORE_CASE events/sec: 235434.3
NUMERIC events/sec: 154845.9
ANYTHING-BUT events/sec: 160806.0
COMPLEX_ARRAYS events/sec: 6088.0
PARTIAL_COMBO events/sec: 108874.8
COMBO events/sec: 3660.5
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 10301
Events/sec: 20684.2
 Rules/sec: 144789.4
Before: 211.9
After: 2406.3
Per rule: -5485
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2098
Events/sec: 101557.7
Before: 245.3
After: 1352.7
Per rule: -2768
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 1381
Events/sec: 154285.3
 Rules/sec: 561907064.4
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 10224
Events/sec: 20840.0
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 9186
Events/sec: 23194.9
 Rules/sec: 162364.0
DEEP EXACT events/sec: 11111.1

```