### PR TITLE
Calc size

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,18 @@ names* section, you would have to call `deleteRule()` the same number of times,
 with the same associated patterns, to remove all references to that rule name
 from the machine.
 
+### approximateObjectCount()
+
+This method roughly the number of objects within the machine. It's value only varies as rule are added or
+removed. This is useful to identify large machines that potentially require loads of memory.
+As this method is dependent on number of internal objects, this counts may change when ruler library internals
+are changed. The method performs all of its calculation at runtime to avoid taking up memory and making the
+impact of large rule-machines worse. Its computation is intentionally NOT thread-safe to avoid blocking rule
+evaluations and machine changes. It means that if a parallel process is adding or removing from the machine,
+you may get a different results compared to when such parallel processes are complete. Also, as the library
+makes optimizations to its internals for some patterns (see `ShortcutTransition.java` for more details), you
+may also get different results depending on the order in which rules were added or removed.
+
 ### rulesForEvent() / rulesForJSONEvent()
 
 This method returns a `List<String>` for Machine (and `List<T>` for GenericMachine) which contains

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -1916,6 +1916,16 @@ class ByteMachine {
         return (startStateMatch != null ? 1 : 0) + evaluator.evaluate(startState);
     }
 
+    public void gatherObjects(Set<Object> objectSet) {
+        if (!objectSet.contains(this)) { // stops looping
+            objectSet.add(this);
+            startState.gatherObjects(objectSet);
+            for (ByteMatch byteMatch : anythingButs) {
+                byteMatch.gatherObjects(objectSet);
+            }
+        }
+    }
+
     public static final class EmptyByteTransition extends SingleByteTransition {
 
         static final EmptyByteTransition INSTANCE = new EmptyByteTransition();
@@ -1960,6 +1970,10 @@ class ByteMachine {
             return match;
         }
 
+        @Override
+        public void gatherObjects(Set<Object> objectSet) {
+            objectSet.add(this);
+        }
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -1920,8 +1920,8 @@ class ByteMachine {
         if (!objectSet.contains(this)) { // stops looping
             objectSet.add(this);
             startState.gatherObjects(objectSet);
-            for (ByteMatch byteMatch : anythingButs) {
-                byteMatch.gatherObjects(objectSet);
+            for (NameState states : anythingButs) {
+                states.gatherObjects(objectSet);
             }
         }
     }

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -67,6 +67,14 @@ final class ByteMatch extends SingleByteTransition  {
     }
 
     @Override
+    public void gatherObjects(Set<Object> objectSet) {
+        if (!objectSet.contains(this)) { // stops looping
+            objectSet.add(this);
+            nextNameState.gatherObjects(objectSet);
+        }
+    }
+
+    @Override
     public String toString() {
         return "BM: HC=" + hashCode() + " P=" + pattern  + "(" + pattern.pattern() + ") NNS=" + nextNameState;
     }

--- a/src/main/software/amazon/event/ruler/ByteTransition.java
+++ b/src/main/software/amazon/event/ruler/ByteTransition.java
@@ -106,6 +106,19 @@ abstract class ByteTransition implements Cloneable {
         return false;
     }
 
+    public void gatherObjects(Set<Object> objectSet) {
+        if (!objectSet.contains(this)) { // stops looping
+            objectSet.add(this);
+            for (ByteTransition byteMachine : getTransitions()) {
+                byteMachine.gatherObjects(objectSet);
+            }
+            final ByteState nextByteState = getNextByteState();
+            if (nextByteState != null) {
+                nextByteState.gatherObjects(objectSet);
+            }
+        }
+    }
+
     @Override
     public ByteTransition clone() {
         try {

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -526,6 +527,27 @@ public class GenericMachine<T> {
 
     public int evaluateComplexity(MachineComplexityEvaluator evaluator) {
         return startState.evaluateComplexity(evaluator);
+    }
+
+    /**
+     * Gives roughly the number of objects within the machine. This is useful to identify large rule-machines
+     * that potentially require loads of memory. The method performs all of its calculation at runtime to avoid
+     * taking up memory and making the impact of large rule-machines worse. When calculating this value; we
+     * consider any transitions, states, byte-machines, and rules. There's are also a checks to ensure we're
+     * not stuck in endless loops (that's possible for wildcard matches) or taking a long time for numeric range
+     * matchers.
+     *
+     * NOTEs:
+     * 1. As this method is dependent on number of internal objects, as ruler evolves this will also
+     * give different results.
+     * 2. It will also give you different results based on the order in which you add or remove rules as in
+     * some-cases Ruler takes short-cuts for exact matches (see ShortcutTransition for more details).
+     * 3. This method isn't thread safe, and so is prefixed with approximate.
+     */
+    public int approximateObjectCount() {
+        final HashSet<Object> objectSet = new HashSet<>();
+        startState.gatherObjects(objectSet);
+        return objectSet.size();
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -152,6 +152,19 @@ class NameState {
         return complexity;
     }
 
+    public void gatherObjects(Set<Object> objectSet) {
+        if (!objectSet.contains(this)) { // stops looping
+            objectSet.add(this);
+            for (ByteMachine byteMachine : valueTransitions.values()) {
+                byteMachine.gatherObjects(objectSet);
+            }
+            for (Map.Entry<String, NameMatcher<NameState>> mustNotExistEntry : mustNotExistMatchers.entrySet()) {
+                mustNotExistEntry.getValue().getNextState().gatherObjects(objectSet);
+            }
+            objectSet.addAll(rules);
+        }
+    }
+
     @Override
     public String toString() {
         return "NameState{" +

--- a/src/main/software/amazon/event/ruler/SingleByteTransition.java
+++ b/src/main/software/amazon/event/ruler/SingleByteTransition.java
@@ -59,4 +59,22 @@ abstract class SingleByteTransition extends ByteTransition {
         return getNextByteState();
     }
 
+    @Override
+    public void gatherObjects(Set<Object> objectSet) {
+        if (!objectSet.contains(this)) { // stops looping
+            objectSet.add(this);
+            final ByteMatch match = getMatch();
+            if (match != null) {
+                match.gatherObjects(objectSet);
+            }
+            for (ByteTransition transition : getTransitions()) {
+                transition.gatherObjects(objectSet);
+            }
+            final ByteTransition nextByteStates = getTransitionForNextByteStates();
+            if (nextByteStates != null) {
+                nextByteStates.gatherObjects(objectSet);
+            }
+        }
+    }
+
 }

--- a/src/test/software/amazon/event/ruler/Benchmarks.java
+++ b/src/test/software/amazon/event/ruler/Benchmarks.java
@@ -426,15 +426,18 @@ public class Benchmarks {
 
         System.gc();
         long memBefore = Runtime.getRuntime().freeMemory();
-        System.out.printf("Before: %.1f\n", 1.0 * memBefore / 1000000);
+        int sizeBefore = mm.approximateObjectCount();
+        System.out.printf("Before: %.1f (%d)\n", 1.0 * memBefore / 1000000, sizeBefore);
         for (int i = 0; i < rules.size(); i++) {
             mm.addRule("mm" + i, rules.get(i));
         }
         System.gc();
         long memAfter = Runtime.getRuntime().freeMemory();
-        System.out.printf("After: %.1f\n", 1.0 * memAfter / 1000000);
-        int perRule = (int) ((1.0 * (memBefore - memAfter)) / rules.size());
-        System.out.println("Per rule: " + perRule);
+        int sizeAfter = mm.approximateObjectCount();
+        System.out.printf("After: %.1f (%d)\n", 1.0 * memAfter / 1000000, sizeAfter);
+        int perRuleMem = (int) ((1.0 * (memAfter - memBefore)) / rules.size());
+        int perRuleSize = (int) ((1.0 * (sizeAfter - sizeBefore)) / rules.size());
+        System.out.println("Per rule: " + perRuleMem + " (" + perRuleSize + ")");
         rules.clear();
     }
 
@@ -470,15 +473,18 @@ public class Benchmarks {
 
         System.gc();
         long memBefore = Runtime.getRuntime().freeMemory();
-        System.out.printf("Before: %.1f\n", 1.0 * memBefore / 1000000);
+        int sizeBefore = mm.approximateObjectCount();
+        System.out.printf("Before: %.1f (%d)\n", 1.0 * memBefore / 1000000, sizeBefore);
         for (int i = 0; i < rules.size(); i++) {
             mm.addRule("mm" + i, rules.get(i));
         }
         System.gc();
         long memAfter = Runtime.getRuntime().freeMemory();
-        System.out.printf("After: %.1f\n", 1.0 * memAfter / 1000000);
-        int perRule = (int) ((1.0 * (memBefore - memAfter)) / rules.size());
-        System.out.println("Per rule: " + perRule);
+        int sizeAfter = mm.approximateObjectCount();
+        System.out.printf("After: %.1f (%d)\n", 1.0 * memAfter / 1000000, sizeAfter);
+        int perRuleMem = (int) ((1.0 * (memAfter - memBefore)) / rules.size());
+        int perRuleSize = (int) ((1.0 * (sizeAfter - sizeBefore)) / rules.size());
+        System.out.println("Per rule: " + perRuleMem + " (" + perRuleSize + ")");
         rules.clear();
     }
 


### PR DESCRIPTION

### Issue #, if available:

### Description of changes:

Ruler is internally a state-machine, so calculating its memory footprint requires checking 1/ all possible states, 2/ the path between various states, and 3/ any final stopping nodes.

As calculating exact memory is not possible without using profiling or other memory monitoring techniques, we are isntead counting each unique object as weight 1. We then calculate all possible states by traversing from the starting state-machine.

Internally this is implemented through build a set of object refs while traversing the entire the state-machine. This is ineffecient but allows us to review if "traversing the state machine" is the best technique. hashcodes also help block any looping situations.

#### Benchmark / Performance (for source code changes):

```
/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/bin/java -Dvisualvm.id=62371601411016 -ea -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=58564:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8 -classpath /Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar:/Applications/IntelliJ IDEA.app/Contents/plugins/junit/lib/junit5-rt.jar:/Applications/IntelliJ IDEA.app/Contents/plugins/junit/lib/junit-rt.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/cldrdata.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/dnsns.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/jaccess.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/jfxrt.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/localedata.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/nashorn.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/sunec.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/sunjce_provider.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/sunpkcs11.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/ext/zipfs.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/jfxswt.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/management-agent.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/ant-javafx.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/dt.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/javafx-mx.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/jconsole.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/packager.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/sa-jdi.jar:/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/lib/tools.jar:/Volumes/Unix/workspaces/event-ruler/target/test-classes:/Volumes/Unix/workspaces/event-ruler/target/classes:/Users/baldawar/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar:/Users/baldawar/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar:/Users/baldawar/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar:/Users/baldawar/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/Users/baldawar/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar:/Users/baldawar/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit4 software.amazon.event.ruler.Benchmarks
Reading citylots2
Read 213068 events
EXACT events/sec: 143383.6
WILDCARD events/sec: 103030.9
PREFIX events/sec: 171690.6
SUFFIX events/sec: 185115.6
EQUALS_IGNORE_CASE events/sec: 144062.2
NUMERIC events/sec: 113757.6
ANYTHING-BUT events/sec: 124455.6
ANYTHING-BUT-IGNORE-CASE events/sec: 121753.1
ANYTHING-BUT-PREFIX events/sec: 128664.3
ANYTHING-BUT-SUFFIX events/sec: 134089.4
COMPLEX_ARRAYS events/sec: 4289.3
PARTIAL_COMBO events/sec: 64920.2
COMBO events/sec: 2407.4
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 13425
Events/sec: 15871.0
 Rules/sec: 111096.9
Before: 2029.4 (1)
After: 1264.5 (5076905)
Per rule: -1912 (12)
Turning JSON into field-lists...
Finding Rules...
Lines: 213068, Msec: 2735
Events/sec: 77904.2
Before: 1633.8 (1)
After: 1069.8 (3669583)
Per rule: -1409 (9)
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 2077
Events/sec: 102584.5
 Rules/sec: 373612737.6
Reading citylots2
Read 213068 events
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Matched: 52527
Lines: 213068, Msec: 12051
Events/sec: 17680.5
Reading lines...
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 11394
Events/sec: 18700.0
 Rules/sec: 130900.1
DEEP EXACT events/sec: 6666.7

Process finished with exit code 0
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
