### PR TITLE
Fixing MachineComplexityEvaluator to evaluate machines nested via next NameStates

### DIFF
--- a/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
+++ b/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
@@ -31,20 +31,19 @@ public class MachineComplexityEvaluator {
     /**
      * Returns the maximum possible number of wildcard rule prefixes that could match a theoretical input value for a
      * machine beginning with ByteState state. This value is equivalent to the maximum number of states a traversal
-     * could be present in simultaneously, counting only states that can lead to a wildcard rule pattern. Caps out
-     * evaluation at maxComplexity to keep runtime under control. Otherwise, runtime for this machine would be O(N^2),
-     * where N is the number of states accessible from ByteState state. This function will also recursively evaluate all
-     * other machines accessible via next NameStates, and will return the maximum observed from any machine.
+     * could be present in simultaneously, counting only states that can lead to a wildcard match pattern. This function
+     * will recursively evaluate all other machines accessible via next NameStates, and will return the maximum observed
+     * from any machine. Caps out evaluation at maxComplexity to keep runtime under control. Otherwise, runtime for this
+     * machine would be O(MN^2), where N is the number of states accessible from ByteState state, and M is the total
+     * number of ByteMachines accessible via next NameStates.
      *
      * @param state Evaluates a machine beginning at this state.
      * @return The lesser of maxComplexity and the maximum possible number of wildcard rule prefixes from any machines.
      */
     int evaluate(ByteState state) {
-        // Upfront cost: generate the map of all the wildcard patterns accessible from every state in the machine.
-        // This also evaluates the complexity of all nested machines via next Namestates.
-        Map<SingleByteTransition, Set<Patterns>> wildcardPatternsAccessibleFromEachTransition = new HashMap<>();
-        int nextNameStateMaxSize = getAccessibleWildcardPatternsAndMaxNextNameStateComplexity(state,
-                wildcardPatternsAccessibleFromEachTransition);
+        // Upfront cost: generate the map of all matches accessible from every state in the machine.
+        Map<SingleByteTransition, Set<ByteMatch>> matchesAccessibleFromEachTransition =
+                getMatchesAccessibleFromEachTransition(state);
 
         Set<ByteTransition> visited = new HashSet<>();
         visited.add(state);
@@ -63,7 +62,7 @@ public class MachineComplexityEvaluator {
             // current traversal is the number of wildcard rule prefixes matching a theoretical worst-case input value.
             int size = 0;
             for (SingleByteTransition single : transition.expand()) {
-                size += wildcardPatternsAccessibleFromEachTransition.get(single).size();
+                size += getWildcardPatterns(matchesAccessibleFromEachTransition.get(single)).size();
 
                 // Look for "transitions for all bytes" (i.e. wildcard transitions). Since an input value that matches
                 // foo will also match foo*, we also need to include in our size wildcard patterns accessible from foo*.
@@ -73,7 +72,8 @@ public class MachineComplexityEvaluator {
                     for (SingleByteTransition transitionForAllBytes : transitionsForAllBytes) {
                         if (!(transitionForAllBytes instanceof ByteMachine.EmptyByteTransition) &&
                                 !(transition.expand().contains(transitionForAllBytes))) {
-                            size += wildcardPatternsAccessibleFromEachTransition.get(transitionForAllBytes).size();
+                            size += getWildcardPatterns(matchesAccessibleFromEachTransition.get(transitionForAllBytes))
+                                    .size();
                         }
                     }
                 }
@@ -93,49 +93,56 @@ public class MachineComplexityEvaluator {
             }
         }
 
-        return Math.max(nextNameStateMaxSize, maxSize);
+        // Now that we have a maxSize for this ByteMachine, let's recursively get the maxSize for each next NameState
+        // accessible via any of this ByteMachine's matches. We will return the maximum maxSize.
+        int maxSizeFromNextNameStates = 0;
+        Set<ByteMatch> uniqueMatches = new HashSet<>();
+        for (Set<ByteMatch> matches : matchesAccessibleFromEachTransition.values()) {
+            uniqueMatches.addAll(matches);
+        }
+        for (ByteMatch match : uniqueMatches) {
+            NameState nextNameState = match.getNextNameState();
+            if (nextNameState != null) {
+                maxSizeFromNextNameStates = Math.max(maxSizeFromNextNameStates, nextNameState.evaluateComplexity(this));
+            }
+        }
+
+        return Math.max(maxSize, maxSizeFromNextNameStates);
     }
 
     /**
-     * Populates a map of SingleByteTransition to all the wildcard patterns accessible from the SingleByteTransition.
-     * The map includes all SingleByteTransitions accessible from ByteState state. Also recursively evaluates the
-     * complexity of all other machines accessible through any next NameStates from this machine's matches. This
-     * function is O(N), where N is the number of states accessible from ByteState state, plus the time to recursively
-     * evaluate all other machines, which caps out below O(N^2) for each machine.
-     *
-     * Note: this function has two purposes. Although we could split this into two separate functions, doing it this way
-     * saves a traversal.
+     * Generates a map of SingleByteTransition to all the matches accessible from the SingleByteTransition. The map
+     * includes all SingleByteTransitions accessible from ByteState state. This function is O(N), where N is the number
+     * of states accessible from ByteState state.
      *
      * @param state Starting state.
-     * @param result Populate this map with all SingleByteTransitions mapped to all accessible wildcard patterns.
-     * @return The maximum complexity from all other machines accessible through any next NameStates.
+     * @return A map of SingleByteTransition to all the matches accessible from the SingleByteTransition
      */
-    private int getAccessibleWildcardPatternsAndMaxNextNameStateComplexity(ByteState state,
-                                                                           Map<SingleByteTransition, Set<Patterns>> result) {
-        int maxComplexity = 0;
+    private Map<SingleByteTransition, Set<ByteMatch>> getMatchesAccessibleFromEachTransition(ByteState state) {
+        Map<SingleByteTransition, Set<ByteMatch>> result = new HashMap<>();
         Set<SingleByteTransition> visited = new HashSet<>();
         Stack<SingleByteTransition> stack = new Stack<>();
         stack.push(state);
 
-        // We'll do a depth-first-search as a state's patterns can only be computed once the computation is complete for
+        // We'll do a depth-first-search as a state's matches can only be computed once the computation is complete for
         // all deeper states. Let's avoid recursion, which is prone to stack overflow.
         while (!stack.isEmpty()) {
-            // Peek instead of pop. Need this transition to remain on stack so we can compute its patterns once all
+            // Peek instead of pop. Need this transition to remain on stack so we can compute its matches once all
             // deeper states are complete.
             SingleByteTransition transition = stack.peek();
             if (!result.containsKey(transition)) {
                 result.put(transition, new HashSet<>());
             }
-            Set<Patterns> patterns = result.get(transition);
+            Set<ByteMatch> matches = result.get(transition);
 
             // Visited means we have already processed this transition once (via peeking) and have since computed the
-            // patterns for all deeper states. Time to compute this transition's patterns then pop it from the stack.
+            // matches for all deeper states. Time to compute this transition's matches then pop it from the stack.
             if (visited.contains(transition)) {
                 ByteState nextState = transition.getNextByteState();
                 if (nextState != null) {
                     for (ByteTransition eachTransition : nextState.getTransitions()) {
                         for (SingleByteTransition single : eachTransition.expand()) {
-                            patterns.addAll(result.get(single));
+                            matches.addAll(result.get(single));
                         }
                     }
                 }
@@ -145,22 +152,11 @@ public class MachineComplexityEvaluator {
 
             visited.add(transition);
 
-            // Consider all patterns directly accessible from this transition.
-            for (ByteMatch match : transition.getMatches()) {
-                // Add pattern if it is a wildcard pattern.
-                if (match.getPattern().type() == WILDCARD) {
-                    patterns.add(match.getPattern());
-                }
-
-                // Evaluate the complexity of any next NameState.
-                NameState nextNameState = match.getNextNameState();
-                if (nextNameState != null) {
-                    maxComplexity = Math.max(maxComplexity, nextNameState.evaluateComplexity(this));
-                }
-            }
+            // Add all matches directly accessible from this transition.
+            matches.addAll(transition.getMatches());
 
             // Push the next round of deeper states into the stack. By the time we return back to the current transition
-            // on the stack, all patterns for deeper states will have been computed.
+            // on the stack, all matches for deeper states will have been computed.
             ByteState nextState = transition.getNextByteState();
             if (nextState != null) {
                 for (ByteTransition eachTransition : nextState.getTransitions()) {
@@ -173,7 +169,17 @@ public class MachineComplexityEvaluator {
             }
         }
 
-        return maxComplexity;
+        return result;
+    }
+
+    private static Set<Patterns> getWildcardPatterns(Set<ByteMatch> matches) {
+        Set<Patterns> patterns = new HashSet<>();
+        for (ByteMatch match : matches) {
+            if (match.getPattern().type() == WILDCARD) {
+                patterns.add(match.getPattern());
+            }
+        }
+        return patterns;
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -379,6 +379,17 @@ public class MachineComplexityEvaluatorTest {
                                     Patterns.wildcardMatch("Fea*tureFeature"));
     }
 
+    @Test
+    public void testEvaluateNestedMachinesViaNextNameStates() throws Exception {
+        Machine machine = new Machine();
+        machine.addRule("name", "{" +
+                "\"abc\": [ { \"prefix\": \"a\" }, \"abcdef\", { \"suffix\": \"z\" } ]," +
+                "\"def\": [ { \"prefix\": \"b\" }, { \"wildcard\": \"a*a*a*a*a*a*\" }, { \"suffix\": \"c\" } ]," +
+                "\"ghi\": [ { \"prefix\": \"a\" }, \"abcdef\", { \"suffix\": \"z\" } ]" +
+                "}");
+        assertEquals(11, machine.evaluateComplexity(evaluator));
+    }
+
     /**
      * I'm not going to try to determine the maximum complexity input string. This is here just to demonstrate that this
      * set of rules, which has proven problematic for Quamina in the past, is handled ok by Ruler.


### PR DESCRIPTION
MachineComplexityEvaluator was not considering next NameStates. So complexity was only accurate if max complexity occurred in first ByteMachine.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
