### PR TITLE
support anything-but suffix matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ Anything-but prefix:
   }
 }
 ```
+
+Anything-but suffix:
+```javascript
+{
+  "detail": {
+    "instance-id": [ { "anything-but": { "suffix": "1234" } } ]
+  }
+}
+```
+
 ### Numeric matching
 ```javascript
 {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.0.6</version>
+  <version>1.1.0</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -479,7 +479,7 @@ class ByteMachine {
                         case PREFIX:
                             transitionTo.add(match.getNextNameState());
                             break;
-
+                        case ANYTHING_BUT_SUFFIX:
                         case SUFFIX:
                         case EXISTS:
                             // we already harvested these matches via separate functions due to special matching
@@ -501,7 +501,6 @@ class ByteMachine {
                                 failedAnythingButs.add(match.getNextNameState());
                             }
                             break;
-                        case ANYTHING_BUT_SUFFIX:
                         case ANYTHING_BUT_PREFIX:
                             failedAnythingButs.add(match.getNextNameState());
                             break;

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -23,6 +23,8 @@ import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 import static software.amazon.event.ruler.MatchType.EXACT;
 import static software.amazon.event.ruler.MatchType.EXISTS;
 import static software.amazon.event.ruler.MatchType.SUFFIX;
+import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_SUFFIX;
+
 import static software.amazon.event.ruler.input.MultiByte.MAX_FIRST_BYTE_FOR_ONE_BYTE_CHAR;
 import static software.amazon.event.ruler.input.MultiByte.MAX_FIRST_BYTE_FOR_TWO_BYTE_CHAR;
 import static software.amazon.event.ruler.input.MultiByte.MAX_NON_FIRST_BYTE;
@@ -135,6 +137,7 @@ class ByteMachine {
             case PREFIX:
             case SUFFIX:
             case ANYTHING_BUT_PREFIX:
+            case ANYTHING_BUT_SUFFIX:
             case EQUALS_IGNORE_CASE:
             case WILDCARD:
                 assert pattern instanceof ValuePatterns;
@@ -440,7 +443,7 @@ class ByteMachine {
         addExistenceMatch(transitionTo);
 
         // attempt to harvest the possible suffix match
-        addSuffixMatch(val, transitionTo);
+        addSuffixMatch(val, transitionTo, failedAnythingButs);
 
         if (startStateMatch != null) {
             transitionTo.add(startStateMatch.getNextNameState());
@@ -498,7 +501,7 @@ class ByteMachine {
                                 failedAnythingButs.add(match.getNextNameState());
                             }
                             break;
-
+                        case ANYTHING_BUT_SUFFIX:
                         case ANYTHING_BUT_PREFIX:
                             failedAnythingButs.add(match.getNextNameState());
                             break;
@@ -551,7 +554,7 @@ class ByteMachine {
         }
     }
 
-    private void addSuffixMatch(final byte[] val, final Set<NameState> transitionTo) {
+    private void addSuffixMatch(final byte[] val, final Set<NameState> transitionTo, Set<NameState> failedAnythingButs) {
         // we only attempt to evaluate suffix matches when there is suffix match in current byte machine instance.
         // it works as performance level to avoid other type of matches from being affected by suffix checking.
         if (hasSuffix.get() > 0) {
@@ -562,8 +565,11 @@ class ByteMachine {
                 for (ByteMatch match : nextTrans.getMatches()) {
                     // given we are traversing in reverse order (from right to left), only suffix matches are eligible
                     // to be collected.
-                    if (match.getPattern().type() == SUFFIX) {
+                    MatchType patternType = match.getPattern().type();
+                    if (patternType == SUFFIX) {
                         transitionTo.add(match.getNextNameState());
+                    } else if(patternType == ANYTHING_BUT_SUFFIX) {
+                        failedAnythingButs.add(match.getNextNameState());
                     }
                 }
                 trans = nextTrans.getTransitionForNextByteStates();
@@ -614,6 +620,7 @@ class ByteMachine {
                 assert pattern instanceof AnythingBut;
                 return addAnythingButPattern((AnythingBut) pattern);
 
+            case ANYTHING_BUT_SUFFIX:
             case ANYTHING_BUT_PREFIX:
             case EXACT:
             case NUMERIC_EQ:
@@ -796,6 +803,7 @@ class ByteMachine {
         case NUMERIC_EQ:
         case PREFIX:
         case SUFFIX:
+        case ANYTHING_BUT_SUFFIX:
         case ANYTHING_BUT_PREFIX:
         case EQUALS_IGNORE_CASE:
         case WILDCARD:
@@ -1511,6 +1519,10 @@ class ByteMachine {
                 hasNumeric.incrementAndGet();
             }
             break;
+        case ANYTHING_BUT_SUFFIX:
+            hasSuffix.incrementAndGet();
+            anythingButs.add(match.getNextNameState());
+            break;
         case ANYTHING_BUT_PREFIX:
             anythingButs.add(match.getNextNameState());
             break;
@@ -1605,6 +1617,10 @@ class ByteMachine {
             if (((AnythingBut) pattern).isNumeric()) {
                 hasNumeric.decrementAndGet();
             }
+            break;
+        case ANYTHING_BUT_SUFFIX:
+            hasSuffix.decrementAndGet();
+            anythingButs.remove(match.getNextNameState());
             break;
         case ANYTHING_BUT_PREFIX:
             anythingButs.remove(match.getNextNameState());

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -408,7 +408,7 @@ public class JsonRuleCompiler {
                 }
                 final JsonToken anythingButParamType = parser.nextToken();
                 if (anythingButParamType != JsonToken.VALUE_STRING) {
-                    barf(parser, "prefix match pattern must be a string");
+                    barf(parser, "prefix/suffix match pattern must be a string");
                 }
                 final String text = parser.getText();
                 if (text.isEmpty()) {

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -401,25 +401,30 @@ public class JsonRuleCompiler {
                     barf(parser, "Anything-But expression name not found");
                 }
                 final String anythingButObjectOp = parser.getCurrentName();
-                if (!Constants.PREFIX_MATCH.equals(anythingButObjectOp)) {
+                final boolean isPrefix = Constants.PREFIX_MATCH.equals(anythingButObjectOp);
+                final boolean isSuffix = Constants.SUFFIX_MATCH.equals(anythingButObjectOp);
+                if (!isPrefix && !isSuffix) {
                     barf(parser, "Unsupported anything-but pattern: " + anythingButObjectOp);
                 }
-                final JsonToken anythingButPrefix = parser.nextToken();
-                if (anythingButPrefix != JsonToken.VALUE_STRING) {
+                final JsonToken anythingButParamType = parser.nextToken();
+                if (anythingButParamType != JsonToken.VALUE_STRING) {
                     barf(parser, "prefix match pattern must be a string");
                 }
-                final String prefixText = parser.getText();
-                if (prefixText.isEmpty()) {
-                    barf(parser, "Null prefix not allowed");
-                }
-                final Patterns pattern = Patterns.anythingButPrefix('"' + prefixText); // note no trailing quote
-                if (parser.nextToken() != JsonToken.END_OBJECT) {
-                    barf(parser, "Only one key allowed in match expression");
+                final String text = parser.getText();
+                if (text.isEmpty()) {
+                    barf(parser, "Null prefix/suffix not allowed");
                 }
                 if (parser.nextToken() != JsonToken.END_OBJECT) {
                     barf(parser, "Only one key allowed in match expression");
                 }
-                return pattern;
+                if (parser.nextToken() != JsonToken.END_OBJECT) {
+                    barf(parser, "Only one key allowed in match expression");
+                }
+                if(isPrefix) {
+                    return  Patterns.anythingButPrefix('"' + text); // note no trailing quote
+                } else {
+                    return  Patterns.anythingButSuffix(text + '"'); // note no leading quote
+                }
             }
 
             if (anythingButExpressionToken != JsonToken.START_ARRAY &&

--- a/src/main/software/amazon/event/ruler/MatchType.java
+++ b/src/main/software/amazon/event/ruler/MatchType.java
@@ -13,6 +13,7 @@ public enum MatchType {
     NUMERIC_RANGE,       // numeric range with high & low bound & </<=/>/>= options
     ANYTHING_BUT,        // black list effect
     ANYTHING_BUT_PREFIX, // anything that doesn't start with this
+    ANYTHING_BUT_SUFFIX, // anything that doesn't end with this
     EQUALS_IGNORE_CASE,  // case-insensitive string match
     WILDCARD,             // string match using one or more non-consecutive '*' wildcard characters
 }

--- a/src/main/software/amazon/event/ruler/Patterns.java
+++ b/src/main/software/amazon/event/ruler/Patterns.java
@@ -73,6 +73,10 @@ public class Patterns implements Cloneable  {
         return new ValuePatterns(MatchType.ANYTHING_BUT_PREFIX, prefix);
     }
 
+    public static ValuePatterns anythingButSuffix(final String suffix) {
+        return new ValuePatterns(MatchType.ANYTHING_BUT_SUFFIX, new StringBuilder(suffix).reverse().toString());
+    }
+
     public static ValuePatterns numericEquals(final double val) {
         return new ValuePatterns(MatchType.NUMERIC_EQ, ComparableNumber.generate(val));
     }

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -299,7 +299,8 @@ public final class RuleCompiler {
                     barf(parser, "Anything-But expression name not found");
                 }
                 final String anythingButObjectOp = parser.getCurrentName();
-                if (!Constants.PREFIX_MATCH.equals(anythingButObjectOp)) {
+                if (!Constants.PREFIX_MATCH.equals(anythingButObjectOp) &&
+                    !Constants.SUFFIX_MATCH.equals(anythingButObjectOp)) {
                     barf(parser, "Unsupported anything-but pattern: " + anythingButObjectOp);
                 }
                 final JsonToken anythingButPrefix = parser.nextToken();

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -299,26 +299,30 @@ public final class RuleCompiler {
                     barf(parser, "Anything-But expression name not found");
                 }
                 final String anythingButObjectOp = parser.getCurrentName();
-                if (!Constants.PREFIX_MATCH.equals(anythingButObjectOp) &&
-                    !Constants.SUFFIX_MATCH.equals(anythingButObjectOp)) {
+                final boolean isPrefix = Constants.PREFIX_MATCH.equals(anythingButObjectOp);
+                final boolean isSuffix = Constants.SUFFIX_MATCH.equals(anythingButObjectOp);
+                if (!isPrefix && !isSuffix) {
                     barf(parser, "Unsupported anything-but pattern: " + anythingButObjectOp);
                 }
-                final JsonToken anythingButPrefix = parser.nextToken();
-                if (anythingButPrefix != JsonToken.VALUE_STRING) {
-                    barf(parser, "prefix match pattern must be a string");
+                final JsonToken anythingButParamType = parser.nextToken();
+                if (anythingButParamType != JsonToken.VALUE_STRING) {
+                    barf(parser, "prefix/suffix match pattern must be a string");
                 }
-                final String prefixText = parser.getText();
-                if (prefixText.isEmpty()) {
-                    barf(parser, "Null prefix not allowed");
-                }
-                final Patterns pattern = Patterns.anythingButPrefix('"' + prefixText); // note no trailing quote
-                if (parser.nextToken() != JsonToken.END_OBJECT) {
-                    barf(parser, "Only one key allowed in match expression");
+                final String text = parser.getText();
+                if (text.isEmpty()) {
+                    barf(parser, "Null prefix/suffix not allowed");
                 }
                 if (parser.nextToken() != JsonToken.END_OBJECT) {
                     barf(parser, "Only one key allowed in match expression");
                 }
-                return pattern;
+                if (parser.nextToken() != JsonToken.END_OBJECT) {
+                    barf(parser, "Only one key allowed in match expression");
+                }
+                if(isPrefix) {
+                   return Patterns.anythingButPrefix('"' + text); // note no trailing quote
+                } else {
+                   return Patterns.anythingButSuffix(text + '"'); // note no leading quote
+                }
             }
 
             if (anythingButExpressionToken != JsonToken.START_ARRAY &&

--- a/src/main/software/amazon/event/ruler/Ruler.java
+++ b/src/main/software/amazon/event/ruler/Ruler.java
@@ -121,6 +121,9 @@ public class Ruler {
                 }
                 return false;
 
+            case ANYTHING_BUT_SUFFIX:
+                valuePattern = (ValuePatterns) pattern;
+                return !(val.isTextual() && (val.asText() + '"').startsWith(valuePattern.pattern()));
             case ANYTHING_BUT_PREFIX:
                 valuePattern = (ValuePatterns) pattern;
                 return !(val.isTextual() && ('"' + val.asText()).startsWith(valuePattern.pattern()));

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -1278,6 +1278,29 @@ public class ACMachineTest {
     }
 
     @Test
+    public void testAnythingButSuffix() throws Exception {
+
+        String rule = "{\n" +
+                "\"a\": [ { \"anything-but\": {\"suffix\": \"$\"} } ]\n" +
+                "}";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule);
+
+        String event1 = "{" +
+                "    \"a\": \"$value\"\n" +
+                "}\n";
+
+        String event2 = "{" +
+                "    \"a\": \"not$value\"\n" +
+                "}\n";
+
+        assertEquals(0, machine.rulesForJSONEvent(event1).size());
+        assertEquals(1, machine.rulesForJSONEvent(event2).size());
+
+    }
+
+    @Test
     public void testACWithExistFalseRule() throws Exception {
         // exists:false on leaf node of "interfaceName"
         String rule1 = "{\n" +

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -1300,8 +1300,13 @@ public class ACMachineTest {
                 "    \"a\": \"notvalue\"\n" +
                 "}\n";
 
+        String event3 = "{" +
+                "    \"a\": \"$notvalue\"\n" +
+                "}\n";
+
         assertEquals(0, machine.rulesForJSONEvent(event1).size());
         assertEquals(1, machine.rulesForJSONEvent(event2).size());
+        assertEquals(1, machine.rulesForJSONEvent(event3).size());
 
     }
 

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -124,6 +124,11 @@ public class ACMachineTest {
                         "  \"detail\": {\n" +
                         "    \"state\": [ { \"anything-but\": { \"prefix\": \"init\" } } ]\n" +
                         "  }\n" +
+                        "}",
+                "{\n" +
+                        "  \"detail\": {\n" +
+                        "    \"instance-id\": [ { \"anything-but\": { \"suffix\": \"1234\" } } ]\n" +
+                        "  }\n" +
                         "}"
         };
 
@@ -1288,11 +1293,11 @@ public class ACMachineTest {
         machine.addRule("r1", rule);
 
         String event1 = "{" +
-                "    \"a\": \"$value\"\n" +
+                "    \"a\": \"value$\"\n" +
                 "}\n";
 
         String event2 = "{" +
-                "    \"a\": \"not$value\"\n" +
+                "    \"a\": \"notvalue\"\n" +
                 "}\n";
 
         assertEquals(0, machine.rulesForJSONEvent(event1).size());

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -297,6 +297,63 @@ public class Benchmarks {
     };
     private final int[] ANYTHING_BUT_MATCHES = { 211158, 210411, 96682, 120, 210615 };
 
+    private final String[] ANYTHING_BUT_PREFIX_RULES = {
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but\": {\"prefix\": \"FULTO\" } } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but\": { \"prefix\": \"MASO\"} } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"ST_TYPE\": [ { \"anything-but\": {\"prefix\": \"S\"}  } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"geometry\": {\n" +
+              "    \"type\": [ {\"anything-but\": {\"prefix\": \"Poly\"} } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"FROM_ST\": [ { \"anything-but\": {\"prefix\": \"44\"} } ]\n" +
+              "  }\n" +
+              "}"
+    };
+    private final int[] ANYTHING_BUT_PREFIX_MATCHES = { 211158, 210118, 96667, 120, 209091 };
+
+    private final String[] ANYTHING_BUT_SUFFIX_RULES = {
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but\": {\"suffix\": \"ULTON\" } } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but\": { \"suffix\": \"ASON\"} } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"ST_TYPE\": [ { \"anything-but\": {\"suffix\": \"T\"}  } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"geometry\": {\n" +
+              "    \"type\": [ {\"anything-but\": {\"suffix\": \"olygon\"} } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"FROM_ST\": [ { \"anything-but\": {\"suffix\": \"41\"} } ]\n" +
+              "  }\n" +
+              "}"
+    };
+    private final int[] ANYTHING_BUT_SUFFIX_MATCHES = { 211136, 210411, 94908, 0, 209055 };
 
     // This needs to be run with -Xms2g -Xmx2g (Dunno about the 2g but the same Xms and Xmx, and big enough
     //  to hold several copies of the 200M in citylots2
@@ -516,6 +573,18 @@ public class Benchmarks {
         bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
         bm.run(citylots2);
         System.out.println("ANYTHING-BUT events/sec: " + String.format("%.1f", bm.getEPS()));
+
+        bm = new Benchmarker();
+
+        bm.addRules(ANYTHING_BUT_PREFIX_RULES, ANYTHING_BUT_PREFIX_MATCHES);
+        bm.run(citylots2);
+        System.out.println("ANYTHING-BUT-PREFIX events/sec: " + String.format("%.1f", bm.getEPS()));
+
+        bm = new Benchmarker();
+
+        bm.addRules(ANYTHING_BUT_SUFFIX_RULES, ANYTHING_BUT_SUFFIX_MATCHES);
+        bm.run(citylots2);
+        System.out.println("ANYTHING-BUT-SUFFIX events/sec: " + String.format("%.1f", bm.getEPS()));
 
         bm = new Benchmarker();
 

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -1765,6 +1765,15 @@ public class ByteMachineTest {
     }
 
     @Test
+    public void testWildcardWithAnythingButSuffixPatternEndsWithSuffix() {
+        String[] noMatches = new String[] { "going", "leaving", "ng", "gong" };
+        testPatternPermutations(noMatches,
+                new PatternMatch(Patterns.anythingButSuffix("ng"),
+                        "", "g", "gog", "x", "xx")
+        );
+    }
+
+    @Test
     public void testWildcardWithAnythingButPrefixPatternWildcardStartsWithHalfOfPrefix() {
         String[] noMatches = new String[] { "he", "hel", "hell", "hello", "hexxx" };
         testPatternPermutations(noMatches,

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -67,6 +67,51 @@ public class GenericMachineTest {
         }
     }
 
+    @Test
+    public void anythingButSuffixTest() throws Exception {
+        String event = "  {\n" +
+                "    \"a\": \"lorem\", " +
+                "    \"b\": \"ipsum\"" +
+                "  }";
+        String ruleTemplate = "{\n" +
+                "  \"a\": [ { \"anything-but\": { \"suffix\": \"FOO\" } } ]" +
+                "}";
+
+        String[] suffixes = { "m", "em", "rem", "orem", "lorem" };
+        List<String> ruleNames = new ArrayList<>();
+        Machine m = new Machine();
+        for (int i = 0; i < suffixes.length; i++) {
+            String ruleName = "r" + i;
+            ruleNames.add(ruleName);
+            String rule = ruleTemplate.replace("FOO", suffixes[i]);
+            m.addRule(ruleName, rule);
+        }
+        List<String> matches = m.rulesForJSONEvent(event);
+
+        assertEquals(0, matches.size());
+
+        String[] shouldMatch = { "run", "walk", "skip", "hop" };
+        for (String s : shouldMatch) {
+            String e = event.replace("lorem", s);
+            matches = m.rulesForJSONEvent(e);
+            assertEquals(ruleNames.size(), matches.size());
+            for (String rn : ruleNames) {
+                assertTrue(matches.contains(rn));
+            }
+        }
+
+        for (int i = 0; i < suffixes.length; i++) {
+            String ruleName = "r" + i;
+            String rule = ruleTemplate.replace("FOO", suffixes[i]);
+            m.deleteRule(ruleName, rule);
+        }
+        for (String s : shouldMatch) {
+            String e = event.replace("lorem", s);
+            matches = m.rulesForJSONEvent(e);
+            assertEquals(0, matches.size());
+        }
+    }
+
     public static String readData(String jsonName) throws Exception {
         String wd = System.getProperty("user.dir");
         Path path = FileSystems.getDefault().getPath(wd, "src", "test", "data", jsonName);

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -114,6 +114,9 @@ public class JsonRuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
+        assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
+
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
         assertNull("Good exact-match should parse", JsonRuleCompiler.check(j));
 
@@ -152,6 +155,10 @@ public class JsonRuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\" }, \"x\": 1 } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": 27 } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -124,6 +124,9 @@ public class RuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", RuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
+        assertNull("Good anything-but should parse", RuleCompiler.check(j));
+
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
         assertNull("Good exact-match should parse", RuleCompiler.check(j));
 
@@ -162,6 +165,10 @@ public class RuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"prefix\": \"foo\" }, \"x\": 1 } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": 27 } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
+                "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",
@@ -220,7 +227,8 @@ public class RuleCompilerTest {
                 "\"c1\": [" +
                 "{ \"suffix\": \"child\" }," +
                 "{ \"anything-but\": [111,222,333]}," +
-                "{ \"anything-but\": { \"prefix\": \"foo\"}}" +
+                "{ \"anything-but\": { \"prefix\": \"foo\"}}," +
+                "{ \"anything-but\": { \"suffix\": \"oof\"}}" +
                 "]," +
                 "\"c2\": { \"d\": { \"e\": [" +
                 "{ \"exactly\": \"child\" }," +
@@ -239,7 +247,8 @@ public class RuleCompilerTest {
         expected.put(Arrays.asList("a2", "b", "c1"), Arrays.asList(
                 Patterns.suffixMatch("child\""),
                 Patterns.anythingButNumberMatch(Stream.of(111, 222, 333).map(Double::valueOf).collect(Collectors.toSet())),
-                Patterns.anythingButPrefix("\"foo")
+                Patterns.anythingButPrefix("\"foo"),
+                Patterns.anythingButSuffix("oof\"")
         ));
         expected.put(Arrays.asList("a2", "b", "c2", "d", "e"), Arrays.asList(
                 Patterns.exactMatch("\"child\""),

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -228,7 +228,7 @@ public class RuleCompilerTest {
                 "{ \"suffix\": \"child\" }," +
                 "{ \"anything-but\": [111,222,333]}," +
                 "{ \"anything-but\": { \"prefix\": \"foo\"}}," +
-                "{ \"anything-but\": { \"suffix\": \"oof\"}}" +
+                "{ \"anything-but\": { \"suffix\": \"ing\"}}" +
                 "]," +
                 "\"c2\": { \"d\": { \"e\": [" +
                 "{ \"exactly\": \"child\" }," +
@@ -248,7 +248,7 @@ public class RuleCompilerTest {
                 Patterns.suffixMatch("child\""),
                 Patterns.anythingButNumberMatch(Stream.of(111, 222, 333).map(Double::valueOf).collect(Collectors.toSet())),
                 Patterns.anythingButPrefix("\"foo"),
-                Patterns.anythingButSuffix("oof\"")
+                Patterns.anythingButSuffix("ing\"")
         ));
         expected.put(Arrays.asList("a2", "b", "c2", "d", "e"), Arrays.asList(
                 Patterns.exactMatch("\"child\""),


### PR DESCRIPTION
### Issue #, if available:
#66 

### Description of changes:

Adding support for using "suffix" matching with anything-but.

```
{"value": [ { "anything-but": {"suffix": "$"} } ]}
```

#### Benchmark / Performance (for source code changes):
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running software.amazon.event.ruler.Benchmarks
Reading citylots2
Read 213068 events
EXACT events/sec: 431311.7
WILDCARD events/sec: 299673.7
PREFIX events/sec: 430440.4
SUFFIX events/sec: 432186.6
EQUALS_IGNORE_CASE events/sec: 362360.5
NUMERIC events/sec: 265670.8
ANYTHING-BUT events/sec: 239671.5
ANYTHING-BUT-PREFIX events/sec: 242674.3
ANYTHING-BUT-SUFFIX events/sec: 237534.0
COMPLEX_ARRAYS events/sec: 7035.4
PARTIAL_COMBO events/sec: 168433.2
COMBO events/sec: 4396.7
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 6075
Events/sec: 35072.9
 Rules/sec: 245510.5
Before: 178.4
After: 862.1
Per rule: -1709
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 1280
Events/sec: 166459.4
Before: 196.0
After: 587.3
Per rule: -978
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 686
Events/sec: 310594.8
 Rules/sec: 1131186087.5
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 8488
Events/sec: 25102.3
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 5272
Events/sec: 40415.0
 Rules/sec: 282905.2
DEEP EXACT events/sec: 12500.0
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 124.818 sec
```
^^ run on m1 macbook air openjdk version "19.0.1" 2022-10-18

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
