### PR TITLE
Support for anything-but/ignore-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Anything-but-ignore-case list (strings):
 ```javascript
 {
   "detail": {
-    "state": [ { "anything-but-ignore-case": [ "Stopped", "OverLoaded" ] } ]
+    "state": [ { "anything-but": {"ignore-case": [ "Stopped", "OverLoaded" ] } } ]
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Anything-but-ignore-case list (strings):
 ```javascript
 {
   "detail": {
-    "state": [ { "anything-but": {"ignore-case": [ "Stopped", "OverLoaded" ] } } ]
+    "state": [ { "anything-but": {"equals-ignore-case": [ "Stopped", "OverLoaded" ] } } ]
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ Anything-but suffix:
 }
 ```
 
+Anything-but-ignore-case list (strings):
+```javascript
+{
+  "detail": {
+    "state": [ { "anything-but-ignore-case": [ "Stopped", "OverLoaded" ] } ]
+  }
+}
+
+```
+
 ### Numeric matching
 ```javascript
 {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/AnythingButEqualsIgnoreCase.java
+++ b/src/main/software/amazon/event/ruler/AnythingButEqualsIgnoreCase.java
@@ -9,11 +9,11 @@ import java.util.Set;
  * It supports lists whose members must be all strings.
  * Matching is case-insensitive
  */
-public class AnythingButIgnoreCase extends Patterns {
+public class AnythingButEqualsIgnoreCase extends Patterns {
 
     private final Set<String> values;
 
-    AnythingButIgnoreCase(final Set<String> values) {
+    AnythingButEqualsIgnoreCase(final Set<String> values) {
         super(MatchType.ANYTHING_BUT_IGNORE_CASE);
         this.values = Collections.unmodifiableSet(values);
     }
@@ -34,7 +34,7 @@ public class AnythingButIgnoreCase extends Patterns {
             return false;
         }
 
-        AnythingButIgnoreCase that = (AnythingButIgnoreCase) o;
+        AnythingButEqualsIgnoreCase that = (AnythingButEqualsIgnoreCase) o;
 
         return (Objects.equals(values, that.values));
     }

--- a/src/main/software/amazon/event/ruler/AnythingButIgnoreCase.java
+++ b/src/main/software/amazon/event/ruler/AnythingButIgnoreCase.java
@@ -1,0 +1,53 @@
+package software.amazon.event.ruler;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents denylist like rule: any value matches if it's *not* in the anything-but-ignore-case list.
+ * It supports lists whose members must be all strings.
+ * Matching is case-insensitive
+ */
+public class AnythingButIgnoreCase extends Patterns {
+
+    private final Set<String> values;
+
+    AnythingButIgnoreCase(final Set<String> values) {
+        super(MatchType.ANYTHING_BUT_IGNORE_CASE);
+        this.values = Collections.unmodifiableSet(values);
+    }
+
+    public Set<String> getValues() {
+        return values;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        AnythingButIgnoreCase that = (AnythingButIgnoreCase) o;
+
+        return (Objects.equals(values, that.values));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (values != null ? values.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ABIC:"+ values + ", (" + super.toString() + ")";
+    }
+}

--- a/src/main/software/amazon/event/ruler/AnythingButIgnoreCase.java
+++ b/src/main/software/amazon/event/ruler/AnythingButIgnoreCase.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents denylist like rule: any value matches if it's *not* in the anything-but-ignore-case list.
+ * Represents denylist like rule: any value matches if it's *not* in the anything-but/ignore-case list.
  * It supports lists whose members must be all strings.
  * Matching is case-insensitive
  */

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -133,8 +133,8 @@ class ByteMachine {
                 deleteAnythingButPattern((AnythingBut) pattern);
                 break;
             case ANYTHING_BUT_IGNORE_CASE:
-                assert pattern instanceof AnythingButIgnoreCase;
-                deleteAnythingButIgnoreCasePattern((AnythingButIgnoreCase) pattern);
+                assert pattern instanceof AnythingButEqualsIgnoreCase;
+                deleteAnythingButEqualsIgnoreCasePattern((AnythingButEqualsIgnoreCase) pattern);
                 break;
             case EXACT:
             case NUMERIC_EQ:
@@ -165,7 +165,7 @@ class ByteMachine {
             deleteMatchStep(startState, 0, pattern, getParser().parse(pattern.type(), value)));
     }
 
-    private void deleteAnythingButIgnoreCasePattern(AnythingButIgnoreCase pattern) {
+    private void deleteAnythingButEqualsIgnoreCasePattern(AnythingButEqualsIgnoreCase pattern) {
         pattern.getValues().forEach(value ->
             deleteMatchStep(startState, 0, pattern, getParser().parse(pattern.type(), value)));
     }
@@ -634,8 +634,8 @@ class ByteMachine {
                 assert pattern instanceof AnythingBut;
                 return addAnythingButPattern((AnythingBut) pattern);
             case ANYTHING_BUT_IGNORE_CASE:
-                assert pattern instanceof AnythingButIgnoreCase;
-                return addAnythingButIgnoreCasePattern((AnythingButIgnoreCase) pattern);
+                assert pattern instanceof AnythingButEqualsIgnoreCase;
+                return addAnythingButEqualsIgnoreCasePattern((AnythingButEqualsIgnoreCase) pattern);
 
             case ANYTHING_BUT_SUFFIX:
             case ANYTHING_BUT_PREFIX:
@@ -676,7 +676,7 @@ class ByteMachine {
         return nameStateToBeReturned;
     }
 
-    private NameState addAnythingButIgnoreCasePattern(AnythingButIgnoreCase pattern) {
+    private NameState addAnythingButEqualsIgnoreCasePattern(AnythingButEqualsIgnoreCase pattern) {
 
         NameState nameStateToBeReturned = null;
         NameState nameStateChecker = null;
@@ -834,8 +834,8 @@ class ByteMachine {
             assert pattern instanceof AnythingBut;
             return findAnythingButPattern((AnythingBut) pattern);
         case ANYTHING_BUT_IGNORE_CASE:
-            assert pattern instanceof AnythingButIgnoreCase;
-            return findAnythingButIgnoreCasePattern((AnythingButIgnoreCase) pattern);
+            assert pattern instanceof AnythingButEqualsIgnoreCase;
+            return findAnythingButEqualsIgnoreCasePattern((AnythingButEqualsIgnoreCase) pattern);
         case EXACT:
         case NUMERIC_EQ:
         case PREFIX:
@@ -869,7 +869,7 @@ class ByteMachine {
         return null;
     }
 
-    private NameState findAnythingButIgnoreCasePattern(AnythingButIgnoreCase pattern) {
+    private NameState findAnythingButEqualsIgnoreCasePattern(AnythingButEqualsIgnoreCase pattern) {
 
         Set<NameState> nextNameStates = new HashSet<>(pattern.getValues().size());
         for (String value : pattern.getValues()) {

--- a/src/main/software/amazon/event/ruler/Constants.java
+++ b/src/main/software/amazon/event/ruler/Constants.java
@@ -15,7 +15,7 @@ final class Constants {
   final static String PREFIX_MATCH = "prefix";
   final static String SUFFIX_MATCH = "suffix";
   final static String ANYTHING_BUT_MATCH = "anything-but";
-  final static String ANYTHING_BUT_IGNORE_CASE_MATCH = "anything-but-ignore-case";
+  final static String IGNORE_CASE_MATCH = "ignore-case";
   final static String EXISTS_MATCH = "exists";
   final static String WILDCARD = "wildcard";
   final static String NUMERIC = "numeric";
@@ -48,7 +48,7 @@ final class Constants {
       PREFIX_MATCH,
       SUFFIX_MATCH,
       ANYTHING_BUT_MATCH,
-      ANYTHING_BUT_IGNORE_CASE_MATCH,
+      IGNORE_CASE_MATCH,
       EXISTS_MATCH,
       WILDCARD,
       NUMERIC,

--- a/src/main/software/amazon/event/ruler/Constants.java
+++ b/src/main/software/amazon/event/ruler/Constants.java
@@ -15,7 +15,6 @@ final class Constants {
   final static String PREFIX_MATCH = "prefix";
   final static String SUFFIX_MATCH = "suffix";
   final static String ANYTHING_BUT_MATCH = "anything-but";
-  final static String IGNORE_CASE_MATCH = "ignore-case";
   final static String EXISTS_MATCH = "exists";
   final static String WILDCARD = "wildcard";
   final static String NUMERIC = "numeric";
@@ -48,7 +47,6 @@ final class Constants {
       PREFIX_MATCH,
       SUFFIX_MATCH,
       ANYTHING_BUT_MATCH,
-      IGNORE_CASE_MATCH,
       EXISTS_MATCH,
       WILDCARD,
       NUMERIC,

--- a/src/main/software/amazon/event/ruler/Constants.java
+++ b/src/main/software/amazon/event/ruler/Constants.java
@@ -15,6 +15,7 @@ final class Constants {
   final static String PREFIX_MATCH = "prefix";
   final static String SUFFIX_MATCH = "suffix";
   final static String ANYTHING_BUT_MATCH = "anything-but";
+  final static String ANYTHING_BUT_IGNORE_CASE_MATCH = "anything-but-ignore-case";
   final static String EXISTS_MATCH = "exists";
   final static String WILDCARD = "wildcard";
   final static String NUMERIC = "numeric";
@@ -47,6 +48,7 @@ final class Constants {
       PREFIX_MATCH,
       SUFFIX_MATCH,
       ANYTHING_BUT_MATCH,
+      ANYTHING_BUT_IGNORE_CASE_MATCH,
       EXISTS_MATCH,
       WILDCARD,
       NUMERIC,

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -396,10 +396,6 @@ public class JsonRuleCompiler {
             JsonToken anythingButExpressionToken = parser.nextToken();
             if (anythingButExpressionToken == JsonToken.START_OBJECT) {
 
-                if(isIgnoreCase) {
-                    barf(parser, "Anything-But-Ignore-Case does not support prefix/suffix");
-                }
-
                 // there are a limited set of things we can apply Anything-But to
                 final JsonToken anythingButObject = parser.nextToken();
                 if (anythingButObject != JsonToken.FIELD_NAME) {

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -542,7 +542,7 @@ public class JsonRuleCompiler {
                         values.add('"' + parser.getText() + '"');
                         break;
                     default:
-                        barf(parser, "Inside anything but list, numberic|start|null|boolean is not supported.");
+                        barf(parser, "Inside anything-but-ignore-case list, numberic|start|null|boolean is not supported.");
                 }
             }
         } catch (IllegalArgumentException | IOException e) {

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -548,7 +548,7 @@ public class JsonRuleCompiler {
                         values.add('"' + parser.getText() + '"');
                         break;
                     default:
-                        barf(parser, "Inside anything-but/equals-ignore-case list, numberic|start|null|boolean is not supported.");
+                        barf(parser, "Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.");
                 }
             }
         } catch (IllegalArgumentException | IOException e) {

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -429,6 +429,7 @@ public class JsonRuleCompiler {
                         return  Patterns.anythingButSuffix(text + '"'); // note no leading quote
                     }
                 } else {
+                    // Step into anything-but's ignore-case
                     anythingButExpressionToken = parser.nextToken();
                 }
             }

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -445,13 +445,13 @@ public class JsonRuleCompiler {
             Patterns anythingBut;
             if (anythingButExpressionToken == JsonToken.START_ARRAY) {
                if(isIgnoreCase) {
-                  anythingBut = processAnythingButIgnoreCaseListMatchExpression(parser);
+                  anythingBut = processAnythingButEqualsIgnoreCaseListMatchExpression(parser);
                } else {
                   anythingBut = processAnythingButListMatchExpression(parser);
                }
             } else {
                if(isIgnoreCase) {
-                  anythingBut = processAnythingButIgnoreCaseMatchExpression(parser, anythingButExpressionToken);
+                  anythingBut = processAnythingButEqualsIgnoreCaseMatchExpression(parser, anythingButExpressionToken);
                } else {
                   anythingBut = processAnythingButMatchExpression(parser, anythingButExpressionToken);
                }
@@ -537,7 +537,7 @@ public class JsonRuleCompiler {
         return AnythingBut.anythingButMatch(values, hasNumber);
     }
 
-    private static Patterns processAnythingButIgnoreCaseListMatchExpression(JsonParser parser) throws JsonParseException {
+    private static Patterns processAnythingButEqualsIgnoreCaseListMatchExpression(JsonParser parser) throws JsonParseException {
         JsonToken token;
         Set<String> values = new HashSet<>();
         boolean hasNumber = false;
@@ -555,7 +555,7 @@ public class JsonRuleCompiler {
             barf(parser, e.getMessage());
         }
 
-        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
+        return AnythingButEqualsIgnoreCase.anythingButIgnoreCaseMatch(values);
     }
 
     private static Patterns processAnythingButMatchExpression(JsonParser parser,
@@ -577,7 +577,7 @@ public class JsonRuleCompiler {
         return AnythingBut.anythingButMatch(values, hasNumber);
     }
 
-    private static Patterns processAnythingButIgnoreCaseMatchExpression(JsonParser parser,
+    private static Patterns processAnythingButEqualsIgnoreCaseMatchExpression(JsonParser parser,
                                                               JsonToken anythingButExpressionToken) throws IOException {
         Set<String> values = new HashSet<>();
         switch (anythingButExpressionToken) {
@@ -587,7 +587,7 @@ public class JsonRuleCompiler {
             default:
                 barf(parser, "Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.");
         }
-        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
+        return AnythingButEqualsIgnoreCase.anythingButIgnoreCaseMatch(values);
     }
 
     private static Patterns processNumericMatchExpression(final JsonParser parser) throws IOException {

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -404,7 +404,7 @@ public class JsonRuleCompiler {
                 final String anythingButObjectOp = parser.getCurrentName();
                 final boolean isPrefix = Constants.PREFIX_MATCH.equals(anythingButObjectOp);
                 final boolean isSuffix = Constants.SUFFIX_MATCH.equals(anythingButObjectOp);
-                isIgnoreCase = Constants.IGNORE_CASE_MATCH.equals(anythingButObjectOp);
+                isIgnoreCase = Constants.EQUALS_IGNORE_CASE.equals(anythingButObjectOp);
                 if(!isIgnoreCase) {
                     if (!isPrefix && !isSuffix) {
                         barf(parser, "Unsupported anything-but pattern: " + anythingButObjectOp);
@@ -429,7 +429,7 @@ public class JsonRuleCompiler {
                         return  Patterns.anythingButSuffix(text + '"'); // note no leading quote
                     }
                 } else {
-                    // Step into anything-but's ignore-case
+                    // Step into anything-but's equals-ignore-case
                     anythingButExpressionToken = parser.nextToken();
                 }
             }
@@ -460,7 +460,7 @@ public class JsonRuleCompiler {
             if (parser.nextToken() != JsonToken.END_OBJECT) {
                 tooManyElements(parser);
             }
-            // Complete the object closure for ignore-case
+            // Complete the object closure for equals-ignore-case
             if (isIgnoreCase && parser.nextToken() != JsonToken.END_OBJECT) {
                 tooManyElements(parser);
             }
@@ -548,7 +548,7 @@ public class JsonRuleCompiler {
                         values.add('"' + parser.getText() + '"');
                         break;
                     default:
-                        barf(parser, "Inside anything-but/ignore-case list, numberic|start|null|boolean is not supported.");
+                        barf(parser, "Inside anything-but/equals-ignore-case list, numberic|start|null|boolean is not supported.");
                 }
             }
         } catch (IllegalArgumentException | IOException e) {
@@ -585,7 +585,7 @@ public class JsonRuleCompiler {
                 values.add('"' + parser.getText() + '"');
                 break;
             default:
-                barf(parser, "Inside anything-but/ignore-case list, number|start|null|boolean is not supported.");
+                barf(parser, "Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.");
         }
         return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
     }

--- a/src/main/software/amazon/event/ruler/MatchType.java
+++ b/src/main/software/amazon/event/ruler/MatchType.java
@@ -11,7 +11,8 @@ public enum MatchType {
     SUFFIX,              // string suffix
     NUMERIC_EQ,          // exact numeric match
     NUMERIC_RANGE,       // numeric range with high & low bound & </<=/>/>= options
-    ANYTHING_BUT,        // black list effect
+    ANYTHING_BUT,        // deny list effect
+    ANYTHING_BUT_IGNORE_CASE, // deny list effect (case insensitive)
     ANYTHING_BUT_PREFIX, // anything that doesn't start with this
     ANYTHING_BUT_SUFFIX, // anything that doesn't end with this
     EQUALS_IGNORE_CASE,  // case-insensitive string match

--- a/src/main/software/amazon/event/ruler/Patterns.java
+++ b/src/main/software/amazon/event/ruler/Patterns.java
@@ -61,6 +61,14 @@ public class Patterns implements Cloneable  {
         return new AnythingBut(anythingButs, false);
     }
 
+    public static AnythingButIgnoreCase anythingButIgnoreCaseMatch(final String anythingBut) {
+        return new AnythingButIgnoreCase(Collections.singleton(anythingBut));
+    }
+
+    public static AnythingButIgnoreCase anythingButIgnoreCaseMatch(final Set<String> anythingButs) {
+        return new AnythingButIgnoreCase(anythingButs);
+    }
+
     public static AnythingBut anythingButNumberMatch(final Set<Double> anythingButs) {
         Set<String> normalizedNumbers = new HashSet<>(anythingButs.size());
         for (Double d : anythingButs) {

--- a/src/main/software/amazon/event/ruler/Patterns.java
+++ b/src/main/software/amazon/event/ruler/Patterns.java
@@ -61,12 +61,12 @@ public class Patterns implements Cloneable  {
         return new AnythingBut(anythingButs, false);
     }
 
-    public static AnythingButIgnoreCase anythingButIgnoreCaseMatch(final String anythingBut) {
-        return new AnythingButIgnoreCase(Collections.singleton(anythingBut));
+    public static AnythingButEqualsIgnoreCase anythingButIgnoreCaseMatch(final String anythingBut) {
+        return new AnythingButEqualsIgnoreCase(Collections.singleton(anythingBut));
     }
 
-    public static AnythingButIgnoreCase anythingButIgnoreCaseMatch(final Set<String> anythingButs) {
-        return new AnythingButIgnoreCase(anythingButs);
+    public static AnythingButEqualsIgnoreCase anythingButIgnoreCaseMatch(final Set<String> anythingButs) {
+        return new AnythingButEqualsIgnoreCase(anythingButs);
     }
 
     public static AnythingBut anythingButNumberMatch(final Set<Double> anythingButs) {

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -447,7 +447,7 @@ public final class RuleCompiler {
                         values.add('"' + parser.getText() + '"');
                         break;
                     default:
-                        barf(parser, "Inside anything-but/ignore-case list, nummeric|start|null|boolean is not supported.");
+                        barf(parser, "Inside anything-but/ignore-case list, number|start|null|boolean is not supported.");
                 }
             }
         } catch (IllegalArgumentException | IOException e) {

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -302,7 +302,7 @@ public final class RuleCompiler {
                 final String anythingButObjectOp = parser.getCurrentName();
                 final boolean isPrefix = Constants.PREFIX_MATCH.equals(anythingButObjectOp);
                 final boolean isSuffix = Constants.SUFFIX_MATCH.equals(anythingButObjectOp);
-                isIgnoreCase = Constants.IGNORE_CASE_MATCH.equals(anythingButObjectOp);
+                isIgnoreCase = Constants.EQUALS_IGNORE_CASE.equals(anythingButObjectOp);
                 if(!isIgnoreCase) {
                     if (!isPrefix && !isSuffix) {
                         barf(parser, "Unsupported anything-but pattern: " + anythingButObjectOp);

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -288,11 +288,16 @@ public final class RuleCompiler {
                 tooManyElements(parser);
             }
             return range;
-        } else if (Constants.ANYTHING_BUT_MATCH.equals(matchTypeName)) {
+        } else if (Constants.ANYTHING_BUT_MATCH.equals(matchTypeName) || 
+                   Constants.ANYTHING_BUT_IGNORE_CASE_MATCH.equals(matchTypeName)) {
 
+            final boolean isIgnoreCase = Constants.ANYTHING_BUT_IGNORE_CASE_MATCH.equals(matchTypeName);
             final JsonToken anythingButExpressionToken = parser.nextToken();
             if (anythingButExpressionToken == JsonToken.START_OBJECT) {
 
+                if(isIgnoreCase) {
+                    barf(parser, "Anything-But-Ignore-Case does not support prefix/suffix");
+                }
                 // there are a limited set of things we can apply Anything-But to
                 final JsonToken anythingButObject = parser.nextToken();
                 if (anythingButObject != JsonToken.FIELD_NAME) {
@@ -335,9 +340,17 @@ public final class RuleCompiler {
 
             Patterns anythingBut;
             if (anythingButExpressionToken == JsonToken.START_ARRAY) {
-                anythingBut = processAnythingButListMatchExpression(parser);
+                if(isIgnoreCase) {
+                   anythingBut = processAnythingButIgnoreCaseListMatchExpression(parser);
+                } else {
+                   anythingBut = processAnythingButListMatchExpression(parser);
+                }
             } else {
-                anythingBut = processAnythingButMatchExpression(parser, anythingButExpressionToken);
+                if(isIgnoreCase) {
+                   anythingBut = processAnythingButIgnoreCaseMatchExpression(parser, anythingButExpressionToken);
+                } else {
+                   anythingBut = processAnythingButMatchExpression(parser, anythingButExpressionToken);
+                }
             }
 
             if (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -415,6 +428,28 @@ public final class RuleCompiler {
         return AnythingBut.anythingButMatch(values, hasNumber);
     }
 
+    private static Patterns processAnythingButIgnoreCaseListMatchExpression(JsonParser parser) throws JsonParseException {
+        JsonToken token;
+        Set<String> values = new HashSet<>();
+        boolean hasNumber = false;
+        try {
+            while ((token = parser.nextToken()) != JsonToken.END_ARRAY) {
+                switch (token) {
+                    case VALUE_STRING:
+                        values.add('"' + parser.getText() + '"');
+                        break;
+                    default:
+                        barf(parser, "Inside anything but list, numberic|start|null|boolean is not supported.");
+                }
+            }
+        } catch (IllegalArgumentException | IOException e) {
+            barf(parser, e.getMessage());
+        }
+
+        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
+    }
+
+
     private static Patterns processAnythingButMatchExpression(JsonParser parser,
                                                               JsonToken anythingButExpressionToken) throws IOException {
         Set<String> values = new HashSet<>();
@@ -432,6 +467,19 @@ public final class RuleCompiler {
                 barf(parser, "Inside anything-but list, start|null|boolean is not supported.");
         }
         return AnythingBut.anythingButMatch(values, hasNumber);
+    }
+
+    private static Patterns processAnythingButIgnoreCaseMatchExpression(JsonParser parser,
+                                                              JsonToken anythingButExpressionToken) throws IOException {
+        Set<String> values = new HashSet<>();
+        switch (anythingButExpressionToken) {
+            case VALUE_STRING:
+                values.add('"' + parser.getText() + '"');
+                break;
+            default:
+                barf(parser, "Inside anything-but-ignore-case list, number|start|null|boolean is not supported.");
+        }
+        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
     }
 
     private static Patterns processNumericMatchExpression(final JsonParser parser) throws IOException {

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -294,9 +294,6 @@ public final class RuleCompiler {
             JsonToken anythingButExpressionToken = parser.nextToken();
             if (anythingButExpressionToken == JsonToken.START_OBJECT) {
 
-                if(isIgnoreCase) {
-                    barf(parser, "Anything-But-Ignore-Case does not support prefix/suffix");
-                }
                 // there are a limited set of things we can apply Anything-But to
                 final JsonToken anythingButObject = parser.nextToken();
                 if (anythingButObject != JsonToken.FIELD_NAME) {
@@ -330,6 +327,7 @@ public final class RuleCompiler {
                        return Patterns.anythingButSuffix(text + '"'); // note no leading quote
                     }
                 } else {
+                    // Step into the anything-but's ignore-case
                     anythingButExpressionToken = parser.nextToken();
                 }
 
@@ -449,7 +447,7 @@ public final class RuleCompiler {
                         values.add('"' + parser.getText() + '"');
                         break;
                     default:
-                        barf(parser, "Inside anything but list, numberic|start|null|boolean is not supported.");
+                        barf(parser, "Inside anything-but/ignore-case list, nummeric|start|null|boolean is not supported.");
                 }
             }
         } catch (IllegalArgumentException | IOException e) {

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -344,13 +344,13 @@ public final class RuleCompiler {
             Patterns anythingBut;
             if (anythingButExpressionToken == JsonToken.START_ARRAY) {
                 if(isIgnoreCase) {
-                   anythingBut = processAnythingButIgnoreCaseListMatchExpression(parser);
+                   anythingBut = processAnythingButEqualsIgnoreCaseListMatchExpression(parser);
                 } else {
                    anythingBut = processAnythingButListMatchExpression(parser);
                 }
             } else {
                 if(isIgnoreCase) {
-                   anythingBut = processAnythingButIgnoreCaseMatchExpression(parser, anythingButExpressionToken);
+                   anythingBut = processAnythingButEqualsIgnoreCaseMatchExpression(parser, anythingButExpressionToken);
                 } else {
                    anythingBut = processAnythingButMatchExpression(parser, anythingButExpressionToken);
                 }
@@ -436,7 +436,7 @@ public final class RuleCompiler {
         return AnythingBut.anythingButMatch(values, hasNumber);
     }
 
-    private static Patterns processAnythingButIgnoreCaseListMatchExpression(JsonParser parser) throws JsonParseException {
+    private static Patterns processAnythingButEqualsIgnoreCaseListMatchExpression(JsonParser parser) throws JsonParseException {
         JsonToken token;
         Set<String> values = new HashSet<>();
         boolean hasNumber = false;
@@ -454,7 +454,7 @@ public final class RuleCompiler {
             barf(parser, e.getMessage());
         }
 
-        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
+        return AnythingButEqualsIgnoreCase.anythingButIgnoreCaseMatch(values);
     }
 
 
@@ -477,7 +477,7 @@ public final class RuleCompiler {
         return AnythingBut.anythingButMatch(values, hasNumber);
     }
 
-    private static Patterns processAnythingButIgnoreCaseMatchExpression(JsonParser parser,
+    private static Patterns processAnythingButEqualsIgnoreCaseMatchExpression(JsonParser parser,
                                                               JsonToken anythingButExpressionToken) throws IOException {
         Set<String> values = new HashSet<>();
         switch (anythingButExpressionToken) {
@@ -487,7 +487,7 @@ public final class RuleCompiler {
             default:
                 barf(parser, "Inside anything-but/ignore-case list, number|start|null|boolean is not supported.");
         }
-        return AnythingButIgnoreCase.anythingButIgnoreCaseMatch(values);
+        return AnythingButEqualsIgnoreCase.anythingButIgnoreCaseMatch(values);
     }
 
     private static Patterns processNumericMatchExpression(final JsonParser parser) throws IOException {

--- a/src/main/software/amazon/event/ruler/Ruler.java
+++ b/src/main/software/amazon/event/ruler/Ruler.java
@@ -120,6 +120,13 @@ public class Ruler {
                             .noneMatch(v -> v.equals(ComparableNumber.generate(val.asDouble())));
                 }
                 return false;
+            case ANYTHING_BUT_IGNORE_CASE:
+                assert (pattern instanceof AnythingButIgnoreCase);
+                AnythingButIgnoreCase anythingButIgnoreCasePattern = (AnythingButIgnoreCase) pattern;
+                if (val.isTextual()) {
+                    return anythingButIgnoreCasePattern.getValues().stream().noneMatch(v -> v.equalsIgnoreCase('"' + val.asText() + '"'));
+                }
+                return false;
 
             case ANYTHING_BUT_SUFFIX:
                 valuePattern = (ValuePatterns) pattern;

--- a/src/main/software/amazon/event/ruler/Ruler.java
+++ b/src/main/software/amazon/event/ruler/Ruler.java
@@ -121,8 +121,8 @@ public class Ruler {
                 }
                 return false;
             case ANYTHING_BUT_IGNORE_CASE:
-                assert (pattern instanceof AnythingButIgnoreCase);
-                AnythingButIgnoreCase anythingButIgnoreCasePattern = (AnythingButIgnoreCase) pattern;
+                assert (pattern instanceof AnythingButEqualsIgnoreCase);
+                AnythingButEqualsIgnoreCase anythingButIgnoreCasePattern = (AnythingButEqualsIgnoreCase) pattern;
                 if (val.isTextual()) {
                     return anythingButIgnoreCasePattern.getValues().stream().noneMatch(v -> v.equalsIgnoreCase('"' + val.asText() + '"'));
                 }

--- a/src/main/software/amazon/event/ruler/input/DefaultParser.java
+++ b/src/main/software/amazon/event/ruler/input/DefaultParser.java
@@ -5,6 +5,7 @@ import software.amazon.event.ruler.MatchType;
 import java.nio.charset.StandardCharsets;
 
 import static software.amazon.event.ruler.MatchType.EQUALS_IGNORE_CASE;
+import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.WILDCARD;
 
 /**
@@ -53,7 +54,7 @@ public class DefaultParser implements MatchTypeParser, ByteParser {
     public InputCharacter[] parse(final MatchType type, final String value) {
         if (type == WILDCARD) {
             return wildcardParser.parse(value);
-        } else if (type == EQUALS_IGNORE_CASE) {
+        } else if (type == EQUALS_IGNORE_CASE || type == ANYTHING_BUT_IGNORE_CASE) {
             return equalsIgnoreCaseParser.parse(value);
         }
         final byte[] utf8bytes = value.getBytes(StandardCharsets.UTF_8);

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -1316,7 +1316,7 @@ public class ACMachineTest {
     }
 
     @Test
-    public void testAnythingButIgnoreCase() throws Exception {
+    public void testAnythingButEqualsIgnoreCase() throws Exception {
 
         String rule = "{\n" +
                 "\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [\"yes\", \"please\"]  } } ],\n" +

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -129,6 +129,11 @@ public class ACMachineTest {
                         "  \"detail\": {\n" +
                         "    \"instance-id\": [ { \"anything-but\": { \"suffix\": \"1234\" } } ]\n" +
                         "  }\n" +
+                        "}",
+                "{\n" +
+                        "  \"detail\": {\n" +
+                        "    \"instance-id\": [ { \"anything-but-ignore-case\": [\"i-00012345\", \"i-00098765\"] } ]\n" +
+                        "  }\n" +
                         "}"
         };
 
@@ -1307,6 +1312,74 @@ public class ACMachineTest {
         assertEquals(0, machine.rulesForJSONEvent(event1).size());
         assertEquals(1, machine.rulesForJSONEvent(event2).size());
         assertEquals(1, machine.rulesForJSONEvent(event3).size());
+
+    }
+
+    @Test
+    public void testAnythingButIgnoreCase() throws Exception {
+
+        String rule = "{\n" +
+                "\"a\": [ { \"anything-but-ignore-case\": [\"yes\", \"please\"]  } ],\n" +
+                "\"b\": [ { \"anything-but-ignore-case\": \"no\"  } ]\n" +
+                "}";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule);
+
+        String event1 = "{" +
+                "    \"a\": \"value\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event2 = "{" +
+                "    \"a\": \"YES\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event3 = "{" +
+                "    \"a\": \"yEs\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event4 = "{" +
+                "    \"a\": \"pLease\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event5 = "{" +
+                "    \"a\": \"PLEASE\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event6 = "{" +
+                "    \"a\": \"please\",\n" +
+                "    \"b\": \"nothing\"\n" +
+                "}\n";
+
+        String event7 = "{" +
+                "    \"a\": \"please\",\n" +
+                "    \"b\": \"no\"\n" +
+                "}\n";
+
+        String event8 = "{" +
+                "    \"a\": \"please\",\n" +
+                "    \"b\": \"No\"\n" +
+                "}\n";
+
+        String event9 = "{" +
+                "    \"a\": \"please\",\n" +
+                "    \"b\": \"No!\"\n" +
+                "}\n";
+
+        assertEquals(1, machine.rulesForJSONEvent(event1).size());
+        assertEquals(0, machine.rulesForJSONEvent(event2).size());
+        assertEquals(0, machine.rulesForJSONEvent(event3).size());
+        assertEquals(0, machine.rulesForJSONEvent(event4).size());
+        assertEquals(0, machine.rulesForJSONEvent(event5).size());
+        assertEquals(0, machine.rulesForJSONEvent(event6).size());
+        assertEquals(0, machine.rulesForJSONEvent(event7).size());
+        assertEquals(0, machine.rulesForJSONEvent(event8).size());
+        assertEquals(0, machine.rulesForJSONEvent(event9).size());
 
     }
 

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -132,7 +132,7 @@ public class ACMachineTest {
                         "}",
                 "{\n" +
                         "  \"detail\": {\n" +
-                        "    \"state\": [ { \"anything-but-ignore-case\": [\"Stopped\", \"OverLoaded\"] } ]\n" +
+                        "    \"state\": [ { \"anything-but\": {\"ignore-case\": [\"Stopped\", \"OverLoaded\"] } } ]\n" +
                         "  }\n" +
                         "}"
         };
@@ -1319,8 +1319,8 @@ public class ACMachineTest {
     public void testAnythingButIgnoreCase() throws Exception {
 
         String rule = "{\n" +
-                "\"a\": [ { \"anything-but-ignore-case\": [\"yes\", \"please\"]  } ],\n" +
-                "\"b\": [ { \"anything-but-ignore-case\": \"no\"  } ]\n" +
+                "\"a\": [ { \"anything-but\": {\"ignore-case\": [\"yes\", \"please\"]  } } ],\n" +
+                "\"b\": [ { \"anything-but\": {\"ignore-case\": \"no\"  } } ]\n" +
                 "}";
 
         Machine machine = new Machine();

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -132,7 +132,7 @@ public class ACMachineTest {
                         "}",
                 "{\n" +
                         "  \"detail\": {\n" +
-                        "    \"instance-id\": [ { \"anything-but-ignore-case\": [\"i-00012345\", \"i-00098765\"] } ]\n" +
+                        "    \"state\": [ { \"anything-but-ignore-case\": [\"Stopped\", \"OverLoaded\"] } ]\n" +
                         "  }\n" +
                         "}"
         };

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -132,7 +132,7 @@ public class ACMachineTest {
                         "}",
                 "{\n" +
                         "  \"detail\": {\n" +
-                        "    \"state\": [ { \"anything-but\": {\"ignore-case\": [\"Stopped\", \"OverLoaded\"] } } ]\n" +
+                        "    \"state\": [ { \"anything-but\": {\"equals-ignore-case\": [\"Stopped\", \"OverLoaded\"] } } ]\n" +
                         "  }\n" +
                         "}"
         };
@@ -1319,8 +1319,8 @@ public class ACMachineTest {
     public void testAnythingButIgnoreCase() throws Exception {
 
         String rule = "{\n" +
-                "\"a\": [ { \"anything-but\": {\"ignore-case\": [\"yes\", \"please\"]  } } ],\n" +
-                "\"b\": [ { \"anything-but\": {\"ignore-case\": \"no\"  } } ]\n" +
+                "\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [\"yes\", \"please\"]  } } ],\n" +
+                "\"b\": [ { \"anything-but\": {\"equals-ignore-case\": \"no\"  } } ]\n" +
                 "}";
 
         Machine machine = new Machine();

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -297,6 +297,36 @@ public class Benchmarks {
     };
     private final int[] ANYTHING_BUT_MATCHES = { 211158, 210411, 96682, 120, 210615 };
 
+    private final String[] ANYTHING_BUT_IGNORE_CASE_RULES = {
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but-ignore-case\": [ \"Fulton\" ] } ]\n" +
+              "  }\n" +
+              "}", 
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"STREET\": [ { \"anything-but-ignore-case\": [ \"Mason\" ] } ]\n" + 
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"ST_TYPE\": [ { \"anything-but-ignore-case\": [ \"st\" ] } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"geometry\": {\n" +
+              "    \"type\": [ {\"anything-but-ignore-case\": [ \"polygon\" ] } ]\n" +
+              "  }\n" +
+              "}",
+      "{\n" +
+              "  \"properties\": {\n" +
+              "    \"FROM_ST\": [ { \"anything-but-ignore-case\": [ \"441\" ] } ]\n" +
+              "  }\n" +  
+              "}"   
+    };              
+    private final int[] ANYTHING_BUT_IGNORE_CASE_MATCHES = { 211158, 210411, 96682, 120, 210615 };
+
+
     private final String[] ANYTHING_BUT_PREFIX_RULES = {
       "{\n" +
               "  \"properties\": {\n" +
@@ -576,6 +606,12 @@ public class Benchmarks {
 
         bm = new Benchmarker();
 
+        bm.addRules(ANYTHING_BUT_IGNORE_CASE_RULES, ANYTHING_BUT_IGNORE_CASE_MATCHES);
+        bm.run(citylots2);
+        System.out.println("ANYTHING-BUT-IGNORE-CASE events/sec: " + String.format("%.1f", bm.getEPS()));
+
+        bm = new Benchmarker();
+
         bm.addRules(ANYTHING_BUT_PREFIX_RULES, ANYTHING_BUT_PREFIX_MATCHES);
         bm.run(citylots2);
         System.out.println("ANYTHING-BUT-PREFIX events/sec: " + String.format("%.1f", bm.getEPS()));
@@ -601,6 +637,9 @@ public class Benchmarks {
         bm.addRules(EXACT_RULES, EXACT_MATCHES);
         bm.addRules(PREFIX_RULES, PREFIX_MATCHES);
         bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
+        bm.addRules(ANYTHING_BUT_IGNORE_CASE_RULES, ANYTHING_BUT_IGNORE_CASE_MATCHES);
+        bm.addRules(ANYTHING_BUT_PREFIX_RULES, ANYTHING_BUT_PREFIX_MATCHES);
+        bm.addRules(ANYTHING_BUT_SUFFIX_RULES, ANYTHING_BUT_SUFFIX_MATCHES);
         bm.run(citylots2);
         System.out.println("PARTIAL_COMBO events/sec: " + String.format("%.1f", bm.getEPS()));
 
@@ -609,6 +648,9 @@ public class Benchmarks {
         bm.addRules(EXACT_RULES, EXACT_MATCHES);
         bm.addRules(PREFIX_RULES, PREFIX_MATCHES);
         bm.addRules(ANYTHING_BUT_RULES, ANYTHING_BUT_MATCHES);
+        bm.addRules(ANYTHING_BUT_IGNORE_CASE_RULES, ANYTHING_BUT_IGNORE_CASE_MATCHES);
+        bm.addRules(ANYTHING_BUT_PREFIX_RULES, ANYTHING_BUT_PREFIX_MATCHES);
+        bm.addRules(ANYTHING_BUT_SUFFIX_RULES, ANYTHING_BUT_SUFFIX_MATCHES);
         bm.addRules(COMPLEX_ARRAYS_RULES, COMPLEX_ARRAYS_MATCHES);
         bm.run(citylots2);
         System.out.println("COMBO events/sec: " + String.format("%.1f", bm.getEPS()));

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -300,27 +300,27 @@ public class Benchmarks {
     private final String[] ANYTHING_BUT_IGNORE_CASE_RULES = {
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"STREET\": [ { \"anything-but-ignore-case\": [ \"Fulton\" ] } ]\n" +
+              "    \"STREET\": [ { \"anything-but\": {\"ignore-case\": [ \"Fulton\" ] } } ]\n" +
               "  }\n" +
               "}", 
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"STREET\": [ { \"anything-but-ignore-case\": [ \"Mason\" ] } ]\n" + 
+              "    \"STREET\": [ { \"anything-but\": {\"ignore-case\": [ \"Mason\" ] } } ]\n" + 
               "  }\n" +
               "}",
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"ST_TYPE\": [ { \"anything-but-ignore-case\": [ \"st\" ] } ]\n" +
+              "    \"ST_TYPE\": [ { \"anything-but\": {\"ignore-case\": [ \"st\" ] } } ]\n" +
               "  }\n" +
               "}",
       "{\n" +
               "  \"geometry\": {\n" +
-              "    \"type\": [ {\"anything-but-ignore-case\": [ \"polygon\" ] } ]\n" +
+              "    \"type\": [ {\"anything-but\": {\"ignore-case\": [ \"polygon\" ] } } ]\n" +
               "  }\n" +
               "}",
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"FROM_ST\": [ { \"anything-but-ignore-case\": [ \"441\" ] } ]\n" +
+              "    \"FROM_ST\": [ { \"anything-but\": {\"ignore-case\": [ \"441\" ] } } ]\n" +
               "  }\n" +  
               "}"   
     };              

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -300,27 +300,27 @@ public class Benchmarks {
     private final String[] ANYTHING_BUT_IGNORE_CASE_RULES = {
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"STREET\": [ { \"anything-but\": {\"ignore-case\": [ \"Fulton\" ] } } ]\n" +
+              "    \"STREET\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"Fulton\" ] } } ]\n" +
               "  }\n" +
               "}", 
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"STREET\": [ { \"anything-but\": {\"ignore-case\": [ \"Mason\" ] } } ]\n" + 
+              "    \"STREET\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"Mason\" ] } } ]\n" + 
               "  }\n" +
               "}",
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"ST_TYPE\": [ { \"anything-but\": {\"ignore-case\": [ \"st\" ] } } ]\n" +
+              "    \"ST_TYPE\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"st\" ] } } ]\n" +
               "  }\n" +
               "}",
       "{\n" +
               "  \"geometry\": {\n" +
-              "    \"type\": [ {\"anything-but\": {\"ignore-case\": [ \"polygon\" ] } } ]\n" +
+              "    \"type\": [ {\"anything-but\": {\"equals-ignore-case\": [ \"polygon\" ] } } ]\n" +
               "  }\n" +
               "}",
       "{\n" +
               "  \"properties\": {\n" +
-              "    \"FROM_ST\": [ { \"anything-but\": {\"ignore-case\": [ \"441\" ] } } ]\n" +
+              "    \"FROM_ST\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"441\" ] } } ]\n" +
               "  }\n" +  
               "}"   
     };              

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -117,10 +117,10 @@ public class JsonRuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": \"rule\" } } ] }";
+        j = "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": \"rule\" } } ] }";
         assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": [\"abc\", \"123\"] } } ] }";
+        j = "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [\"abc\", \"123\"] } } ] }";
         assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
 
@@ -166,8 +166,8 @@ public class JsonRuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
-                "{\"a\": [ { \"anything-but\" : { \"ignore-case\": [1, 2 3] } } ] }",
-                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2, 3] } } ] }", // no numbers
+                "{\"a\": [ { \"anything-but\" : { \"equals-ignore-case\": [1, 2 3] } } ] }",
+                "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [1, 2, 3] } } ] }", // no numbers
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -117,11 +117,11 @@ public class JsonRuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but-ignore-case\": \"rule\" } ] }";
-        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": \"rule\" } } ] }";
+        assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but-ignore-case\": [\"abc\", \"123\"] } ] }";
-        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": [\"abc\", \"123\"] } } ] }";
+        assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
 
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
@@ -166,8 +166,8 @@ public class JsonRuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
-                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2 3] } ] }",
-                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2, 3] } ] }", // no numbers
+                "{\"a\": [ { \"anything-but\" : { \"ignore-case\": [1, 2 3] } } ] }",
+                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2, 3] } } ] }", // no numbers
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -117,6 +117,13 @@ public class JsonRuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", JsonRuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"anything-but-ignore-case\": \"rule\" } ] }";
+        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+
+        j = "{\"a\": [ { \"anything-but-ignore-case\": [\"abc\", \"123\"] } ] }";
+        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+
+
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
         assertNull("Good exact-match should parse", JsonRuleCompiler.check(j));
 
@@ -159,6 +166,8 @@ public class JsonRuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
+                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2, 3] } ] }", // no numbers
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1414,6 +1414,39 @@ public class MachineTest {
     }
 
     @Test
+    public void testAnythingButIgnoreCaseDeletion() throws Exception {
+        String rule = "{\n" +
+                "\"a\": [ { \"anything-but-ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } ],\n" +
+                "\"c\": [ { \"anything-but-ignore-case\": \"dad0\" } ],\n" +
+                "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ]\n" +
+                "}";
+        Machine cut = new Machine();
+    
+        // add the rule, ensure it matches
+        cut.addRule("r1", rule);
+        
+        String event = "{" +
+                "    \"a\": \"Child1\",\n" +
+                "    \"c\": \"chiLd1\",\n" +
+                "    \"z\": 0.001 \n" + 
+                "}\n";
+        String event1 = "{" +
+                "    \"a\": \"dAd4\",\n" +
+                "    \"c\": \"Child1\",\n" +
+                "    \"z\": 0.001 \n" +
+                "}\n";
+
+        assertEquals(1, cut.rulesForEvent(event).size());
+        assertEquals(1, cut.rulesForEvent(event1).size());
+
+        // delete partial rule 23, partial match
+        cut.deleteRule("r1", rule);
+        assertEquals(0, cut.rulesForEvent(event).size());
+        assertEquals(0, cut.rulesForEvent(event1).size());
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
     public void testIpExactMatch() throws Exception {
 
         String[] ipAddressesToBeMatched = {

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1416,8 +1416,8 @@ public class MachineTest {
     @Test
     public void testAnythingButIgnoreCaseDeletion() throws Exception {
         String rule = "{\n" +
-                "\"a\": [ { \"anything-but-ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } ],\n" +
-                "\"c\": [ { \"anything-but-ignore-case\": \"dad0\" } ],\n" +
+                "\"a\": [ { \"anything-but\": {\"ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } } ],\n" +
+                "\"c\": [ { \"anything-but\": {\"ignore-case\": \"dad0\" } } ],\n" +
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ]\n" +
                 "}";
         Machine cut = new Machine();

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1414,7 +1414,7 @@ public class MachineTest {
     }
 
     @Test
-    public void testAnythingButIgnoreCaseDeletion() throws Exception {
+    public void testAnythingButEqualsIgnoreCaseDeletion() throws Exception {
         String rule = "{\n" +
                 "\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } } ],\n" +
                 "\"c\": [ { \"anything-but\": {\"equals-ignore-case\": \"dad0\" } } ],\n" +

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1416,8 +1416,8 @@ public class MachineTest {
     @Test
     public void testAnythingButIgnoreCaseDeletion() throws Exception {
         String rule = "{\n" +
-                "\"a\": [ { \"anything-but\": {\"ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } } ],\n" +
-                "\"c\": [ { \"anything-but\": {\"ignore-case\": \"dad0\" } } ],\n" +
+                "\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [ \"dad0\",\"dad1\",\"dad2\" ] } } ],\n" +
+                "\"c\": [ { \"anything-but\": {\"equals-ignore-case\": \"dad0\" } } ],\n" +
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ]\n" +
                 "}";
         Machine cut = new Machine();

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -127,11 +127,11 @@ public class RuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", RuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but-ignore-case\": \"rule\" } ] }";
-        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": \"rule\" } } ] }";
+        assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but-ignore-case\": [\"abc\", \"123\"] } ] }";
-        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": [\"abc\", \"123\"] } } ] }";
+        assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
         assertNull("Good exact-match should parse", RuleCompiler.check(j));
@@ -175,8 +175,8 @@ public class RuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
-                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2 3] } ] }",
-                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2, 3] } ] }", // no numbers allowed
+                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2 3] } } ] }",
+                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2, 3] } } ] }", // no numbers allowed
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",
@@ -237,7 +237,7 @@ public class RuleCompilerTest {
                 "{ \"anything-but\": [111,222,333]}," +
                 "{ \"anything-but\": { \"prefix\": \"foo\"}}," +
                 "{ \"anything-but\": { \"suffix\": \"ing\"}}," +
-                "{ \"anything-but-ignore-case\": \"def\" }" +
+                "{ \"anything-but\": {\"ignore-case\": \"def\" } }" +
                 "]," +
                 "\"c2\": { \"d\": { \"e\": [" +
                 "{ \"exactly\": \"child\" }," +

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -127,10 +127,10 @@ public class RuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", RuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": \"rule\" } } ] }";
+        j = "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": \"rule\" } } ] }";
         assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
-        j = "{\"a\": [ { \"anything-but\": {\"ignore-case\": [\"abc\", \"123\"] } } ] }";
+        j = "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [\"abc\", \"123\"] } } ] }";
         assertNull("Good anything-but/ignore-case should parse", JsonRuleCompiler.check(j));
 
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
@@ -175,8 +175,8 @@ public class RuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
-                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2 3] } } ] }",
-                "{\"a\": [ { \"anything-but\": {\"ignore-case\": [1, 2, 3] } } ] }", // no numbers allowed
+                "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [1, 2 3] } } ] }",
+                "{\"a\": [ { \"anything-but\": {\"equals-ignore-case\": [1, 2, 3] } } ] }", // no numbers allowed
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",
@@ -237,7 +237,7 @@ public class RuleCompilerTest {
                 "{ \"anything-but\": [111,222,333]}," +
                 "{ \"anything-but\": { \"prefix\": \"foo\"}}," +
                 "{ \"anything-but\": { \"suffix\": \"ing\"}}," +
-                "{ \"anything-but\": {\"ignore-case\": \"def\" } }" +
+                "{ \"anything-but\": {\"equals-ignore-case\": \"def\" } }" +
                 "]," +
                 "\"c2\": { \"d\": { \"e\": [" +
                 "{ \"exactly\": \"child\" }," +

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -127,6 +127,12 @@ public class RuleCompilerTest {
         j = "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" } } ] }";
         assertNull("Good anything-but should parse", RuleCompiler.check(j));
 
+        j = "{\"a\": [ { \"anything-but-ignore-case\": \"rule\" } ] }";
+        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+
+        j = "{\"a\": [ { \"anything-but-ignore-case\": [\"abc\", \"123\"] } ] }";
+        assertNull("Good anything-but-ignore-case should parse", JsonRuleCompiler.check(j));
+
         j = "{\"a\": [ { \"exactly\": \"child\" } ] }";
         assertNull("Good exact-match should parse", RuleCompiler.check(j));
 
@@ -169,6 +175,8 @@ public class RuleCompilerTest {
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"\" } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\", \"a\":1 } } ] }",
                 "{\"a\": [ { \"anything-but\": { \"suffix\": \"foo\" }, \"x\": 1 } ] }",
+                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2 3] } ] }",
+                "{\"a\": [ { \"anything-but-ignore-case\": [1, 2, 3] } ] }", // no numbers allowed
                 "{\"a\": [ { \"equals-ignore-case\": 5 } ] }",
                 "{\"a\": [ { \"equals-ignore-case\": [ \"abc\" ] } ] }",
                 "{\"a\": [ { \"wildcard\": 5 } ] }",
@@ -228,7 +236,8 @@ public class RuleCompilerTest {
                 "{ \"suffix\": \"child\" }," +
                 "{ \"anything-but\": [111,222,333]}," +
                 "{ \"anything-but\": { \"prefix\": \"foo\"}}," +
-                "{ \"anything-but\": { \"suffix\": \"ing\"}}" +
+                "{ \"anything-but\": { \"suffix\": \"ing\"}}," +
+                "{ \"anything-but-ignore-case\": \"def\" }" +
                 "]," +
                 "\"c2\": { \"d\": { \"e\": [" +
                 "{ \"exactly\": \"child\" }," +
@@ -248,7 +257,8 @@ public class RuleCompilerTest {
                 Patterns.suffixMatch("child\""),
                 Patterns.anythingButNumberMatch(Stream.of(111, 222, 333).map(Double::valueOf).collect(Collectors.toSet())),
                 Patterns.anythingButPrefix("\"foo"),
-                Patterns.anythingButSuffix("ing\"")
+                Patterns.anythingButSuffix("ing\""),
+                Patterns.anythingButIgnoreCaseMatch("\"def\"")
         ));
         expected.put(Arrays.asList("a2", "b", "c2", "d", "e"), Arrays.asList(
                 Patterns.exactMatch("\"child\""),

--- a/src/test/software/amazon/event/ruler/RulerTest.java
+++ b/src/test/software/amazon/event/ruler/RulerTest.java
@@ -399,7 +399,10 @@ public class RulerTest {
                 "\"c\": [ { \"anything-but\": \"zdd\" } ],\n" +
                 "\"d\": [ { \"anything-but\": 444 } ],\n" +
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ],\n" +
-                "\"w\": [ { \"anything-but\": { \"prefix\": \"zax\" } } ]\n" +
+                "\"w\": [ { \"anything-but\": { \"prefix\": \"zax\" } } ],\n" +
+                "\"n\": [ { \"anything-but\": { \"suffix\": \"ing\" } } ],\n" +
+                "\"o\": [ { \"anything-but-ignore-case\": \"CamelCase\" } ],\n" +
+                "\"p\": [ { \"anything-but-ignore-case\": [\"CamelCase\", \"AbC\"] } ]\n" +
                 "}";
 
         String[] events = {
@@ -409,7 +412,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.001 \n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"dad789\",\n" +
@@ -417,7 +423,10 @@ public class RulerTest {
                         "    \"c\": \"zdd\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.001 \n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"dad789\",\n" +
@@ -425,7 +434,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 1.01 \n" +
+                        "    \"z\": 1.01, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"dad1\",\n" +
@@ -433,7 +445,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.001 \n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"abc\",\n" +
@@ -441,7 +456,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.001 \n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"dad1\",\n" +
@@ -449,7 +467,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.001 \n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"abc\",\n" +
@@ -457,7 +478,10 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 444,\n" +
                         "    \"w\": \"xaz\",\n" +
-                        "    \"z\": 0.999999 \n" +
+                        "    \"z\": 0.999999, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
                         "}\n",
                 "{" +
                         "    \"a\": \"child1\",\n" +
@@ -465,11 +489,47 @@ public class RulerTest {
                         "    \"c\": \"child1\",\n" +
                         "    \"d\": 123,\n" +
                         "    \"w\": \"zaxonie\",\n" +
-                        "    \"z\": 0.001 \n" +
-                        "}\n"
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
+                        "}\n",
+                "{" +
+                        "    \"a\": \"child1\",\n" +
+                        "    \"b\": \"444\",\n" +
+                        "    \"c\": \"child1\",\n" +
+                        "    \"d\": 123,\n" +
+                        "    \"w\": \"xaz\",\n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"matching\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
+                        "}\n",
+                "{" +
+                        "    \"a\": \"child1\",\n" +
+                        "    \"b\": \"444\",\n" +
+                        "    \"c\": \"child1\",\n" +
+                        "    \"d\": 123,\n" +
+                        "    \"w\": \"xaz\",\n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"camelcase\", \n" +
+                        "    \"p\": \"nomatch\" \n" +
+                        "}\n",
+                "{" +
+                        "    \"a\": \"child1\",\n" +
+                        "    \"b\": \"444\",\n" +
+                        "    \"c\": \"child1\",\n" +
+                        "    \"d\": 123,\n" +
+                        "    \"w\": \"xaz\",\n" +
+                        "    \"z\": 0.001, \n" +
+                        "    \"n\": \"nomatch\", \n" +
+                        "    \"o\": \"nomatch\", \n" +
+                        "    \"p\": \"abc\" \n" +
+                        "}\n",
         };
 
-        boolean[] result = {true, false, false, false, false, false, false, false };
+        boolean[] result = {true, false, false, false, false, false, false, false, false, false, false };
 
         for (int i = 0; i< events.length; i++) {
             assertEquals(events[i], result[i], Ruler.matchesRule(events[i], rule));

--- a/src/test/software/amazon/event/ruler/RulerTest.java
+++ b/src/test/software/amazon/event/ruler/RulerTest.java
@@ -401,8 +401,8 @@ public class RulerTest {
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ],\n" +
                 "\"w\": [ { \"anything-but\": { \"prefix\": \"zax\" } } ],\n" +
                 "\"n\": [ { \"anything-but\": { \"suffix\": \"ing\" } } ],\n" +
-                "\"o\": [ { \"anything-but\": {\"ignore-case\": \"CamelCase\" } } ],\n" +
-                "\"p\": [ { \"anything-but\": {\"ignore-case\": [\"CamelCase\", \"AbC\"] } } ]\n" +
+                "\"o\": [ { \"anything-but\": {\"equals-ignore-case\": \"CamelCase\" } } ],\n" +
+                "\"p\": [ { \"anything-but\": {\"equals-ignore-case\": [\"CamelCase\", \"AbC\"] } } ]\n" +
                 "}";
 
         String[] events = {

--- a/src/test/software/amazon/event/ruler/RulerTest.java
+++ b/src/test/software/amazon/event/ruler/RulerTest.java
@@ -401,8 +401,8 @@ public class RulerTest {
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ],\n" +
                 "\"w\": [ { \"anything-but\": { \"prefix\": \"zax\" } } ],\n" +
                 "\"n\": [ { \"anything-but\": { \"suffix\": \"ing\" } } ],\n" +
-                "\"o\": [ { \"anything-but-ignore-case\": \"CamelCase\" } ],\n" +
-                "\"p\": [ { \"anything-but-ignore-case\": [\"CamelCase\", \"AbC\"] } ]\n" +
+                "\"o\": [ { \"anything-but\": {\"ignore-case\": \"CamelCase\" } } ],\n" +
+                "\"p\": [ { \"anything-but\": {\"ignore-case\": [\"CamelCase\", \"AbC\"] } } ]\n" +
                 "}";
 
         String[] events = {


### PR DESCRIPTION
### Issue #, if available:
#70
### Description of changes:

Add a case-insensitive anything-but construct:

```
{
  "detail": {
    "command_path": [ { "anything-but": {"equals-ignore-case": [ "c:\windows", "c:\Program Files" ] } } ]
  }
}
```

#### Benchmark / Performance (for source code changes):

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running software.amazon.event.ruler.Benchmarks
Reading citylots2
Read 213068 events
EXACT events/sec: 421083.0
WILDCARD events/sec: 298833.1
PREFIX events/sec: 415337.2
SUFFIX events/sec: 418601.2
EQUALS_IGNORE_CASE events/sec: 342553.1
NUMERIC events/sec: 250079.8
ANYTHING-BUT events/sec: 234398.2
ANYTHING-BUT-IGNORE-CASE events/sec: 235955.7
ANYTHING-BUT-PREFIX events/sec: 243506.3
ANYTHING-BUT-SUFFIX events/sec: 237269.5
COMPLEX_ARRAYS events/sec: 6953.7
PARTIAL_COMBO events/sec: 103230.6
COMBO events/sec: 4215.7
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 6262
Events/sec: 34025.6
 Rules/sec: 238178.9
Before: 180.3
After: 861.4
Per rule: -1702
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 1350
Events/sec: 157828.1
Before: 196.0
After: 633.1
Per rule: -1092
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 686
Events/sec: 310594.8
 Rules/sec: 1131186087.5
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 9141
Events/sec: 23309.0
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 5512
Events/sec: 38655.3
 Rules/sec: 270587.1
DEEP EXACT events/sec: 14285.7
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 130.768 sec

```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
