### PR TITLE
Add a new SuffixParser to handle UTF-8 chracters with more than one byte 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/input/DefaultParser.java
+++ b/src/main/software/amazon/event/ruler/input/DefaultParser.java
@@ -4,8 +4,10 @@ import software.amazon.event.ruler.MatchType;
 
 import java.nio.charset.StandardCharsets;
 
+import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_SUFFIX;
 import static software.amazon.event.ruler.MatchType.EQUALS_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_IGNORE_CASE;
+import static software.amazon.event.ruler.MatchType.SUFFIX;
 import static software.amazon.event.ruler.MatchType.WILDCARD;
 
 /**
@@ -36,14 +38,16 @@ public class DefaultParser implements MatchTypeParser, ByteParser {
     private static final DefaultParser SINGLETON = new DefaultParser();
     private final WildcardParser wildcardParser;
     private final EqualsIgnoreCaseParser equalsIgnoreCaseParser;
+    private final SuffixParser suffixParser;
 
     DefaultParser() {
-        this(new WildcardParser(), new EqualsIgnoreCaseParser());
+        this(new WildcardParser(), new EqualsIgnoreCaseParser(), new SuffixParser());
     }
 
-    DefaultParser(WildcardParser wildcardParser, EqualsIgnoreCaseParser equalsIgnoreCaseParser) {
+    DefaultParser(WildcardParser wildcardParser, EqualsIgnoreCaseParser equalsIgnoreCaseParser, SuffixParser suffixParser) {
         this.wildcardParser = wildcardParser;
         this.equalsIgnoreCaseParser = equalsIgnoreCaseParser;
+        this.suffixParser = suffixParser;
     }
 
     public static DefaultParser getParser() {
@@ -56,7 +60,10 @@ public class DefaultParser implements MatchTypeParser, ByteParser {
             return wildcardParser.parse(value);
         } else if (type == EQUALS_IGNORE_CASE || type == ANYTHING_BUT_IGNORE_CASE) {
             return equalsIgnoreCaseParser.parse(value);
+        } else if (type == SUFFIX || type == ANYTHING_BUT_SUFFIX) {
+            return suffixParser.parse(value);
         }
+
         final byte[] utf8bytes = value.getBytes(StandardCharsets.UTF_8);
         final InputCharacter[] result = new InputCharacter[utf8bytes.length];
         for (int i = 0; i < utf8bytes.length; i++) {

--- a/src/main/software/amazon/event/ruler/input/SuffixParser.java
+++ b/src/main/software/amazon/event/ruler/input/SuffixParser.java
@@ -17,9 +17,6 @@ public class SuffixParser implements StringValueParser {
         final byte[] utf8bytes = new StringBuilder(value).reverse()
                 .toString().getBytes(StandardCharsets.UTF_8);
         final InputCharacter[] result = new InputCharacter[utf8bytes.length];
-//        if(utf8bytes[utf8bytes.length - 1] != 34) {
-//            throw new ParseException("Suffix matchers expect to end with '\"' character");
-//        }
         for (int i = 0; i < utf8bytes.length; i++) {
             byte utf8byte = utf8bytes[utf8bytes.length - i - 1];
             result[i] = new InputByte(utf8byte);

--- a/src/main/software/amazon/event/ruler/input/SuffixParser.java
+++ b/src/main/software/amazon/event/ruler/input/SuffixParser.java
@@ -1,0 +1,29 @@
+package software.amazon.event.ruler.input;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A parser to be used specifically for suffix rules.
+ *
+ * This undoes the `reverse()` from {@code software.amazon.event.ruler.Patterns} intentionally
+ * to ensure we can correctly reverse utf-8 characters with 2+ bytes like '大' and '雨'.
+ */
+public class SuffixParser implements StringValueParser {
+
+    SuffixParser() { }
+
+    @Override
+    public InputCharacter[] parse(String value) {
+        final byte[] utf8bytes = new StringBuilder(value).reverse()
+                .toString().getBytes(StandardCharsets.UTF_8);
+        final InputCharacter[] result = new InputCharacter[utf8bytes.length];
+//        if(utf8bytes[utf8bytes.length - 1] != 34) {
+//            throw new ParseException("Suffix matchers expect to end with '\"' character");
+//        }
+        for (int i = 0; i < utf8bytes.length; i++) {
+            byte utf8byte = utf8bytes[utf8bytes.length - i - 1];
+            result[i] = new InputByte(utf8byte);
+        }
+        return result;
+    }
+}

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -307,6 +307,25 @@ public class ACMachineTest {
     }
 
     @Test
+    public void testSuffixChineseMatch() throws Exception {
+        Machine m = new Machine();
+        String rule = "{\n" +
+                "   \"status\": {\n" +
+                "       \"weatherText\": [{\"suffix\": \"统治者\"}]\n" +
+                "    }\n" +
+                "}";
+        String eventStr ="{\n" +
+                "  \"status\": {\n" +
+                "    \"weatherText\": \"事件统治者\",\n" +
+                "    \"pm25\": 23\n" +
+                "  }\n" +
+                "}";
+        m.addRule("r1", rule);
+        List<String> matchRules = m.rulesForJSONEvent(eventStr);
+        assertEquals(1, matchRules.size());
+    }
+
+    @Test
     public void testCityLotsProblemLines() throws Exception {
 
         String eJSON = "{" +

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1562,17 +1562,17 @@ public class MachineTest {
         Machine m = new Machine();
         String rule = "{\n" +
                 "   \"status\": {\n" +
-                "       \"weatherText\": [{\"suffix\": \"雨\"}]\n" +
+                "       \"weatherText\": [{\"suffix\": \"统治者\"}]\n" +
                 "    }\n" +
                 "}";
         String eventStr ="{\n" +
                 "  \"status\": {\n" +
-                "    \"weatherText\": \"大雨\",\n" +
+                "    \"weatherText\": \"事件统治者\",\n" +
                 "    \"pm25\": 23\n" +
                 "  }\n" +
                 "}";
         m.addRule("r1", rule);
-        List<String> matchRules = m.rulesForJSONEvent(eventStr);
+        List<String> matchRules = m.rulesForEvent(eventStr);
         assertEquals(1, matchRules.size());
     }
 

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1557,6 +1557,25 @@ public class MachineTest {
         assertEquals(60, machine.approximateObjectCount());
     }
 
+    @Test
+    public void testSuffixChineseMatch() throws Exception {
+        Machine m = new Machine();
+        String rule = "{\n" +
+                "   \"status\": {\n" +
+                "       \"weatherText\": [{\"suffix\": \"雨\"}]\n" +
+                "    }\n" +
+                "}";
+        String eventStr ="{\n" +
+                "  \"status\": {\n" +
+                "    \"weatherText\": \"大雨\",\n" +
+                "    \"pm25\": 23\n" +
+                "  }\n" +
+                "}";
+        m.addRule("r1", rule);
+        List<String> matchRules = m.rulesForJSONEvent(eventStr);
+        assertEquals(1, matchRules.size());
+    }
+
     @Test(timeout = 500)
     public void testApproximateSizeDoNotTakeForeverForRulesWithNumericMatchers() throws Exception {
         Machine machine = new Machine();

--- a/src/test/software/amazon/event/ruler/input/ParserTest.java
+++ b/src/test/software/amazon/event/ruler/input/ParserTest.java
@@ -27,30 +27,44 @@ public class ParserTest {
 
     @Test
     public void testOtherMatchTypes() {
-        final boolean[] parserInvoked = { false, false };
+        final int[] parserInvokedCount = { 0, 0, 0 };
         DefaultParser parser = new DefaultParser(
             new WildcardParser() {
                @Override
                public InputCharacter[] parse(String value) {
-                   parserInvoked[0] = true;
+                   parserInvokedCount[0] +=1;
                    return null;
                }
             },
             new EqualsIgnoreCaseParser() {
                 @Override
                 public InputCharacter[] parse(String value) {
-                    parserInvoked[1] = true;
+                    parserInvokedCount[1] += 1;
+                    return null;
+                }
+            },
+            new SuffixParser() {
+                @Override
+                public InputCharacter[] parse(String value) {
+                    parserInvokedCount[2] += 1;
                     return null;
                 }
             }
         );
 
         assertNull(parser.parse(MatchType.WILDCARD, "abc"));
-        assertTrue(parserInvoked[0]);
-        assertFalse(parserInvoked[1]);
+        assertEquals(parserInvokedCount[0], 1);
+        assertEquals(parserInvokedCount[1], 0);
+        assertEquals(parserInvokedCount[2], 0);
 
         assertNull(parser.parse(MatchType.EQUALS_IGNORE_CASE, "abc"));
-        assertTrue(parserInvoked[0]);
-        assertTrue(parserInvoked[1]);
+        assertEquals(parserInvokedCount[0], 1);
+        assertEquals(parserInvokedCount[1], 1);
+        assertEquals(parserInvokedCount[2], 0);
+
+        assertNull(parser.parse(MatchType.SUFFIX, "abc"));
+        assertEquals(parserInvokedCount[0], 1);
+        assertEquals(parserInvokedCount[1], 1);
+        assertEquals(parserInvokedCount[2], 1);
     }
 }

--- a/src/test/software/amazon/event/ruler/input/ParserTest.java
+++ b/src/test/software/amazon/event/ruler/input/ParserTest.java
@@ -6,9 +6,7 @@ import org.junit.Test;
 import static software.amazon.event.ruler.input.DefaultParser.getParser;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class ParserTest {
 

--- a/src/test/software/amazon/event/ruler/input/SuffixParserTest.java
+++ b/src/test/software/amazon/event/ruler/input/SuffixParserTest.java
@@ -1,0 +1,40 @@
+package software.amazon.event.ruler.input;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class SuffixParserTest {
+
+    private SuffixParser parser;
+
+    @Before
+    public void setup() {
+        parser = new SuffixParser();
+    }
+
+    @Test
+    public void testParseSimpleString() {
+        assertArrayEquals(new InputCharacter[] {
+                new InputByte((byte) 34), new InputByte((byte) 97) ,
+                new InputByte((byte) 98), new InputByte((byte) 99)
+        }, parser.parse("\"abc"));
+    }
+
+    @Test
+    public void testParseReverseString() {
+        assertArrayEquals(new InputCharacter[] {
+                new InputByte((byte) 34), new InputByte((byte) 100) , new InputByte((byte) 99) ,
+                new InputByte((byte) 98), new InputByte((byte) 97)
+        }, parser.parse("\"dcba"));
+    }
+
+    @Test
+    public void testParseChineseString() {
+        assertArrayEquals(new InputCharacter[] {
+                new InputByte((byte) 34), new InputByte((byte) -88) ,
+                new InputByte((byte) -101), new InputByte((byte) -23)
+        }, parser.parse("\"雨"));
+    }
+}


### PR DESCRIPTION

### Issue #, if available: https://github.com/aws/event-ruler/issues/73

### Description of changes:

Add a new suffix parser that reverses utf-8 characters correctly.

Before we would convert `"雨` to  `[34,  -23, -101, -88]` while [`addSuffixMatch(...)`](https://github.com/aws/event-ruler/blob/main/src/main/software/amazon/event/ruler/ByteMachine.java#L571) in ByteMatchine expected the the value to be `[34, -88, -101, -23]`. 

In this change, we're changing how we build `InputCharacter[]` within the default parser by introducing SuffixParser  for the current "reverse and then match backwards" quirky behaviour within suffix and anything-bit-suffix matcher.  

I decided against switching to a wildcard based pattern like `*雨` within suffix because 
1. Patterns.suffixMatch() is a public method, so any changes can be breaking.
2. Wildcard hasn't been significantly tested in the wild yet and introduces a new layer of complexity. 
3. There's significant amount of refactoring (mostly deletion) which will lead to rebasing issues with https://github.com/aws/event-ruler/pull/75 that I don't want at introduce at the moment.

No issues detected within benchmarks.

#### Benchmark / Performance (for source code changes):

Before

```
EXACT events/sec: 201387.5
WILDCARD events/sec: 160201.5
PREFIX events/sec: 214138.7
SUFFIX events/sec: 197651.2
EQUALS_IGNORE_CASE events/sec: 175798.7
NUMERIC events/sec: 129840.3
ANYTHING-BUT events/sec: 127356.8
ANYTHING-BUT-IGNORE-CASE events/sec: 129524.6
ANYTHING-BUT-PREFIX events/sec: 135971.9
ANYTHING-BUT-SUFFIX events/sec: 136319.9
COMPLEX_ARRAYS events/sec: 4285.7
PARTIAL_COMBO events/sec: 56712.3
COMBO events/sec: 2421.7
```

After
```
EXACT events/sec: 205664.1
WILDCARD events/sec: 154062.2
PREFIX events/sec: 213281.3
SUFFIX events/sec: 209506.4
EQUALS_IGNORE_CASE events/sec: 183048.1
NUMERIC events/sec: 125852.3
ANYTHING-BUT events/sec: 127738.6
ANYTHING-BUT-IGNORE-CASE events/sec: 129367.3
ANYTHING-BUT-PREFIX events/sec: 129998.8
ANYTHING-BUT-SUFFIX events/sec: 131280.3
COMPLEX_ARRAYS events/sec: 4411.9
PARTIAL_COMBO events/sec: 44781.0
COMBO events/sec: 2360.7
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
