### PR TITLE
Adding back try/catch inadvertently removed from CIDR code

### DIFF
--- a/src/main/software/amazon/event/ruler/CIDR.java
+++ b/src/main/software/amazon/event/ruler/CIDR.java
@@ -65,8 +65,8 @@ public class CIDR {
     }
 
     /**
-     * Converts a string to an IP address literal to isCIDR format Range if this is possible.  If not
-     *  possible, returns null
+     * Converts a string to an IP address literal to isCIDR format Range if this is possible.
+     * If not possible, returns null.
      * @param ip String that might be an IP address literal
      * @return Range with isCIDR as true
      */
@@ -74,27 +74,31 @@ public class CIDR {
         if (!isIPv4OrIPv6(ip)) {
             return null;
         }
-        final byte[] digits = toHexDigits(ipToBytes(ip));
-        final byte[] bottom = digits.clone();
-        final byte[] top = digits.clone();
-        boolean openBottom;
-        boolean openTop;
-        byte lastByte = top[top.length - 1];
+        try {
+            final byte[] digits = toHexDigits(ipToBytes(ip));
+            final byte[] bottom = digits.clone();
+            final byte[] top = digits.clone();
+            boolean openBottom;
+            boolean openTop;
+            byte lastByte = top[top.length - 1];
 
-        if (lastByte == MAX_DIGIT) {
-            bottom[top.length - 1] = (byte) (lastByte - 1);
-            openBottom = true;
-            openTop = false;
-        } else {
-            if (lastByte != HEX_DIGITS[9]) {
-                top[top.length - 1] = (byte) (lastByte + 1);
+            if (lastByte == MAX_DIGIT) {
+                bottom[top.length - 1] = (byte) (lastByte - 1);
+                openBottom = true;
+                openTop = false;
             } else {
-                top[top.length - 1] = HEX_DIGITS[10];
+                if (lastByte != HEX_DIGITS[9]) {
+                    top[top.length - 1] = (byte) (lastByte + 1);
+                } else {
+                    top[top.length - 1] = HEX_DIGITS[10];
+                }
+                openBottom = false;
+                openTop = true;
             }
-            openBottom = false;
-            openTop = true;
+            return new Range(bottom, openBottom, top, openTop, true);
+        } catch (Exception e) {
+            return null;
         }
-        return new Range(bottom, openBottom, top, openTop, true);
     }
 
     private static byte[] toHexDigits(final byte[] address) {

--- a/src/test/software/amazon/event/ruler/CIDRTest.java
+++ b/src/test/software/amazon/event/ruler/CIDRTest.java
@@ -3,6 +3,7 @@ package software.amazon.event.ruler;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -249,6 +250,14 @@ public class CIDRTest {
             tryDeletingAsRule(m, c);
         }
         assertTrue(m.isEmpty());
+    }
+
+    @Test
+    public void testInvalidIPMatchedByIPv6Regex() throws Exception {
+        String invalidIpRule = "{ \"a\": [ \"08:23\" ] }";
+        Machine machine = new Machine();
+        machine.addRule("r1", invalidIpRule);
+        assertEquals(Arrays.asList("r1"), machine.rulesForJSONEvent("{ \"a\": [ \"08:23\" ] }"));
     }
 
     private void tryAddingAsRule(Machine m, Range r) {


### PR DESCRIPTION
This try/catch was inadvertently removed as part of the wildcard matching PR (#18). The effect of this is certain strings that fail to be parsed as CIDR will bubble-up an exception instead of being treated as an exact match. Reverting to be like before.