### PR TITLE
Making deletePatternRule a public method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,10 +593,11 @@ public static Range between(final double bottom, final boolean openBottom, final
 ```
 
 Once you have constructed appropriate `Patterns` matchers with these methods, you can use the
-following form of `Machine.addRule()` to add them to your machine:
+following methods to add to or delete from your machine:
 
 ```java
 public void addPatternRule(final String name, final Map<String, List<Patterns>> namevals);
+public void deletePatternRule(final String name, final Map<String, List<Patterns>> namevals);
 ```
 
 ## JSON text matching

--- a/README.md
+++ b/README.md
@@ -600,6 +600,9 @@ public void addPatternRule(final String name, final Map<String, List<Patterns>> 
 public void deletePatternRule(final String name, final Map<String, List<Patterns>> namevals);
 ```
 
+NOTE: The cautions listed in [`deleteRule()`](#deleterule) apply
+to `deletePatternRule()` as well.
+
 ## JSON text matching
 
 The field values in rules must be provided in their JSON representations.

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${javadoc.plugin.version}</version>
+        <configuration>
+          <additionalJOption>-Xdoclint:none</additionalJOption>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -227,7 +227,7 @@ public class GenericMachine<T> {
      * @param name ARN of the rule
      * @param namevals names & values which make up the rule
      */
-    void deletePatternRule(final T name, final Map<String, List<Patterns>> namevals) {
+    public void deletePatternRule(final T name, final Map<String, List<Patterns>> namevals) {
         if (namevals.size() > MAXIMUM_RULE_SIZE) {
             throw new RuntimeException("Size of rule '" + name + "' exceeds max value of " + MAXIMUM_RULE_SIZE);
         }


### PR DESCRIPTION
We already have `addPatternRule` as public but offer no equivalent for deleting patterns. The method is tested as part of our MachineTests.java so assuming we missed making this public in past (probably because nobody asked until https://github.com/aws/event-ruler/issues/64).

Benchmarks were not necessary for this change. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
