### PR TITLE
Exponential memory improvement by re-using NameState across multiple patterns

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -5,6 +5,10 @@ import java.util.Set;
 
 /**
  * Represents a place in a ByteMachine where we have to do something in addition to just transitioning to another step.
+ *
+ * ByteMatch will be saved in anythingBut ConcurrentSkipListSet which is threadsafe, ordering that require
+ * the element must implement comparable interface and override appropriate interface for deduplication and
+ * comparison.
  */
 final class ByteMatch extends SingleByteTransition  {
 

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -5,10 +5,6 @@ import java.util.Set;
 
 /**
  * Represents a place in a ByteMachine where we have to do something in addition to just transitioning to another step.
- *
- * ByteMatch will be saved in anythingBut ConcurrentSkipListSet which is threadsafe, ordering that require
- * the element must implement comparable interface and override appropriate interface for deduplication and
- * comparison.
  */
 final class ByteMatch extends SingleByteTransition  {
 

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -9,8 +9,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -278,20 +280,27 @@ public class GenericMachine<T> {
                 }
             }
             if (nextNameState != null) {
-                // if this was the last step, then reaching the last state means the rule matched.
+                // If this was the last step, then reaching the last state means the rule matched, and we should delete
+                // the rule from the next NameState.
                 final int nextKeyIndex = keyIndex + 1;
                 if (nextKeyIndex == keys.size()) {
-                    if (nextNameState.hasRule(ruleName)) {
-                        nextNameState.deleteRule(ruleName);
-                        // only when this state have no rules and no next transition, we could remove it.
-                        if (checkAndDeleteNameState(nextNameState, state, key, pattern)) {
+                    if (nextNameState.hasRuleWithPattern(ruleName, pattern)) {
+                        nextNameState.deleteRuleWithPattern(ruleName, pattern);
+                        // Only delete the pattern if:
+                        //   1. There are no other rules using the same pattern also leading to the next NameState, and
+                        //   2. The next NameState is a dead-end; it doesn't transition to a ByteMachine or NameMatcher.
+                        Set<Patterns> nextPatterns = nextNameState.getPatterns();
+                        boolean doesNextNameStateStillContainPattern = nextPatterns.contains(pattern);
+                        if (!doesNextNameStateStillContainPattern && !nextNameState.hasTransitions()
+                                && deletePattern(state, key, pattern)) {
                             deletedKeys.add(key);
                         }
                     }
                 } else {
                     deleteStep(nextNameState, keys, nextKeyIndex, patterns, ruleName, deletedKeys);
-                    // only when this state have no rules and no next transition, we could remove it.
-                    if (checkAndDeleteNameState(nextNameState, state, key, pattern)) {
+                    // Unwinding the key recursion, so we aren't on a rule match. Only delete the pattern if the next
+                    // NameState is a dead-end, meaning it doesn't transition to a ByteMachine or NameMatcher.
+                    if (!nextNameState.hasTransitions() && deletePattern(state, key, pattern)) {
                         deletedKeys.add(key);
                     }
                 }
@@ -301,23 +310,29 @@ public class GenericMachine<T> {
 
     }
 
-    private boolean checkAndDeleteNameState(final NameState currentNameState, final NameState parentNameState,
-            final String key, Patterns pattern) {
-        if (currentNameState.isEmpty()) {
-            if (isNamePattern(pattern)) {
-                NameMatcher<NameState> nameMatcher = parentNameState.getKeyTransitionOn(key);
-                nameMatcher.deletePattern(pattern);
-                if (nameMatcher.isEmpty()) {
-                    parentNameState.removeKeyTransition(key);
-                    return true;
-                }
-            } else {
-                ByteMachine byteMachine = parentNameState.getTransitionOn(key);
-                byteMachine.deletePattern(pattern);
-                if (byteMachine.isEmpty()) {
-                    parentNameState.removeTransition(key);
-                    return true;
-                }
+    /**
+     * Delete given pattern from either NameMatcher or ByteMachine. Remove the parent NameState's transition to
+     * NameMatcher or ByteMachine if empty after pattern deletion.
+     *
+     * @param parentNameState The NameState transitioning to the NameMatcher or ByteMachine.
+     * @param key The key we transition on.
+     * @param pattern The pattern to delete.
+     * @return True if and only if transition from parent NameState was removed.
+     */
+    private boolean deletePattern(final NameState parentNameState, final String key, Patterns pattern) {
+        if (isNamePattern(pattern)) {
+            NameMatcher<NameState> nameMatcher = parentNameState.getKeyTransitionOn(key);
+            nameMatcher.deletePattern(pattern);
+            if (nameMatcher.isEmpty()) {
+                parentNameState.removeKeyTransition(key);
+                return true;
+            }
+        } else {
+            ByteMachine byteMachine = parentNameState.getTransitionOn(key);
+            byteMachine.deletePattern(pattern);
+            if (byteMachine.isEmpty()) {
+                parentNameState.removeTransition(key);
+                return true;
             }
         }
         return false;
@@ -453,23 +468,29 @@ public class GenericMachine<T> {
         // for each pattern, we'll provisionally add it to the BMC, which may already have it.  Pass the states
         //  list in in case the BMC doesn't already have a next-step for this pattern and needs to make a new one
         //
+        NameState lastNextState = null;
+        Set<NameState> nameStates = new HashSet<>();
         for (Patterns pattern : patterns.get(key)) {
-            final NameState nextState;
-
             if (isNamePattern(pattern)) {
                 assert nameMatcher != null;
-                nextState = nameMatcher.addPattern(pattern, NameState::new);
+                final NameState nameStateForSupplier = lastNextState == null ? new NameState() : lastNextState;
+                lastNextState = nameMatcher.addPattern(pattern, () -> nameStateForSupplier);
             } else {
                 assert byteMachine != null;
-                nextState = byteMachine.addPattern(pattern);
+                lastNextState = byteMachine.addPattern(pattern, lastNextState);
             }
+            nameStates.add(lastNextState);
+        }
 
+        for (NameState nameState : nameStates) {
             // if this was the last step, then reaching the last state means the rule matched.
             final int nextKeyIndex = keyIndex + 1;
             if (nextKeyIndex == keys.size()) {
-                nextState.addRule(ruleName);
+                for (Patterns pattern : patterns.get(key)) {
+                    nameState.addRuleWithPattern(ruleName, pattern);
+                }
             } else {
-                addStep(nextState, keys, nextKeyIndex, patterns, ruleName, addedKeys);
+                addStep(nameState, keys, nextKeyIndex, patterns, ruleName, addedKeys);
             }
         }
 

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents a state in the machine.
  *
@@ -176,8 +178,8 @@ class NameState {
         private final Patterns pattern;
 
         public RuleWithPattern(Object rule, Patterns pattern) {
-            this.rule = rule;
-            this.pattern = pattern;
+            this.rule = requireNonNull(rule);
+            this.pattern = requireNonNull(pattern);
         }
 
         @Override

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2094,6 +2095,71 @@ public class ByteMachineTest {
         } catch (ParseException e) {
             assertEquals("Consecutive wildcard characters at pos 1", e.getMessage());
         }
+    }
+
+    @Test
+    public void testAddMatchPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.exactMatch("a"), nameState));
+    }
+
+    @Test
+    public void testAddMatchPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.exactMatch("a")));
+    }
+
+    @Test
+    public void testAddExistencePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.existencePatterns(), nameState));
+    }
+
+    @Test
+    public void testAddExistencePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.existencePatterns()));
+    }
+
+    @Test
+    public void testAddAnythingButPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.anythingButMatch("z"), nameState));
+    }
+
+    @Test
+    public void testAddAnythingButPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.anythingButMatch("z")));
+    }
+
+    @Test
+    public void testAddAnythingButEqualsIgnoreCasePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z"), nameState));
+    }
+
+    @Test
+    public void testAddAnythingButEqualsIgnoreCasePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z")));
+    }
+
+    @Test
+    public void testAddRangePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Range.lessThan(5), nameState));
+    }
+
+    @Test
+    public void testAddRangePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Range.lessThan(5)));
     }
 
     private void testPatternPermutations(PatternMatch ... patternMatches) {

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -422,6 +422,8 @@ public class JsonRuleCompilerTest {
         assertTrue(found.contains("rule2"));
 
         machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
         machine.deleteRule("rule2", rule2);
         found = machine.rulesForJSONEvent(event);
         assertEquals(0, found.size());
@@ -496,7 +498,6 @@ public class JsonRuleCompilerTest {
         assertTrue(rules.isArray());
         assertTrue(machine.isEmpty());
 
-        final int expectedSubRuleSize [] = {1, 1, 1, 1};
         final String expectedCompiledRules [] = {
                 "{$or=[0A000000/0A0000FF:false/false (T:NUMERIC_RANGE)]}",
                 "{$or.namespace=[VP:\"AWS/EC2\" (T:EXACT), VP:\"AWS/ES\" (T:EXACT)], source=[VP:\"aws.cloudwatch\" (T:EXACT)], $or.metricType=[VP:\"MetricType\" (T:EXACT)]}",
@@ -505,7 +506,6 @@ public class JsonRuleCompilerTest {
         };
 
         int i = 0;
-        List<Map<String, List<Patterns>>> compiledRules = null;
 
         // verify the legacy rules with using "$or" as normal field can work correctly with legacy RuleCompiler
         for (final JsonNode rule : rules) {

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1537,4 +1537,68 @@ public class MachineTest {
 
         assertTrue(machine.isEmpty());
     }
+
+    @Test
+    public void testAddAndDeleteTwoRulesSamePattern() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
+    public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternEqualsIgnoreCase() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"y\" } ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"Y\" } ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
 }


### PR DESCRIPTION
### Description of changes:
Seeking feedback from Tim and Long. This seems like a huge improvement to the fundamental Ruler code for minimal effort, so it has occurred to me that I might be overlooking something. I'd love some feedback about the validity of the approach. (It seems valid in my mind.)

Previously, Ruler would create a new NameState for every pattern. Now, NameStates are re-used across patterns for a given field.

The NameState is accessed via the pattern's ByteMatch at the end of the ByteMachine and provides access to the ByteMachine for the next field. So picture a rule with many fields, and for each of these fields, an array of many elements. Each array element is a pattern for the field. So this turns into a rapidly/exponentially expanding tree of NameStates and ByteMachines. But it's all unnecessary. Since the next field and its patterns will be the same no matter what value we use to match the current field, there is no reason not to re-use NameStates (and thus ByteMachines). This collapses an exponentially-expanding tree into a line. Or to word it another way, this changes Ruler's memory complexity from O(product of all array sizes) to O(sum of all array sizes).

#### Benchmark / Performance (for source code changes):
Testing against one event with several large arrays, there was a 99.5% reduction in the number of ByteMatches created.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
