### PR TITLE
Exponential memory improvement by re-using NameState across multiple patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -99,7 +99,7 @@ class ACFinder {
                     candidateSubRulesForNextStep = calculateCandidateSubRulesForNextStep(null, fromStateWithPattern);
                     // If there are no more candidate sub-rules, there is no need to proceed further.
                     if (candidateSubRulesForNextStep == null || candidateSubRulesForNextStep.isEmpty()) {
-                        continue;
+                        break;
                     }
                 } else {
                     candidateSubRulesForNextStep = new HashSet<>();

--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -60,7 +60,7 @@ class ACFinder {
 
                     // we have moved to a new NameState
                     // this NameState might imply a rule match
-                    task.collectRules(step.candidateSubRules, nextNameStateWithPattern);
+                    task.collectRules(step.candidateSubRuleIds, nextNameStateWithPattern);
 
                     // set up for attempting to move on from the new state
                     moveFrom(step, nextNameStateWithPattern, nextFieldIndex, task, newMembership);
@@ -92,29 +92,29 @@ class ACFinder {
             tryMustNotExistMatch(null, fromStateWithPattern.getNameState(), task, fieldIndex, arrayMembership);
 
             while (fieldIndex < task.fieldCount) {
-                // Calculate candidate sub-rules for next step. If we have a pattern, use it to calculate candidates.
+                // Calculate candidate sub-rule IDs for next step. If we have a pattern, use it to calculate candidates.
                 // Otherwise, use empty candidate set, meaning we are on first step and everything is still a candidate.
-                Set<NameState.SubRule> candidateSubRulesForNextStep;
+                Set<Double> candidateSubRuleIdsForNextStep;
                 if (fromStateWithPattern.getPattern() != null) {
-                    candidateSubRulesForNextStep = calculateCandidateSubRulesForNextStep(null, fromStateWithPattern);
-                    // If there are no more candidate sub-rules, there is no need to proceed further.
-                    if (candidateSubRulesForNextStep == null || candidateSubRulesForNextStep.isEmpty()) {
+                    candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(null, fromStateWithPattern);
+                    // If there are no more candidate sub-rule IDs, there is no need to proceed further.
+                    if (candidateSubRuleIdsForNextStep == null || candidateSubRuleIdsForNextStep.isEmpty()) {
                         break;
                     }
                 } else {
-                    candidateSubRulesForNextStep = new HashSet<>();
+                    candidateSubRuleIdsForNextStep = new HashSet<>();
                 }
 
-                task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRulesForNextStep,
+                task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
                         arrayMembership);
             }
             return;
         }
 
-        Set<NameState.SubRule> candidateSubRulesForNextStep = calculateCandidateSubRulesForNextStep(
-                step.candidateSubRules, fromStateWithPattern);
+        Set<Double> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(step.candidateSubRuleIds,
+                fromStateWithPattern);
         // If there are no more candidate sub-rules, there is no need to proceed further.
-        if (candidateSubRulesForNextStep == null || candidateSubRulesForNextStep.isEmpty()) {
+        if (candidateSubRuleIdsForNextStep == null || candidateSubRuleIdsForNextStep.isEmpty()) {
             return;
         }
 
@@ -133,60 +133,60 @@ class ACFinder {
          * the final state can still be evaluated to true if the particular event
          * does not have the key configured for [ { exists: false } ].
          */
-        tryMustNotExistMatch(new ACStep(fieldIndex, fromStateWithPattern.getNameState(), candidateSubRulesForNextStep, arrayMembership),
-                fromStateWithPattern.getNameState(), task, fieldIndex, arrayMembership);
+        tryMustNotExistMatch(new ACStep(fieldIndex, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
+                arrayMembership), fromStateWithPattern.getNameState(), task, fieldIndex, arrayMembership);
 
         // Add more steps using our new set of candidate sub-rules.
         while (fieldIndex < task.fieldCount) {
-            task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRulesForNextStep,
+            task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
                     arrayMembership);
         }
     }
 
     /**
-     * Calculate the candidate sub-rules for the next step.
+     * Calculate the candidate sub-rule IDs for the next step.
      *
-     * @param currentCandidateSubRules The candidate sub-rules for the current step. Use null to indicate that we are on
-     *                                 first step and so there are not yet any candidate sub-rules.
+     * @param currentCandidateSubRuleIds The candidate sub-rule IDs for the current step. Use null to indicate that we
+     *                                   are on first step and so there are not yet any candidate sub-rules.
      * @param fromStateWithPattern The NameStateWithPattern for the NameState we are transitioning from.
-     * @return The set of candidate sub-rules for the next step. Null means there are no candidates and thus, there is
-     *         no point to evaluating subsequent steps.
+     * @return The set of candidate sub-rule IDs for the next step. Null means there are no candidates and thus, there
+     *         is no point to evaluating subsequent steps.
      */
-    private static Set<NameState.SubRule> calculateCandidateSubRulesForNextStep(
-            final Set<NameState.SubRule> currentCandidateSubRules, final NameStateWithPattern fromStateWithPattern) {
-        // Start out with the candidate sub-rules from the current step.
-        Set<NameState.SubRule> candidateSubRulesForNextStep = new HashSet<>();
-        if (currentCandidateSubRules != null) {
-            candidateSubRulesForNextStep.addAll(currentCandidateSubRules);
+    private static Set<Double> calculateCandidateSubRuleIdsForNextStep(
+            final Set<Double> currentCandidateSubRuleIds, final NameStateWithPattern fromStateWithPattern) {
+        // Start out with the candidate sub-rule IDs from the current step.
+        Set<Double> candidateSubRuleIdsForNextStep = new HashSet<>();
+        if (currentCandidateSubRuleIds != null) {
+            candidateSubRuleIdsForNextStep.addAll(currentCandidateSubRuleIds);
         }
 
-        // These are all the sub-rules that use the matched pattern to transition to the next NameState. Note that they
-        // are not all candidates as they may have required different values for previously evaluated fields.
-        Set<NameState.SubRule> subRules = fromStateWithPattern.getNameState().getNonTerminalSubRulesForPattern(
+        // These are all the sub-rule IDs that use the matched pattern to transition to the next NameState. Note that
+        // they are not all candidates as they may have required different values for previously evaluated fields.
+        Set<Double> subRuleIds = fromStateWithPattern.getNameState().getNonTerminalSubRuleIdsForPattern(
                 fromStateWithPattern.getPattern());
 
         // If no sub-rules used the matched pattern to transition to the next NameState, then there are no matches to be
         // found by going further.
-        if (subRules == null) {
+        if (subRuleIds == null) {
             return null;
         }
 
         // If there are no candidate sub-rules, this means we are on the first NameState and must initialize the
         // candidate sub-rules to those that used the matched pattern to transition to the next NameState. If there are
         // already candidates, then retain only those that used the matched pattern to transition to the next NameState.
-        if (candidateSubRulesForNextStep.isEmpty()) {
-            candidateSubRulesForNextStep.addAll(subRules);
+        if (candidateSubRuleIdsForNextStep.isEmpty()) {
+            candidateSubRuleIdsForNextStep.addAll(subRuleIds);
         } else {
-            candidateSubRulesForNextStep.retainAll(subRules);
+            candidateSubRuleIdsForNextStep.retainAll(subRuleIds);
         }
 
-        return candidateSubRulesForNextStep;
+        return candidateSubRuleIdsForNextStep;
     }
 
     private static void addNameState(ACStep step, NameStateWithPattern nameStateWithPattern, ACTask task,
                                      int nextKeyIndex, final ArrayMembership arrayMembership) {
         // one of the matches might imply a rule match
-        task.collectRules(step == null ? new HashSet<>() : step.candidateSubRules, nameStateWithPattern);
+        task.collectRules(step == null ? new HashSet<>() : step.candidateSubRuleIds, nameStateWithPattern);
 
         moveFrom(step, nameStateWithPattern, nextKeyIndex, task, arrayMembership);
     }

--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -5,10 +5,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static software.amazon.event.ruler.SetOperations.intersection;
+
 /**
  * Matches rules to events as does Finder, but in an array-consistent fashion, thus the AC prefix on the class name.
  */
 class ACFinder {
+
+    private static final Patterns ABSENCE_PATTERN = Patterns.absencePatterns();
 
     private ACFinder() { }
 
@@ -31,7 +35,7 @@ class ACFinder {
         if (startState == null) {
             return Collections.emptyList();
         }
-        moveFrom(null, new NameStateWithPattern(startState, null), 0, task, new ArrayMembership());
+        moveFrom(null, startState, 0, task, new ArrayMembership());
 
         // each iteration removes a Step and adds zero or more new ones
         while (task.stepsRemain()) {
@@ -60,64 +64,33 @@ class ACFinder {
 
                     // we have moved to a new NameState
                     // this NameState might imply a rule match
-                    task.collectRules(step.candidateSubRuleIds, nextNameStateWithPattern);
+                    task.collectRules(step.candidateSubRuleIds, nextNameStateWithPattern.getNameState(),
+                            nextNameStateWithPattern.getPattern());
 
                     // set up for attempting to move on from the new state
-                    moveFrom(step, nextNameStateWithPattern, nextFieldIndex, task, newMembership);
+                    moveFromWithPriorCandidates(step.candidateSubRuleIds, nextNameStateWithPattern.getNameState(),
+                            nextNameStateWithPattern.getPattern(), nextFieldIndex, task, newMembership);
                 }
             }
         }
     }
 
-    private static void tryMustNotExistMatch(final ACStep step, final NameState nameState, final ACTask task,
-                                             int nextKeyIndex, final ArrayMembership arrayMembership) {
+    private static void tryMustNotExistMatch(final Set<Double> candidateSubRuleIds, final NameState nameState,
+                                             final ACTask task, int nextKeyIndex, final ArrayMembership arrayMembership) {
         if (!nameState.hasKeyTransitions()) {
             return;
         }
 
         for (NameState nextNameState : nameState.getNameTransitions(task.event, arrayMembership)) {
             if (nextNameState != null) {
-                addNameState(step, new NameStateWithPattern(nextNameState, Patterns.absencePatterns()), task,
-                        nextKeyIndex, arrayMembership);
+                addNameState(candidateSubRuleIds, nextNameState, ABSENCE_PATTERN, task, nextKeyIndex, arrayMembership);
             }
         }
     }
 
-    // Move from a state.  Give all the remaining event fields a chance to transition from it
-    private static void moveFrom(final ACStep step, final NameStateWithPattern fromStateWithPattern, int fieldIndex,
-                                 final ACTask task, final ArrayMembership arrayMembership) {
-        // There is no step for initial move. Use empty candidate sub-rule set when adding steps. Do not proceed with
-        // rest of function as it is only relevant for subsequent moves.
-        if (step == null) {
-            tryMustNotExistMatch(null, fromStateWithPattern.getNameState(), task, fieldIndex, arrayMembership);
-
-            while (fieldIndex < task.fieldCount) {
-                // Calculate candidate sub-rule IDs for next step. If we have a pattern, use it to calculate candidates.
-                // Otherwise, use empty candidate set, meaning we are on first step and everything is still a candidate.
-                Set<Double> candidateSubRuleIdsForNextStep;
-                if (fromStateWithPattern.getPattern() != null) {
-                    candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(null, fromStateWithPattern);
-                    // If there are no more candidate sub-rule IDs, there is no need to proceed further.
-                    if (candidateSubRuleIdsForNextStep == null || candidateSubRuleIdsForNextStep.isEmpty()) {
-                        break;
-                    }
-                } else {
-                    candidateSubRuleIdsForNextStep = new HashSet<>();
-                }
-
-                task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
-                        arrayMembership);
-            }
-            return;
-        }
-
-        Set<Double> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(step.candidateSubRuleIds,
-                fromStateWithPattern);
-        // If there are no more candidate sub-rules, there is no need to proceed further.
-        if (candidateSubRuleIdsForNextStep == null || candidateSubRuleIdsForNextStep.isEmpty()) {
-            return;
-        }
-
+    // Move from a state. Give all the remaining event fields a chance to transition from it.
+    private static void moveFrom(final Set<Double> candidateSubRuleIdsForNextStep, final NameState nameState,
+                                 int fieldIndex, final ACTask task, final ArrayMembership arrayMembership) {
         /*
          * The Name Matchers look for an [ { exists: false } ] match. They
          * will match if a particular key is not present
@@ -133,13 +106,23 @@ class ACFinder {
          * the final state can still be evaluated to true if the particular event
          * does not have the key configured for [ { exists: false } ].
          */
-        tryMustNotExistMatch(new ACStep(fieldIndex, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
-                arrayMembership), fromStateWithPattern.getNameState(), task, fieldIndex, arrayMembership);
+        tryMustNotExistMatch(candidateSubRuleIdsForNextStep, nameState, task, fieldIndex, arrayMembership);
 
-        // Add more steps using our new set of candidate sub-rules.
         while (fieldIndex < task.fieldCount) {
-            task.addStep(fieldIndex++, fromStateWithPattern.getNameState(), candidateSubRuleIdsForNextStep,
-                    arrayMembership);
+            task.addStep(fieldIndex++, nameState, candidateSubRuleIdsForNextStep, arrayMembership);
+        }
+    }
+
+    private static void moveFromWithPriorCandidates(final Set<Double> candidateSubRuleIds,
+                                                    final NameState fromState, final Patterns fromPattern,
+                                                    final int fieldIndex, final ACTask task,
+                                                    final ArrayMembership arrayMembership) {
+        Set<Double> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(candidateSubRuleIds,
+                fromState, fromPattern);
+
+        // If there are no more candidate sub-rules, there is no need to proceed further.
+        if (candidateSubRuleIdsForNextStep != null && !candidateSubRuleIdsForNextStep.isEmpty()) {
+            moveFrom(candidateSubRuleIdsForNextStep, fromState, fieldIndex, task, arrayMembership);
         }
     }
 
@@ -148,22 +131,17 @@ class ACFinder {
      *
      * @param currentCandidateSubRuleIds The candidate sub-rule IDs for the current step. Use null to indicate that we
      *                                   are on first step and so there are not yet any candidate sub-rules.
-     * @param fromStateWithPattern The NameStateWithPattern for the NameState we are transitioning from.
+     * @param fromState The NameState we are transitioning from.
+     * @param fromPattern The pattern we used to transition from fromState.
      * @return The set of candidate sub-rule IDs for the next step. Null means there are no candidates and thus, there
      *         is no point to evaluating subsequent steps.
      */
-    private static Set<Double> calculateCandidateSubRuleIdsForNextStep(
-            final Set<Double> currentCandidateSubRuleIds, final NameStateWithPattern fromStateWithPattern) {
-        // Start out with the candidate sub-rule IDs from the current step.
-        Set<Double> candidateSubRuleIdsForNextStep = new HashSet<>();
-        if (currentCandidateSubRuleIds != null) {
-            candidateSubRuleIdsForNextStep.addAll(currentCandidateSubRuleIds);
-        }
-
-        // These are all the sub-rule IDs that use the matched pattern to transition to the next NameState. Note that
-        // they are not all candidates as they may have required different values for previously evaluated fields.
-        Set<Double> subRuleIds = fromStateWithPattern.getNameState().getNonTerminalSubRuleIdsForPattern(
-                fromStateWithPattern.getPattern());
+    private static Set<Double> calculateCandidateSubRuleIdsForNextStep(final Set<Double> currentCandidateSubRuleIds,
+                                                                       final NameState fromState,
+                                                                       final Patterns fromPattern) {
+        // These are all the sub-rules that use the matched pattern to transition to the next NameState. Note that they
+        // are not all candidates as they may have required different values for previously evaluated fields.
+        Set<Double> subRuleIds = fromState.getNonTerminalSubRuleIdsForPattern(fromPattern);
 
         // If no sub-rules used the matched pattern to transition to the next NameState, then there are no matches to be
         // found by going further.
@@ -172,23 +150,24 @@ class ACFinder {
         }
 
         // If there are no candidate sub-rules, this means we are on the first NameState and must initialize the
-        // candidate sub-rules to those that used the matched pattern to transition to the next NameState. If there are
-        // already candidates, then retain only those that used the matched pattern to transition to the next NameState.
-        if (candidateSubRuleIdsForNextStep.isEmpty()) {
-            candidateSubRuleIdsForNextStep.addAll(subRuleIds);
-        } else {
-            candidateSubRuleIdsForNextStep.retainAll(subRuleIds);
+        // candidate sub-rules to those that used the matched pattern to transition to the next NameState.
+        if (currentCandidateSubRuleIds == null || currentCandidateSubRuleIds.isEmpty()) {
+            return subRuleIds;
         }
 
+        // There are candidate sub-rules, so retain only those that used the matched pattern to transition to the next
+        // NameState.
+        Set<Double> candidateSubRuleIdsForNextStep = new HashSet<>();
+        intersection(subRuleIds, currentCandidateSubRuleIds, candidateSubRuleIdsForNextStep);
         return candidateSubRuleIdsForNextStep;
     }
 
-    private static void addNameState(ACStep step, NameStateWithPattern nameStateWithPattern, ACTask task,
-                                     int nextKeyIndex, final ArrayMembership arrayMembership) {
+    private static void addNameState(Set<Double> candidateSubRuleIds, NameState nameState, Patterns pattern,
+                                     ACTask task, int nextKeyIndex, final ArrayMembership arrayMembership) {
         // one of the matches might imply a rule match
-        task.collectRules(step == null ? new HashSet<>() : step.candidateSubRuleIds, nameStateWithPattern);
+        task.collectRules(candidateSubRuleIds, nameState, pattern);
 
-        moveFrom(step, nameStateWithPattern, nextKeyIndex, task, arrayMembership);
+        moveFromWithPriorCandidates(candidateSubRuleIds, nameState, pattern, nextKeyIndex, task, arrayMembership);
     }
 }
 

--- a/src/main/software/amazon/event/ruler/ACStep.java
+++ b/src/main/software/amazon/event/ruler/ACStep.java
@@ -8,14 +8,14 @@ import java.util.Set;
 class ACStep {
     final int fieldIndex;
     final NameState nameState;
-    final Set<NameState.SubRule> candidateSubRules;
+    final Set<Double> candidateSubRuleIds;
     final ArrayMembership membershipSoFar;
 
-    ACStep(final int fieldIndex, final NameState nameState, final Set<NameState.SubRule> candidateSubRules,
+    ACStep(final int fieldIndex, final NameState nameState, final Set<Double> candidateSubRuleIds,
            final ArrayMembership arrayMembership) {
         this.fieldIndex = fieldIndex;
         this.nameState = nameState;
-        this.candidateSubRules = candidateSubRules;
+        this.candidateSubRuleIds = candidateSubRuleIds;
         this.membershipSoFar = arrayMembership;
     }
 }

--- a/src/main/software/amazon/event/ruler/ACStep.java
+++ b/src/main/software/amazon/event/ruler/ACStep.java
@@ -1,16 +1,21 @@
 package software.amazon.event.ruler;
 
+import java.util.Set;
+
 /**
  * Represents a suggestion of a state/token combo from which there might be a transition, in an array-consistent fashion.
  */
 class ACStep {
     final int fieldIndex;
     final NameState nameState;
+    final Set<NameState.SubRule> candidateSubRules;
     final ArrayMembership membershipSoFar;
 
-    ACStep(final int fieldIndex, final NameState nameState, final ArrayMembership arrayMembership) {
+    ACStep(final int fieldIndex, final NameState nameState, final Set<NameState.SubRule> candidateSubRules,
+           final ArrayMembership arrayMembership) {
         this.fieldIndex = fieldIndex;
         this.nameState = nameState;
+        this.candidateSubRules = candidateSubRules;
         this.membershipSoFar = arrayMembership;
     }
 }

--- a/src/main/software/amazon/event/ruler/ACTask.java
+++ b/src/main/software/amazon/event/ruler/ACTask.java
@@ -43,9 +43,9 @@ class ACTask {
     /*
      *  Add a step to the queue for later consideration
      */
-    void addStep(final int fieldIndex, final NameState nameState, final Set<NameState.SubRule> candidateSubRules,
+    void addStep(final int fieldIndex, final NameState nameState, final Set<Double> candidateSubRuleIds,
                  final ArrayMembership membershipSoFar) {
-        stepQueue.add(new ACStep(fieldIndex, nameState, candidateSubRules, membershipSoFar));
+        stepQueue.add(new ACStep(fieldIndex, nameState, candidateSubRuleIds, membershipSoFar));
     }
 
     boolean stepsRemain() {
@@ -58,7 +58,7 @@ class ACTask {
                 .collect(Collectors.toSet()));
     }
 
-    void collectRules(final Set<NameState.SubRule> candidateSubRules, final NameStateWithPattern nameStateWithPattern) {
+    void collectRules(final Set<Double> candidateSubRuleIds, final NameStateWithPattern nameStateWithPattern) {
         Set<NameState.SubRule> terminalSubRules = nameStateWithPattern.getNameState().getTerminalSubRulesForPattern(
                 nameStateWithPattern.getPattern());
         if (terminalSubRules == null) {
@@ -66,11 +66,11 @@ class ACTask {
         }
 
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
-        if (candidateSubRules.isEmpty()) {
+        if (candidateSubRuleIds.isEmpty()) {
             matchingSubRules.addAll(terminalSubRules);
         } else {
-            for (NameState.SubRule subRule : candidateSubRules) {
-                if (terminalSubRules.contains(subRule)) {
+            for (NameState.SubRule subRule : terminalSubRules) {
+                if (candidateSubRuleIds.contains(subRule.getId())) {
                     matchingSubRules.add(subRule);
                 }
             }

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -943,7 +943,7 @@ class ByteMachine {
 
                     SingleByteTransition nextByteState = eachTrans.getNextByteState();
                     if (nextByteState == null) {
-                        return null;
+                        continue;
                     }
 
                     // We are interested in the first state that hasn't simply led back to trans

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -656,8 +656,9 @@ class ByteMachine {
      * Adds one pattern to a byte machine.
      *
      * @param pattern The pattern to add.
-     * @param nameState If non-null, transition to this NameState from the ByteMatch.
-     * @return NameState transitioned to from ByteMatch. Will be equal to provided NameState if it wasn't null.
+     * @param nameState If non-null, attempt to transition to this NameState from the ByteMatch. May be ignored if the
+     *                  ByteMatch already exists with its own NameState.
+     * @return NameState transitioned to from ByteMatch. May or may not equal provided NameState if it wasn't null.
      */
     NameState addPattern(final Patterns pattern, final NameState nameState) {
         switch (pattern.type()) {

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -1936,7 +1936,7 @@ class ByteMachine {
         if (!objectSet.contains(this)) { // stops looping
             objectSet.add(this);
             startState.gatherObjects(objectSet);
-            for (NameState states : anythingButs) {
+            for (NameState states : anythingButs.keySet()) {
                 states.gatherObjects(objectSet);
             }
         }

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -648,28 +648,26 @@ class ByteMachine {
         return false;
     }
 
-    NameState addPattern(final Patterns pattern) {
-        return addPattern(pattern, null);
-    }
-
     /**
      * Adds one pattern to a byte machine.
      *
      * @param pattern The pattern to add.
      * @param nameState If non-null, transition to this NameState from the ByteMatch.
-     * @return NameState transitioned to from ByteMatch. Will be equal to provided NameState if it wasn't null.
      */
-    NameState addPattern(final Patterns pattern, final NameState nameState) {
+    void addPattern(final Patterns pattern, final NameState nameState) {
         switch (pattern.type()) {
             case NUMERIC_RANGE:
                 assert pattern instanceof Range;
-                return addRangePattern((Range) pattern, nameState);
+                addRangePattern((Range) pattern, nameState);
+                break;
             case ANYTHING_BUT:
                 assert pattern instanceof AnythingBut;
-                return addAnythingButPattern((AnythingBut) pattern, nameState);
+                addAnythingButPattern((AnythingBut) pattern, nameState);
+                break;
             case ANYTHING_BUT_IGNORE_CASE:
                 assert pattern instanceof AnythingButEqualsIgnoreCase;
-                return addAnythingButEqualsIgnoreCasePattern((AnythingButEqualsIgnoreCase) pattern, nameState);
+                addAnythingButEqualsIgnoreCasePattern((AnythingButEqualsIgnoreCase) pattern, nameState);
+                break;
 
             case ANYTHING_BUT_SUFFIX:
             case ANYTHING_BUT_PREFIX:
@@ -680,54 +678,34 @@ class ByteMachine {
             case EQUALS_IGNORE_CASE:
             case WILDCARD:
                 assert pattern instanceof ValuePatterns;
-                return addMatchPattern((ValuePatterns) pattern, nameState);
+                addMatchPattern((ValuePatterns) pattern, nameState);
+                break;
 
             case EXISTS:
-                return addExistencePattern(pattern, nameState);
+                addExistencePattern(pattern, nameState);
+                break;
             default:
                 throw new AssertionError(pattern + " is not implemented yet");
         }
     }
 
-    private NameState addExistencePattern(Patterns pattern, NameState nameState) {
-        return addMatchValue(pattern, Patterns.EXISTS_BYTE_STRING, nameState);
+    private void addExistencePattern(Patterns pattern, NameState nameState) {
+        addMatchValue(pattern, Patterns.EXISTS_BYTE_STRING, nameState);
     }
 
-    private NameState addAnythingButPattern(AnythingBut pattern, NameState nameState) {
-
-        NameState nameStateToBeReturned = nameState;
-        NameState nameStateChecker = null;
-        for(String value : pattern.getValues()) {
-            nameStateToBeReturned = addMatchValue(pattern, value, nameStateToBeReturned);
-            if (nameStateChecker == null) {
-                nameStateChecker = nameStateToBeReturned;
-            }
-            // all the values in the list must point to the same NameState because they are sharing the same pattern
-            // object.
-            assert nameStateChecker == null || nameStateChecker == nameStateToBeReturned : " nameStateChecker == nameStateToBeReturned";
+    private void addAnythingButPattern(AnythingBut pattern, NameState nameState) {
+        for (String value : pattern.getValues()) {
+            addMatchValue(pattern, value, nameState);
         }
-
-        return nameStateToBeReturned;
     }
 
-    private NameState addAnythingButEqualsIgnoreCasePattern(AnythingButEqualsIgnoreCase pattern, NameState nameState) {
-
-        NameState nameStateToBeReturned = nameState;
-        NameState nameStateChecker = null;
-        for(String value : pattern.getValues()) {
-            nameStateToBeReturned = addMatchValue(pattern, value, nameStateToBeReturned);
-            if (nameStateChecker == null) {
-                nameStateChecker = nameStateToBeReturned;
-            }
-            // all the values in the list must point to the same NameState because they are sharing the same pattern
-            // object.
-            assert nameStateChecker == null || nameStateChecker == nameStateToBeReturned : " nameStateChecker == nameStateToBeReturned";
+    private void addAnythingButEqualsIgnoreCasePattern(AnythingButEqualsIgnoreCase pattern, NameState nameState) {
+        for (String value : pattern.getValues()) {
+            addMatchValue(pattern, value, nameState);
         }
-
-        return nameStateToBeReturned;
     }
 
-    private NameState addMatchValue(Patterns pattern, String value, NameState nameStateToBeReturned) {
+    private void addMatchValue(Patterns pattern, String value, NameState nameStateToBeReturned) {
 
         final InputCharacter[] characters = getParser().parse(pattern.type(), value);
         ByteState byteState = startState;
@@ -754,7 +732,7 @@ class ByteMachine {
             byteState = stateToReuse;
         }
         // we found our way through the machine with all characters except the last having matches or shortcut.
-        return addEndOfMatch(byteState, prevByteState, characters, i, pattern, nameStateToBeReturned);
+        addEndOfMatch(byteState, prevByteState, characters, i, pattern, nameStateToBeReturned);
     }
 
     private boolean canReuseNextByteState(ByteState byteState, ByteState nextByteState, InputCharacter[] characters,
@@ -1120,12 +1098,7 @@ class ByteMachine {
     //  add a numeric range expression to the byte machine.  Note; the code assumes that the patterns
     //  are encoded as pure strings containing only decimal digits, and that the top and bottom values
     //  are equal in length.
-    private NameState addRangePattern(final Range range, final NameState nameState) {
-
-        // we prepare for one new NameSate here which will be used for range match to point to next NameSate.
-        // however, it will not be used if match is already existing. in that case, we will reuse NameSate
-        // from that match.
-        NameState nextNameState = nameState == null ? new NameState() : nameState;
+    private void addRangePattern(final Range range, final NameState nextNameState) {
 
         ByteState forkState = startState;
         int forkOffset = 0;
@@ -1162,7 +1135,7 @@ class ByteMachine {
 
         // fill in matches in the fork state
         for (byte bb : Range.digitSequence(range.bottom[forkOffset], range.top[forkOffset], false, false)) {
-            nextNameState = insertMatchForRangePattern(bb, forkState, nextNameState, range);
+            insertMatchForRangePattern(bb, forkState, nextNameState, range);
         }
 
         // process all the transitions on the bottom range bytes
@@ -1187,7 +1160,7 @@ class ByteMachine {
 
                 // now add transitions for values greater than this non-9 digit
                 for (byte bb : Range.digitSequence(b, Constants.MAX_DIGIT, false, true)) {
-                    nextNameState = insertMatchForRangePattern(bb, state, nextNameState, range);
+                    insertMatchForRangePattern(bb, state, nextNameState, range);
                 }
             }
         }
@@ -1208,14 +1181,14 @@ class ByteMachine {
 
             // now we insert matches for possible values of last digit
             if (!range.openBottom) {
-                nextNameState = insertMatchForRangePattern(lastBottom, state, nextNameState, range);
+                insertMatchForRangePattern(lastBottom, state, nextNameState, range);
             }
 
             // unless the last digit is also at the fork position, fill in the extra matches due to
             //  the strictly-less-than condition (see discussion above)
             if (forkOffset < (range.bottom.length - 1)) {
                 for (byte bb : Range.digitSequence(lastBottom, Constants.MAX_DIGIT, false, true)) {
-                    nextNameState = insertMatchForRangePattern(bb, state, nextNameState, range);
+                    insertMatchForRangePattern(bb, state, nextNameState, range);
                 }
             }
         }
@@ -1239,7 +1212,7 @@ class ByteMachine {
 
                 // now add transitions for values less than this non-0 digit
                 for (byte bb : Range.digitSequence((byte) '0', range.top[offsetT], true, false)) {
-                    nextNameState = insertMatchForRangePattern(bb, state, nextNameState, range);
+                    insertMatchForRangePattern(bb, state, nextNameState, range);
                 }
             }
         }
@@ -1258,19 +1231,17 @@ class ByteMachine {
 
             // now we insert matches for possible values of last digit
             if (!range.openTop) {
-                nextNameState = insertMatchForRangePattern(lastTop, state, nextNameState, range);
+                insertMatchForRangePattern(lastTop, state, nextNameState, range);
             }
 
             // unless the last digit is also at the fork position, fill in the extra matches due to
             //  the strictly-less-than condition (see discussion above)
             if (forkOffset < (range.top.length - 1)) {
                 for (byte bb : Range.digitSequence((byte) '0', lastTop, true, false)) {
-                    nextNameState = insertMatchForRangePattern(bb, state, nextNameState, range);
+                    insertMatchForRangePattern(bb, state, nextNameState, range);
                 }
             }
         }
-
-        return nextNameState;
     }
 
     // If we meet shortcut trans, that means Range have byte overlapped with shortcut matches,
@@ -1324,8 +1295,8 @@ class ByteMachine {
 
     //  Return the next byte state after transitioning from state using character at currentIndex. Will create it if it
     //  doesn't exist.
-    private ByteState findOrMakeNextByteState(ByteState state, ByteState prevState,
-                                              final InputCharacter[] characters, int currentIndex, Patterns pattern) {
+    private ByteState findOrMakeNextByteState(ByteState state, ByteState prevState, final InputCharacter[] characters,
+                                              int currentIndex, Patterns pattern, NameState nameState) {
         final InputCharacter character = characters[currentIndex];
         ByteTransition trans = getTransition(state, character);
         trans = extendShortcutTransition(state, trans, character, currentIndex);
@@ -1340,7 +1311,7 @@ class ByteMachine {
             //    substring satisfies wildcard. The composite will self-reference and would create unintended matches.
             nextState = new ByteState();
             nextState.setIndeterminatePrefix(state.hasIndeterminatePrefix());
-            addTransitionNextState(state, character, characters, currentIndex, prevState, pattern, nextState);
+            addTransitionNextState(state, character, characters, currentIndex, prevState, pattern, nextState, nameState);
         }
 
         return nextState;
@@ -1356,27 +1327,26 @@ class ByteMachine {
     }
 
     // add a match type pattern, i.e. anything but a numeric range, to the byte machine.
-    private NameState addMatchPattern(final ValuePatterns pattern, final NameState nameState) {
-        return addMatchValue(pattern, pattern.pattern(), nameState);
+    private void addMatchPattern(final ValuePatterns pattern, final NameState nameState) {
+        addMatchValue(pattern, pattern.pattern(), nameState);
     }
 
     // We can reach to this function when we have checked the existing characters array from left to right and found we
     // need add the match in the tail character or we find we can shortcut to tail directly without creating new byte
     // transition in the middle. If we met the shortcut transition, we need compare the input value to adjust it
     // accordingly. Please refer to detail comments in ShortcutTransition.java.
-    private NameState addEndOfMatch(ByteState state,
-                                    ByteState prevState,
-                                    final InputCharacter[] characters,
-                                    final int charIndex,
-                                    final Patterns pattern,
-                                    final NameState nameStateCandidate) {
+    private void addEndOfMatch(ByteState state,
+                               ByteState prevState,
+                               final InputCharacter[] characters,
+                               final int charIndex,
+                               final Patterns pattern,
+                               final NameState nameState) {
         final int length = characters.length;
-        NameState nameState = (nameStateCandidate == null) ? new NameState() : nameStateCandidate;
 
         if (length == 1 && isWildcard(characters[0])) {
             // Only character is '*'. Make the start state a match so empty input is matched.
             startStateMatch = new ByteMatch(pattern, nameState);
-            return nameState;
+            return;
         }
 
         ByteTransition trans = getTransition(state, characters[charIndex]);
@@ -1389,7 +1359,7 @@ class ByteMachine {
             assert match != null && SHORTCUT_MATCH_TYPES.contains(match.getPattern().type());
             // If it is the same pattern, just return.
             if (pattern.equals(match.getPattern())) {
-                return match.getNextNameState();
+                return;
             }
             // Have asserted current match pattern must be value patterns
             String valueInCurrentPos = ((ValuePatterns) match.getPattern()).pattern();
@@ -1486,46 +1456,43 @@ class ByteMachine {
         if (SHORTCUT_MATCH_TYPES.contains(pattern.type())) {
             // For exactly match, if it is last character already, we just put the real transition with match there.
             if (j == length - 1) {
-                return insertMatch(characters, j, state, nameState, pattern, prevState);
+                insertMatch(characters, j, state, nameState, pattern, prevState);
+                return;
             } else if (isEligibleForShortcut) {
                 // If current character is not last character, create the shortcut transition with the next
                 ByteMatch byteMatch = new ByteMatch(pattern, nameState);
                 addTransition(state, characters[j], new ShortcutTransition().setMatch(byteMatch));
                 addMatchReferences(byteMatch);
-                return nameState;
+                return;
             }
         }
 
         // For other match type, keep the old logic to extend all characters to byte state path and put the match in the
         // tail state.
         for (; j < (length - 1); j++) {
-            ByteState nextByteState = findOrMakeNextByteState(state, prevState, characters, j, pattern);
+            ByteState nextByteState = findOrMakeNextByteState(state, prevState, characters, j, pattern, nameState);
             prevState = state;
             state = nextByteState;
         }
 
-        return insertMatch(characters, length - 1, state, nameState, pattern, prevState);
+        insertMatch(characters, length - 1, state, nameState, pattern, prevState);
     }
 
-    private NameState insertMatchForRangePattern(byte b, ByteState state, NameState nextNameState,
-                                                 Patterns pattern) {
-        return insertMatch(new InputCharacter[] { getParser().parse(b) }, 0, state, nextNameState, pattern, null);
+    private void insertMatchForRangePattern(byte b, ByteState state, NameState nextNameState,
+                                            Patterns pattern) {
+        insertMatch(new InputCharacter[] { getParser().parse(b) }, 0, state, nextNameState, pattern, null);
     }
 
-    private NameState insertMatch(InputCharacter[] characters, int currentIndex, ByteState state,
+    private void insertMatch(InputCharacter[] characters, int currentIndex, ByteState state,
                                   NameState nextNameState, Patterns pattern, ByteState prevState) {
         InputCharacter character = characters[currentIndex];
 
         ByteMatch match = findMatch(getTransition(state, character).getMatches(), pattern);
         if (match != null) {
-            // There is a match linked to the transition that's the same type, so we just re-use its nextNameState
-            return match.getNextNameState();
+            return;
         }
 
-        // we make a new NameState and hook it up
-        NameState nameState = nextNameState == null ? new NameState() : nextNameState;
-
-        match = new ByteMatch(pattern, nameState);
+        match = new ByteMatch(pattern, nextNameState);
         addMatchReferences(match);
 
         if (isWildcard(character)) {
@@ -1555,8 +1522,6 @@ class ByteMachine {
                 addTransition(prevState, character, match);
             }
         }
-
-        return nameState;
     }
 
     /**
@@ -1771,7 +1736,7 @@ class ByteMachine {
 
     private static void addTransitionNextState(ByteState state, InputCharacter character, InputCharacter[] characters,
                                                int currentIndex, ByteState prevState, Patterns pattern,
-                                               ByteState nextState) {
+                                               ByteState nextState, NameState nameState) {
         if (isWildcard(character)) {
             addTransitionNextStateForWildcard(state, nextState);
         } else {
@@ -1779,7 +1744,7 @@ class ByteMachine {
             // the transition (turning it into a composite) before adding transitions from state and prevState.
             SingleByteTransition single = nextState;
             if (isWildcard(characters[characters.length - 1]) && currentIndex == characters.length - 2) {
-                ByteMatch match = new ByteMatch(pattern, new NameState());
+                ByteMatch match = new ByteMatch(pattern, nameState);
                 single = nextState.setMatch(match);
                 nextState.setIndeterminatePrefix(true);
             } else if (isMultiByteSet(character)) {

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -5,6 +5,10 @@ import java.util.Set;
 
 /**
  * Represents a place in a ByteMachine where we have to do something in addition to just transitioning to another step.
+ *
+ * ByteMatch will be saved in anythingBut ConcurrentSkipListSet which is threadsafe, ordering that require
+ * the element must implement comparable interface and override appropriate interface for deduplication and
+ * comparison.
  */
 final class ByteMatch extends SingleByteTransition  {
 

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -5,10 +5,6 @@ import java.util.Set;
 
 /**
  * Represents a place in a ByteMachine where we have to do something in addition to just transitioning to another step.
- *
- * ByteMatch will be saved in anythingBut ConcurrentSkipListSet which is threadsafe, ordering that require
- * the element must implement comparable interface and override appropriate interface for deduplication and
- * comparison.
  */
 final class ByteMatch extends SingleByteTransition  {
 

--- a/src/main/software/amazon/event/ruler/Finder.java
+++ b/src/main/software/amazon/event/ruler/Finder.java
@@ -93,7 +93,7 @@ class Finder {
                                 nameStateWithPattern);
                         // If there are no more candidate sub-rules, there is no need to proceed further.
                         if (candidateSubRulesForNextStep == null || candidateSubRulesForNextStep.isEmpty()) {
-                            continue;
+                            break;
                         }
                     } else {
                         candidateSubRulesForNextStep = new HashSet<>();

--- a/src/main/software/amazon/event/ruler/Finder.java
+++ b/src/main/software/amazon/event/ruler/Finder.java
@@ -27,7 +27,7 @@ import java.util.Set;
  */
 
 /**
- *  Uses a state machine created by com.amazon.fsm.ruler.Machine to process tokens
+ *  Uses a state machine created by software.amazon.event.ruler.Machine to process tokens
  *   representing key-value pairs in an event, and return any matching Rules.
  */
 @ThreadSafe

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -231,7 +231,7 @@ public class GenericMachine<T> {
      *  want to remove partial rule from rule name.
      *
      * @param name ARN of the rule
-     * @param namevals names & values which make up the rule
+     * @param namevals names and values which make up the rule
      */
     public void deletePatternRule(final T name, final Map<String, List<Patterns>> namevals) {
         if (namevals.size() > MAXIMUM_RULE_SIZE) {

--- a/src/main/software/amazon/event/ruler/NameMatcher.java
+++ b/src/main/software/amazon/event/ruler/NameMatcher.java
@@ -1,7 +1,6 @@
 package software.amazon.event.ruler;
 
 import javax.annotation.Nonnull;
-import java.util.function.Supplier;
 
 /**
  * Matches the Keys in the flattened event with the { [ "exists" : false ] } pattern.
@@ -22,11 +21,11 @@ public interface NameMatcher<R> {
     /**
      * Adds the given pattern to this name matcher and associate it with the existing or new match result.
      *
-     * @param pattern        the pattern to be added
-     * @param resultSupplier the supplier of match results
+     * @param pattern   the pattern to be added
+     * @param nameState the namestate
      * @return the match result with which the added pattern is associated
      */
-    R addPattern(@Nonnull Patterns pattern, @Nonnull Supplier<? extends R> resultSupplier);
+    R addPattern(@Nonnull Patterns pattern, @Nonnull NameState nameState);
 
     /**
      * Removes the given pattern from this name matcher.

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -1,12 +1,10 @@
 package software.amazon.event.ruler;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 import static java.util.Objects.requireNonNull;
@@ -33,26 +31,102 @@ class NameState {
     // while add/delete Rule is active in another thread, without any locks.
     private final Map<String, NameMatcher<NameState>> mustNotExistMatchers = new ConcurrentHashMap<>(1);
 
-    private final Set<RuleWithPattern> ruleWithPatterns = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    // All terminal sub-rules, keyed by pattern, that led to this NameState.
+    private final Map<Patterns, Set<SubRule>> patternToTerminalSubRules = new ConcurrentHashMap<>();
+
+    // All non-terminal sub-rules, keyed by pattern, that led to this NameState.
+    private final Map<Patterns, Set<SubRule>> patternToNonTerminalSubRules = new ConcurrentHashMap<>();
 
     ByteMachine getTransitionOn(final String token) {
         return valueTransitions.get(token);
     }
 
-    Set<Object> getRules() {
-        return ruleWithPatterns.stream().map(r -> r.rule).collect(Collectors.toSet());
+    /**
+     * Get all the terminal patterns that have led to this NameState. "Terminal" means the pattern was used by the last
+     * field of a rule to lead to this NameState, and thus, the rule's matching criteria have been fully satisfied.
+     *
+     * NOTE: This function returns the raw key set from one of NameState's internal maps. Mutating it will corrupt the
+     * state of NameState. Although standard coding practice would warrant returning a copy of the set, or wrapping it
+     * to be immutable, we instead return the raw key set as a performance optimization. This avoids creating new data
+     * structures and/or copying elements between them.
+     *
+     * @return Set of all terminal patterns.
+     */
+    Set<Patterns> getTerminalPatterns() {
+        return patternToTerminalSubRules.keySet();
     }
 
-    Set<Patterns> getPatterns() {
-        return ruleWithPatterns.stream().map(r -> r.pattern).collect(Collectors.toSet());
+    /**
+     * Get all the terminal sub-rules that used a given pattern to lead to this NameState. "Terminal" means the last
+     * field of the sub-rule led to this NameState, and thus, the sub-rule's matching criteria have been satisfied.
+     *
+     * NOTE: This function returns the raw key set from one of NameState's internal maps. Mutating it will corrupt the
+     * state of NameState. Although standard coding practice would warrant returning a copy of the set, or wrapping it
+     * to be immutable, we instead return the raw key set as a performance optimization since this is called repeatedly
+     * on the critical matching path. This avoids creating new data structures and/or copying elements between them.
+     *
+     * @param pattern The pattern that the rules must use to get to this NameState.
+     * @return The sub-rules.
+     */
+    Set<SubRule> getTerminalSubRulesForPattern(Patterns pattern) {
+        return patternToTerminalSubRules.get(pattern);
     }
 
-    // TODO: unit-test these two methods
-    boolean hasRuleWithPattern(final Object rule, final Patterns pattern) {
-        return ruleWithPatterns.contains(new RuleWithPattern(rule, pattern));
+    /**
+     * Get all the non-terminal sub-rules that used a given pattern to lead to this NameState.
+     *
+     * NOTE: This function returns the raw key set from one of NameState's internal maps. Mutating it will corrupt the
+     * state of NameState. Although standard coding practice would warrant returning a copy of the set, or wrapping it
+     * to be immutable, we instead return the raw key set as a performance optimization since this is called repeatedly
+     * on the critical matching path. This avoids creating new data structures and/or copying elements between them.
+     *
+     * @param pattern The pattern that the rules must use to get to this NameState.
+     * @return The sub-rules.
+     */
+    Set<SubRule> getNonTerminalSubRulesForPattern(Patterns pattern) {
+        return patternToNonTerminalSubRules.get(pattern);
     }
-    void deleteRuleWithPattern(final Object rule, final Patterns pattern) {
-        ruleWithPatterns.remove(new RuleWithPattern(rule, pattern));
+
+    /**
+     * Get all the sub-rule IDs that match the provided rule, pattern, and isTerminal.
+     *
+     * @param rule The rule that led to this NameState.
+     * @param pattern The pattern used by the given rule to lead to this NameState.
+     * @param isTerminal Whether or not the last field of the rule was used to lead to this NameState.
+     * @return All matching sub-rule IDs.
+     */
+    Set<Double> getSubRuleIds(final Object rule, final Patterns pattern, final boolean isTerminal) {
+        Set<Double> subRuleIds = new HashSet<>();
+        Set<SubRule> subRules = (isTerminal ? patternToTerminalSubRules : patternToNonTerminalSubRules).get(pattern);
+        if (subRules != null) {
+            for (SubRule subRule : subRules) {
+                if (subRule.rule.equals(rule)) {
+                    subRuleIds.add(subRule.id);
+                }
+            }
+        }
+        return subRuleIds;
+    }
+
+    /**
+     * Delete a sub-rule to indicate that it no longer transitions to this NameState using the provided pattern.
+     *
+     * @param rule The rule, which may have multiple sub-rules.
+     * @param subRuleId The ID of the sub-rule.
+     * @param pattern The pattern used by the sub-rule to transition to this NameState.
+     * @param isTerminal True indicates that the sub-rule is using pattern to match on the final event field.
+     */
+    void deleteSubRule(final Object rule, final double subRuleId, final Patterns pattern, final boolean isTerminal) {
+        SubRule subRule = new SubRule(rule, subRuleId);
+        Map<Patterns, Set<SubRule>> patternToSubRules =
+                isTerminal ? patternToTerminalSubRules : patternToNonTerminalSubRules;
+        Set<SubRule> subRules = patternToSubRules.get(pattern);
+        if (subRules != null) {
+            subRules.remove(subRule);
+            if (subRules.isEmpty()) {
+                patternToSubRules.remove(pattern);
+            }
+        }
     }
 
     void removeTransition(String name) {
@@ -68,11 +142,28 @@ class NameState {
     }
 
     boolean isEmpty() {
-        return valueTransitions.isEmpty() && ruleWithPatterns.isEmpty() && mustNotExistMatchers.isEmpty();
+        return  valueTransitions.isEmpty() &&
+                patternToTerminalSubRules.isEmpty() &&
+                patternToNonTerminalSubRules.isEmpty() &&
+                mustNotExistMatchers.isEmpty();
     }
 
-    void addRuleWithPattern(final Object rule, final Patterns pattern) {
-        ruleWithPatterns.add(new RuleWithPattern(rule, pattern));
+    /**
+     * Add a sub-rule to indicate that it transitions to this NameState using the provided pattern.
+     *
+     * @param rule The rule, which may have multiple sub-rules.
+     * @param subRuleId The ID of the sub-rule.
+     * @param pattern The pattern used by the sub-rule to transition to this NameState.
+     * @param isTerminal True indicates that the sub-rule is using pattern to match on the final event field.
+     */
+    void addSubRule(final Object rule, final double subRuleId, final Patterns pattern, final boolean isTerminal) {
+        SubRule subRule = new SubRule(rule, subRuleId);
+        Map<Patterns, Set<SubRule>> patternToSubRules =
+                isTerminal ? patternToTerminalSubRules : patternToNonTerminalSubRules;
+        if (!patternToSubRules.containsKey(pattern)) {
+            patternToSubRules.put(pattern, new HashSet<>());
+        }
+        patternToSubRules.get(pattern).add(subRule);
     }
 
     void addTransition(final String key, final ByteMachine to) {
@@ -182,31 +273,41 @@ class NameState {
         return "NameState{" +
                 "valueTransitions=" + valueTransitions +
                 ", mustNotExistMatchers=" + mustNotExistMatchers +
-                ", ruleWithPatterns=" + ruleWithPatterns +
+                ", patternToTerminalSubRules=" + patternToTerminalSubRules +
+                ", patternToNonTerminalSubRules=" + patternToNonTerminalSubRules +
                 '}';
     }
 
-    private static class RuleWithPattern {
+    /**
+     * Store an ID with a rule to represent a sub-rule, which differentiates between rules of the same name.
+     */
+    static class SubRule {
         private final Object rule;
-        private final Patterns pattern;
+        private final double id;
 
-        public RuleWithPattern(Object rule, Patterns pattern) {
+        SubRule(Object rule, double id) {
             this.rule = requireNonNull(rule);
-            this.pattern = requireNonNull(pattern);
+            this.id = id;
+        }
+
+        Object getRule() {
+            return rule;
         }
 
         @Override
         public boolean equals(Object o) {
-            if (o == null || !(o instanceof RuleWithPattern)) {
+            if (o == null || !(o instanceof SubRule)) {
                 return false;
             }
-            RuleWithPattern otherRuleWithPattern = (RuleWithPattern) o;
-            return rule.equals(otherRuleWithPattern.rule) && pattern.equals(otherRuleWithPattern.pattern);
+            SubRule otherSubRule = (SubRule) o;
+            return  rule.equals(otherSubRule.rule) &&
+                    id == otherSubRule.id;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(rule, pattern);
+            return Objects.hash(rule, id);
         }
     }
+
 }

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents a state in the machine.
  *
@@ -189,8 +191,8 @@ class NameState {
         private final Patterns pattern;
 
         public RuleWithPattern(Object rule, Patterns pattern) {
-            this.rule = rule;
-            this.pattern = pattern;
+            this.rule = requireNonNull(rule);
+            this.pattern = requireNonNull(pattern);
         }
 
         @Override

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -264,7 +264,14 @@ class NameState {
             for (Map.Entry<String, NameMatcher<NameState>> mustNotExistEntry : mustNotExistMatchers.entrySet()) {
                 mustNotExistEntry.getValue().getNextState().gatherObjects(objectSet);
             }
-            objectSet.addAll(rules);
+            for (Map.Entry<Patterns, Set<SubRule>> entry : patternToTerminalSubRules.entrySet()) {
+                objectSet.add(entry.getKey());
+                objectSet.addAll(entry.getValue());
+            }
+            for (Map.Entry<Patterns, Set<SubRule>> entry : patternToNonTerminalSubRules.entrySet()) {
+                objectSet.add(entry.getKey());
+                objectSet.addAll(entry.getValue());
+            }
         }
     }
 

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -3,8 +3,10 @@ package software.amazon.event.ruler;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -29,22 +31,26 @@ class NameState {
     // while add/delete Rule is active in another thread, without any locks.
     private final Map<String, NameMatcher<NameState>> mustNotExistMatchers = new ConcurrentHashMap<>(1);
 
-    private final Set<Object> rules = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<RuleWithPattern> ruleWithPatterns = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     ByteMachine getTransitionOn(final String token) {
         return valueTransitions.get(token);
     }
 
     Set<Object> getRules() {
-        return rules;
+        return ruleWithPatterns.stream().map(r -> r.rule).collect(Collectors.toSet());
+    }
+
+    Set<Patterns> getPatterns() {
+        return ruleWithPatterns.stream().map(r -> r.pattern).collect(Collectors.toSet());
     }
 
     // TODO: unit-test these two methods
-    boolean hasRule(final Object name) {
-        return rules.contains(name);
+    boolean hasRuleWithPattern(final Object rule, final Patterns pattern) {
+        return ruleWithPatterns.contains(new RuleWithPattern(rule, pattern));
     }
-    void deleteRule(final Object name) {
-        rules.remove(name);
+    void deleteRuleWithPattern(final Object rule, final Patterns pattern) {
+        ruleWithPatterns.remove(new RuleWithPattern(rule, pattern));
     }
 
     void removeTransition(String name) {
@@ -55,12 +61,16 @@ class NameState {
         mustNotExistMatchers.remove(name);
     }
 
-    boolean isEmpty() {
-        return valueTransitions.isEmpty() && rules.isEmpty() && mustNotExistMatchers.isEmpty();
+    boolean hasTransitions() {
+        return !valueTransitions.isEmpty() || !mustNotExistMatchers.isEmpty();
     }
 
-    void addRule(final Object rule) {
-        rules.add(rule);
+    boolean isEmpty() {
+        return valueTransitions.isEmpty() && ruleWithPatterns.isEmpty() && mustNotExistMatchers.isEmpty();
+    }
+
+    void addRuleWithPattern(final Object rule, final Patterns pattern) {
+        ruleWithPatterns.add(new RuleWithPattern(rule, pattern));
     }
 
     void addTransition(final String key, final ByteMachine to) {
@@ -107,7 +117,7 @@ class NameState {
         return nextNameStates;
     }
 
-   Set<NameState> getNameTransitions(final Event event, final ArrayMembership membership) {
+    Set<NameState> getNameTransitions(final Event event, final ArrayMembership membership) {
 
         final Set<NameState> nextNameStates = new HashSet<>();
 
@@ -170,7 +180,31 @@ class NameState {
         return "NameState{" +
                 "valueTransitions=" + valueTransitions +
                 ", mustNotExistMatchers=" + mustNotExistMatchers +
-                ", rules=" + rules +
+                ", ruleWithPatterns=" + ruleWithPatterns +
                 '}';
+    }
+
+    private static class RuleWithPattern {
+        private final Object rule;
+        private final Patterns pattern;
+
+        public RuleWithPattern(Object rule, Patterns pattern) {
+            this.rule = rule;
+            this.pattern = pattern;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || !(o instanceof RuleWithPattern)) {
+                return false;
+            }
+            RuleWithPattern otherRuleWithPattern = (RuleWithPattern) o;
+            return rule.equals(otherRuleWithPattern.rule) && pattern.equals(otherRuleWithPattern.pattern);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rule, pattern);
+        }
     }
 }

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -174,6 +174,27 @@ class NameState {
         ((Set) patternToSubRules.get(pattern)).add(setElement);
     }
 
+    /**
+     * Determines whether this NameState contains at least one terminal sub-rule accessible via the provided rule and
+     * pattern. Note that this method iterates through all terminal sub-rules for the provided pattern.
+     *
+     * @param rule The rule, which may have multiple sub-rules.
+     * @param pattern The pattern used by the rule to transition to this NameState.
+     * @return True indicates that this NameState contains at least one matching terminal sub-rule.
+     */
+    boolean containsTerminalSubRule(final Object rule, final Patterns pattern) {
+        Set<SubRule> subRules = patternToTerminalSubRules.get(pattern);
+        if (subRules == null) {
+            return false;
+        }
+        for (SubRule subRule : subRules) {
+            if (subRule.getRule().equals(rule)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void addTransition(final String key, final ByteMachine to) {
         valueTransitions.put(key, to);
     }

--- a/src/main/software/amazon/event/ruler/NameStateWithPattern.java
+++ b/src/main/software/amazon/event/ruler/NameStateWithPattern.java
@@ -1,0 +1,49 @@
+package software.amazon.event.ruler;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class that holds a NameState and the Pattern from the match that led to the NameState.
+ */
+public class NameStateWithPattern {
+
+    private final NameState nameState;
+    private final Patterns pattern;
+
+    /**
+     * Create a NameStateWithPattern.
+     *
+     * @param nameState The NameState - cannot be null.
+     * @param pattern The pattern - can be null if the NameState is the starting state of a Machine.
+     */
+    public NameStateWithPattern(NameState nameState, @Nullable Patterns pattern) {
+        this.nameState = requireNonNull(nameState);
+        this.pattern = pattern;
+    }
+
+    public NameState getNameState() {
+        return nameState;
+    }
+
+    public Patterns getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof NameStateWithPattern)) {
+            return false;
+        }
+        NameStateWithPattern otherNameStateWithPattern = (NameStateWithPattern) o;
+        return  nameState.equals(otherNameStateWithPattern.nameState) &&
+                pattern.equals(otherNameStateWithPattern.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nameState, pattern);
+    }
+}

--- a/src/main/software/amazon/event/ruler/SetOperations.java
+++ b/src/main/software/amazon/event/ruler/SetOperations.java
@@ -1,0 +1,44 @@
+package software.amazon.event.ruler;
+
+import java.util.Set;
+import java.util.function.Function;
+
+class SetOperations {
+
+    private SetOperations() { }
+
+    /**
+     * Add each element of the intersection of two sets to a third set. This is optimized for performance as it iterates
+     * through the smaller set.
+     *
+     * @param set1 First set involved in intersection.
+     * @param set2 Second set involved in intersection.
+     * @param addTo Add intersection to this set.
+     * @param <T> Type of all three sets.
+     */
+    public static <T> void intersection(final Set<T> set1, final Set<T> set2, final Set<T> addTo) {
+        intersection(set1, set2, addTo, t -> t);
+    }
+
+    /**
+     * Add the transformation of each element of the intersection of two sets to a third set. This is optimized for
+     * performance as it iterates through the smaller set.
+     *
+     * @param set1 First set involved in intersection.
+     * @param set2 Second set involved in intersection.
+     * @param addTo Add intersection to this set.
+     * @param transform Transform each element of intersection into an element of the third set.
+     * @param <T> Type of first two sets.
+     * @param <R> Type of addTo set.
+     */
+    public static <T, R> void intersection(final Set<T> set1, final Set<T> set2, final Set<R> addTo,
+                                           final Function<T, R> transform) {
+        Set<T> smaller = set1.size() <= set2.size() ? set1 : set2;
+        Set<T> larger = set1.size() <= set2.size() ? set2 : set1;
+        for (T element : smaller) {
+            if (larger.contains(element)) {
+                addTo.add(transform.apply(element));
+            }
+        }
+    }
+}

--- a/src/main/software/amazon/event/ruler/SingleStateNameMatcher.java
+++ b/src/main/software/amazon/event/ruler/SingleStateNameMatcher.java
@@ -1,7 +1,5 @@
 package software.amazon.event.ruler;
 
-import java.util.function.Supplier;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -23,12 +21,12 @@ public class SingleStateNameMatcher implements NameMatcher<NameState> {
     }
 
     @Override
-    public NameState addPattern(@Nonnull final Patterns pattern,
-            @Nonnull final Supplier<? extends NameState> resultSupplier) {
-        if (nameState == null) {
-            nameState = resultSupplier.get();
+    public NameState addPattern(@Nonnull final Patterns pattern, final NameState nameState) {
+        if (this.nameState == null) {
+            this.nameState = nameState;
         }
-        return nameState;
+
+        return this.nameState;
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/Step.java
+++ b/src/main/software/amazon/event/ruler/Step.java
@@ -3,6 +3,7 @@ package software.amazon.event.ruler;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Represents a suggestion of a state/token combo from which there might be a transition.  The event token
@@ -13,10 +14,12 @@ import java.util.Objects;
 class Step {
     final int keyIndex;
     final NameState nameState;
+    final Set<NameState.SubRule> candidateSubRules;
 
-    Step(final int keyIndex, final NameState nameState) {
+    Step(final int keyIndex, final NameState nameState, final Set<NameState.SubRule> candidateSubRules) {
         this.keyIndex = keyIndex;
         this.nameState = nameState;
+        this.candidateSubRules = candidateSubRules;
     }
 
     @Override
@@ -28,12 +31,13 @@ class Step {
             return false;
         }
         Step step = (Step) o;
-        return keyIndex == step.keyIndex &&
-                Objects.equals(nameState, step.nameState);
+        return  keyIndex == step.keyIndex &&
+                Objects.equals(nameState, step.nameState) &&
+                Objects.equals(candidateSubRules, step.candidateSubRules);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyIndex, nameState);
+        return Objects.hash(keyIndex, nameState, candidateSubRules);
     }
 }

--- a/src/main/software/amazon/event/ruler/Step.java
+++ b/src/main/software/amazon/event/ruler/Step.java
@@ -14,12 +14,12 @@ import java.util.Set;
 class Step {
     final int keyIndex;
     final NameState nameState;
-    final Set<NameState.SubRule> candidateSubRules;
+    final Set<Double> candidateSubRuleIds;
 
-    Step(final int keyIndex, final NameState nameState, final Set<NameState.SubRule> candidateSubRules) {
+    Step(final int keyIndex, final NameState nameState, final Set<Double> candidateSubRuleIds) {
         this.keyIndex = keyIndex;
         this.nameState = nameState;
-        this.candidateSubRules = candidateSubRules;
+        this.candidateSubRuleIds = candidateSubRuleIds;
     }
 
     @Override
@@ -33,11 +33,11 @@ class Step {
         Step step = (Step) o;
         return  keyIndex == step.keyIndex &&
                 Objects.equals(nameState, step.nameState) &&
-                Objects.equals(candidateSubRules, step.candidateSubRules);
+                Objects.equals(candidateSubRuleIds, step.candidateSubRuleIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyIndex, nameState, candidateSubRules);
+        return Objects.hash(keyIndex, nameState, candidateSubRuleIds);
     }
 }

--- a/src/main/software/amazon/event/ruler/SubRuleContext.java
+++ b/src/main/software/amazon/event/ruler/SubRuleContext.java
@@ -1,0 +1,51 @@
+package software.amazon.event.ruler;
+
+/**
+ * This class stores context regarding a sub-rule.
+ *
+ * A sub-rule refers to name/value pairs, usually represented by Map of String to List of Patterns, that compose a rule.
+ * In the case of $or, one rule will have multiple name/value pairs, and this is why we use the "sub-rule" terminology.
+ */
+public class SubRuleContext {
+
+    private final double id;
+
+    private SubRuleContext(double id) {
+        this.id = id;
+    }
+
+    public double getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof SubRuleContext)) {
+            return false;
+        }
+        SubRuleContext otherContext = (SubRuleContext) o;
+        return id == otherContext.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(id);
+    }
+
+    /**
+     * Generator for SubRuleContexts.
+     */
+    static final class Generator {
+
+        private double nextId = -Double.MAX_VALUE;
+
+        public SubRuleContext generate() {
+            assert nextId < Double.MAX_VALUE : "SubRuleContext.Generator's nextId reached Double.MAX_VALUE - " +
+                    "this required the equivalent of calling generate() at 6 billion TPS for 100 years";
+
+            SubRuleContext subRuleContext = new SubRuleContext(nextId);
+            nextId = Math.nextUp(nextId);
+            return subRuleContext;
+        }
+    }
+}

--- a/src/main/software/amazon/event/ruler/Task.java
+++ b/src/main/software/amazon/event/ruler/Task.java
@@ -81,7 +81,7 @@ class Task {
                 .collect(Collectors.toSet()));
     }
 
-    void collectRules(final Set<NameState.SubRule> candidateSubRules, final NameStateWithPattern nameStateWithPattern) {
+    void collectRules(final Set<Double> candidateSubRuleIds, final NameStateWithPattern nameStateWithPattern) {
         Set<NameState.SubRule> terminalSubRules = nameStateWithPattern.getNameState().getTerminalSubRulesForPattern(
                 nameStateWithPattern.getPattern());
         if (terminalSubRules == null) {
@@ -89,11 +89,11 @@ class Task {
         }
 
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
-        if (candidateSubRules.isEmpty()) {
+        if (candidateSubRuleIds.isEmpty()) {
             matchingSubRules.addAll(terminalSubRules);
         } else {
-            for (NameState.SubRule subRule : candidateSubRules) {
-                if (terminalSubRules.contains(subRule)) {
+            for (NameState.SubRule subRule : terminalSubRules) {
+                if (candidateSubRuleIds.contains(subRule.getId())) {
                     matchingSubRules.add(subRule);
                 }
             }

--- a/src/main/software/amazon/event/ruler/Task.java
+++ b/src/main/software/amazon/event/ruler/Task.java
@@ -8,7 +8,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import static software.amazon.event.ruler.SetOperations.intersection;
 
 /**
  * Represents the state of a rule-finding project.
@@ -19,8 +20,8 @@ class Task {
     // What we're trying to match rules to
     public final String[] event;
 
-    // the sub-rules that matched the event, if we find any
-    private final Set<NameState.SubRule> matchingSubRules = new HashSet<>();
+    // the rules that matched the event, if we find any
+    private final Set<Object> matchingRules = new HashSet<>();
 
     // Steps queued up for processing
     private final Queue<Step> stepQueue = new ArrayDeque<>();
@@ -76,27 +77,22 @@ class Task {
     }
 
     List<Object> getMatchedRules() {
-        return new ArrayList<>(matchingSubRules.stream()
-                .map(r -> r.getRule())
-                .collect(Collectors.toSet()));
+        return new ArrayList<>(matchingRules);
     }
 
-    void collectRules(final Set<Double> candidateSubRuleIds, final NameStateWithPattern nameStateWithPattern) {
-        Set<NameState.SubRule> terminalSubRules = nameStateWithPattern.getNameState().getTerminalSubRulesForPattern(
-                nameStateWithPattern.getPattern());
-        if (terminalSubRules == null) {
+    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern) {
+        Set<Double> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
+        if (terminalSubRuleIds == null) {
             return;
         }
 
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
-        if (candidateSubRuleIds.isEmpty()) {
-            matchingSubRules.addAll(terminalSubRules);
-        } else {
-            for (NameState.SubRule subRule : terminalSubRules) {
-                if (candidateSubRuleIds.contains(subRule.getId())) {
-                    matchingSubRules.add(subRule);
-                }
+        if (candidateSubRuleIds == null || candidateSubRuleIds.isEmpty()) {
+            for (Double terminalSubRuleId : terminalSubRuleIds) {
+                matchingRules.add(nameState.getRule(terminalSubRuleId));
             }
+        } else {
+            intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules, id -> nameState.getRule(id));
         }
     }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2038,4 +2038,25 @@ public class ACMachineTest {
         assertTrue(matches.contains("rule1"));
         assertTrue(matches.contains("rule3"));
     }
+
+    @Test
+    public void testInitialSharedNameStateWithTwoMustNotExistsIsTerminalForOnlyOne() throws Exception {
+        // Initial NameState has two different (bar and foo) exists=false patterns. One is terminal, whereas the other
+        // leads to another NameState with another key (zoo).
+        String rule1 = "{\"bar\": [{\"exists\": false}]}";
+        String rule2 = "{\"foo\": [{\"exists\": false}], \"zoo\": [\"a\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"a\"" +
+                "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2059,4 +2059,19 @@ public class ACMachineTest {
         assertTrue(matches.contains("rule1"));
         assertTrue(matches.contains("rule2"));
     }
+
+    @Test
+    public void testSharedNameStateForMultipleAnythingButPatterns() throws Exception {
+        // Every event will match this rule because any bar that is "a" cannot also be "b".
+        String rule1 = "{\"bar\": [{\"anything-but\": \"a\"}, {\"anything-but\": \"b\"}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+
+        String event = "{\"bar\": \"b\"}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -19,8 +18,6 @@ import java.util.concurrent.TimeUnit;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2140,60 +2137,4 @@ public class ACMachineTest {
         assertTrue(matches.contains("rule1"));
     }
 
-    @Test
-    public void testSharedNameStateOnlyOneCreated() throws Exception {
-        // Only one NameState should be created since there is only one unique key.
-        Machine machine = new Machine();
-        machine.addRule("rule1", "{\"bar\":[\"x\", \"y\"]}");
-        machine.addRule("rule2", "{\"bar\":[\"x\"]}");
-        machine.addRule("rule3", "{\"bar\":[\"y\"]}");
-
-        // Assert there is only one NameState despite what value we use to transition through ByteMachine.
-        ByteMachine barByteMachine = machine.getStartState().getTransitionOn("bar");
-        Set<NameStateWithPattern> nameStateWithPatternsX = barByteMachine.transitionOn("\"x\"");
-        assertEquals(1, nameStateWithPatternsX.size());
-        NameState nameState = nameStateWithPatternsX.iterator().next().getNameState();
-        Set<NameStateWithPattern> nameStateWithPatternsY = barByteMachine.transitionOn("\"y\"");
-        assertEquals(1, nameStateWithPatternsY.size());
-        assertSame(nameState, nameStateWithPatternsY.iterator().next().getNameState());
-        assertSame(nameState, machine.getStartState().getNextNameState("bar"));
-
-        // Add rules again in different order. No new NameStates should be created.
-        machine.addRule("rule2", "{\"bar\":[\"x\"]}");
-        machine.addRule("rule3", "{\"bar\":[\"y\"]}");
-        machine.addRule("rule1", "{\"bar\":[\"x\", \"y\"]}");
-
-        // Assert there is only one NameState despite what value we use to transition through ByteMachine.
-        barByteMachine = machine.getStartState().getTransitionOn("bar");
-        nameStateWithPatternsX = barByteMachine.transitionOn("\"x\"");
-        assertEquals(1, nameStateWithPatternsX.size());
-        assertSame(nameState, nameStateWithPatternsX.iterator().next().getNameState());
-        nameStateWithPatternsY = barByteMachine.transitionOn("\"y\"");
-        assertEquals(1, nameStateWithPatternsY.size());
-        assertSame(nameState, nameStateWithPatternsY.iterator().next().getNameState());
-        assertSame(nameState, machine.getStartState().getNextNameState("bar"));
-
-        // Assert NameState is still accessible via "x" after rule2 is deleted.
-        machine.deleteRule("rule2", "{\"bar\":[\"x\"]}");
-        barByteMachine = machine.getStartState().getTransitionOn("bar");
-        nameStateWithPatternsX = barByteMachine.transitionOn("\"x\"");
-        assertEquals(1, nameStateWithPatternsX.size());
-        assertSame(nameState, nameStateWithPatternsX.iterator().next().getNameState());
-        assertSame(nameState, machine.getStartState().getNextNameState("bar"));
-
-        // Assert NameState is still accessible via "y", but not "x", after rule1 is deleted.
-        machine.deleteRule("rule1", "{\"bar\":[\"x\", \"y\"]}");
-        barByteMachine = machine.getStartState().getTransitionOn("bar");
-        nameStateWithPatternsX = barByteMachine.transitionOn("\"x\"");
-        assertEquals(0, nameStateWithPatternsX.size());
-        nameStateWithPatternsY = barByteMachine.transitionOn("\"y\"");
-        assertEquals(1, nameStateWithPatternsY.size());
-        assertSame(nameState, nameStateWithPatternsY.iterator().next().getNameState());
-        assertSame(nameState, machine.getStartState().getNextNameState("bar"));
-
-        // Assert NameState is no longer accessible via startState after rule3 is deleted.
-        machine.deleteRule("rule3", "{\"bar\":[\"y\"]}");
-        assertNull(machine.getStartState().getTransitionOn("bar"));
-        assertNull(machine.getStartState().getNextNameState("bar"));
-    }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -30,7 +30,6 @@ public class ACMachineTest {
 
     private String toIP(int ip) {
         StringBuilder sb = new StringBuilder();
-        int octet;
         sb.append((ip >> 24) & 0xFF).append('.');
         sb.append((ip >> 16) & 0xFF).append('.');
         sb.append((ip >> 8) & 0xFF).append('.');
@@ -730,7 +729,6 @@ public class ACMachineTest {
         machine.addPatternRule(rule.name, rule.fields);
         List<String> actual = machine.rulesForJSONEvent(e.toString());
         assertEquals(1, actual.size());
-        //System.out.println("matched rule:" + actual);
 
         rule1 = new Rule("R1");
         rule1.setKeys("a", "b","gamma");
@@ -738,7 +736,6 @@ public class ACMachineTest {
         machine.addPatternRule(rule1.name, rule1.fields);
         List<String> actual1 = machine.rulesForJSONEvent(e.toString());
         assertEquals(1, actual1.size());
-        //System.out.println("matched rule:" + actual1);
 
 
         // delete R1 subset with rule.fields
@@ -746,7 +743,6 @@ public class ACMachineTest {
 
         List<String> actual2 = machine.rulesForJSONEvent(e.toString());
         assertEquals(1, actual2.size());
-        //System.out.println("matched rule:" + actual2);
 
         // delete R1 subset with rule1 fields, after this step,
         // the machine will become empty as if no rule was added before.
@@ -754,8 +750,6 @@ public class ACMachineTest {
 
         List<String> actual3 = machine.rulesForJSONEvent(e.toString());
         assertEquals(0, actual3.size());
-        //System.out.println("matched rule:" + actual3);
-
     }
 
     /**
@@ -1572,5 +1566,476 @@ public class ACMachineTest {
         List<String> matchedRules = cut.rulesForJSONEvent(event2);
         assertEquals(1, matchedRules.size());
         assertEquals("r2", matchedRules.get(0));
+    }
+
+    @Test
+    public void testExists() throws Exception {
+        String rule1 = "{\"abc\": [{\"exists\": false}]}";
+        String rule2 = "{\"abc\": [{\"exists\": true}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event1 = "{\"abc\": \"xyz\"}";
+        String event2 = "{\"xyz\": \"abc\"}";
+
+        List<String> matches = machine.rulesForJSONEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForJSONEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testAddAndDeleteTwoRulesSamePattern() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
+    public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternEqualsIgnoreCase() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"y\" } ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"Y\" } ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
+    public void testDuplicateKeyLastOneWins() throws Exception {
+        final Machine machine = new Machine();
+        String event1 = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+        String event2 = "{\n" +
+                "  \"x\": \"z\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ \"y\" ],\n" +
+                "  \"x\": [ \"z\" ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+
+        List<String> found = machine.rulesForJSONEvent(event1);
+        assertEquals(0, found.size());
+        found = machine.rulesForJSONEvent(event2);
+        assertEquals(1, found.size());
+        assertTrue(found.contains("rule1"));
+    }
+
+    @Test
+    public void testSharedNameState() throws Exception {
+        // "bar" will be the first key (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"x\"]}";
+        String rule3 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"y\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Ensure rule3 does not piggyback on rule1's shared NameState accessed by both "x" and "y" for "bar"
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testRuleDeletionFromSharedNameState() throws Exception {
+        // "bar" will be the first key (alphabetical) and both rules have a match on "x", leading to a shared NameState
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"foo\":[\"b\"], \"bar\":[\"x\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event1 = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+        String event2 = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"y\"" +
+                "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForJSONEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+
+        // Shared NameState will remain as it is used by rule1
+        machine.deleteRule("rule2", rule2);
+
+        matches = machine.rulesForJSONEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForJSONEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+
+        // "y" also leads to the shared NameState. The shared NameState will get extended by rule2's "foo" field. By
+        // checking that only events with a "bar" of "y" and not a "bar" of "x", we verify that no remnants of the
+        // original rule2 were left in the shared NameState.
+        String rule2b = "{\"foo\":[\"a\"], \"bar\":[\"y\"]}";
+
+        machine.addRule("rule2", rule2b);
+
+        matches = machine.rulesForJSONEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForJSONEvent(event2);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testPrefixRuleDeletionFromSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"zoo\":[\"1\"], \"foo\":[\"a\"], \"bar\":[\"x\"]}";
+        String rule2 = "{\"foo\":[\"a\"], \"bar\":[\"x\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+
+        // Delete rule2, which is a subpath/prefix of rule1, and ensure full path still exists for rule1 to match
+        machine.deleteRule("rule2", rule2);
+
+        matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testDifferentValuesFromOrRuleBothGoThroughSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"zoo\":[\"1\"], \"bar\":[\"x\"]}";
+        String rule2b = "{\"foo\":[\"a\"], \"bar\":[\"y\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule2", rule2b);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testDifferentValuesFromExplicitOrRuleBothGoThroughSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"$or\":[{\"zoo\":[\"1\"], \"bar\":[\"x\"]}, {\"foo\":[\"a\"], \"bar\":[\"y\"]}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRule() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRule() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRuleWithPrecedingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"1\"," +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRuleWithPrecedingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"1\"," +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRuleWithFollowingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRuleWithFollowingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsFalseAsFinalKeyAfterSharedNameState() throws Exception {
+        // Second rule added uses same NameState for bar, but then has a final key, foo, that must not exist.
+        String rule1 = "{\"bar\": [\"a\", \"b\"]}";
+        String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": false}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsTrueAsFinalKeyAfterSharedNameState() throws Exception {
+        // Second rule added uses same NameState for bar, but then has a final key, foo, that must exist.
+        String rule1 = "{\"bar\": [\"a\", \"b\"]}";
+        String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": true}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"a\"," +
+                "\"foo\": \"1\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsFalseNameStateSharedWithSpecificValueMatch() throws Exception {
+        // First rule adds a NameState for exists=false. Second rule will use this same NameState and add a value of "1"
+        // to it. Third rule will now use this same shared NameState as well due to its value of "1".
+        String rule1 = "{\"foo\": [\"a\"], \"bar\": [{\"exists\": false}]}";
+        String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": false}, \"1\"]}";
+        String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsTrueNameStateSharedWithSpecificValueMatch() throws Exception {
+        // First rule adds a NameState for exists=true. Second rule will use this same NameState and add a value of "1"
+        // to it. Third rule will now use this same shared NameState as well due to its value of "1".
+        String rule1 = "{\"foo\": [\"a\"], \"bar\": [{\"exists\": true}]}";
+        String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": true}, \"1\"]}";
+        String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"1\"" +
+                "}";
+
+        // Only rule1 and rule3 should match
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule3"));
     }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2137,4 +2137,23 @@ public class ACMachineTest {
         assertTrue(matches.contains("rule1"));
     }
 
+    @Test
+    public void testInitialSharedNameStateAlreadyExistsWithNonLeadingValue() throws Exception {
+        // When rule2 is added, a NameState will already exist for bar=b. Adding bar=a will lead to a new initial
+        // NameState, and then the existing NameState for bar=b will be encountered.
+        String rule1 = "{\"bar\" :[\"b\"], \"foo\": [\"c\"]}";
+        String rule2 = "{\"bar\": [\"a\", \"b\"], \"foo\": [\"c\"]}";
+
+        Machine machine = new Machine();
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{\"bar\": \"a\"," +
+                "\"foo\": \"c\"}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
 }

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import software.amazon.event.ruler.input.ParseException;
-import org.junit.Before;
 import org.junit.Test;
 
 import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
@@ -19,17 +18,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ByteMachineTest {
-
-    private NameState nameState;
-
-    @Before
-    public void setup() {
-        nameState = new NameState();
-    }
 
     @Test
     public void WHEN_ManyOverLappingStringsAreAdded_THEN_TheyAreParsedProperly() {
@@ -43,7 +36,7 @@ public class ByteMachineTest {
 
         ByteMachine cut = new ByteMachine();
         for (String pattern : patterns) {
-            cut.addPattern(Patterns.exactMatch(pattern), nameState);
+            cut.addPattern(Patterns.exactMatch(pattern));
         }
 
         for (String pattern : patterns) {
@@ -62,7 +55,7 @@ public class ByteMachineTest {
     public void WHEN_AnythingButPrefixPatternIsAdded_THEN_ItMatchesAppropriately() {
         Patterns abpp = Patterns.anythingButPrefix("foo");
         ByteMachine bm = new ByteMachine();
-        bm.addPattern(abpp, nameState);
+        bm.addPattern(abpp);
         String[] shouldMatch = {
           "f",
           "fo",
@@ -95,7 +88,7 @@ public class ByteMachineTest {
         abs.add("foo");
         AnythingBut ab = AnythingBut.anythingButMatch(abs);
 
-        bm.addPattern(abpp, nameState);
+        bm.addPattern(abpp);
         Patterns[] trickyPatterns = {
                 Patterns.prefixMatch("foo"),
                 Patterns.anythingButPrefix("f"),
@@ -118,7 +111,7 @@ public class ByteMachineTest {
     public void WHEN_NumericEQIsAdded_THEN_ItMatchesMultipleNumericForms() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.numericEquals(300.0), nameState);
+        cut.addPattern(Patterns.numericEquals(300.0));
         String[] threeHundreds = { "300", "3.0e+2", "300.0000" };
         for (String threeHundred : threeHundreds) {
             assertEquals(1, cut.transitionOn(threeHundred).size());
@@ -140,7 +133,7 @@ public class ByteMachineTest {
             int rangeIdx = 0;
             ByteMachine cut = new ByteMachine();
             for (int i = 1; i < data.length; i++) {
-                cut.addPattern(Range.lessThan(data[i]), nameState);
+                cut.addPattern(Range.lessThan(data[i]));
                 ranges[rangeIdx++] = Range.lessThan(data[i]);
             }
             // shuffle the array
@@ -157,7 +150,7 @@ public class ByteMachineTest {
         // first: less than
         for (int i = 1; i < data.length; i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.lessThan(data[i]), nameState);
+            cut.addPattern(Range.lessThan(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -174,7 +167,7 @@ public class ByteMachineTest {
         // <=
         for (int i = 1; i < data.length; i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.lessThanOrEqualTo(data[i]), nameState);
+            cut.addPattern(Range.lessThanOrEqualTo(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -191,7 +184,7 @@ public class ByteMachineTest {
         // >
         for (int i = 0; i < (data.length - 1); i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.greaterThan(data[i]), nameState);
+            cut.addPattern(Range.greaterThan(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -209,7 +202,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 1); i++) {
             ByteMachine cut = new ByteMachine();
             Range nr = Range.greaterThanOrEqualTo(data[i]);
-            cut.addPattern(nr, nameState);
+            cut.addPattern(nr);
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -228,7 +221,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], true, data[j], true);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -248,7 +241,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], true, data[j], false);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -268,7 +261,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], false, data[j], true);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -287,7 +280,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], false, data[j], false);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -308,7 +301,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 2); i++) {
             for (int j = i + 2; j < data.length; j++) {
                 Range r = Range.between(data[i], false, data[j], false);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (int k = 0; k < data.length; k++) {
                     if (data[k] >= data[i] && data[k] <= data[j]) {
                         containedCount[k]++;
@@ -348,7 +341,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 2); i++) {
             for (int j = i + 2; j < data.length; j++) {
                 Range r = Range.between(data[i], true, data[j], true);
-                cut.addPattern(r, nameState);
+                cut.addPattern(r);
                 for (int k = 0; k < data.length; k++) {
                     if (data[k] > data[i] && data[k] < data[j]) {
                         containedCount[k]++;
@@ -385,8 +378,8 @@ public class ByteMachineTest {
     @Test
     public void WHEN_AnExactMatchAndAPrefixMatchCoincide_THEN_TwoNameStateJumpsAreGenerated() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("horse"), nameState);
-        cut.addPattern(Patterns.prefixMatch("horse"), nameState);
+        cut.addPattern(Patterns.exactMatch("horse"));
+        cut.addPattern(Patterns.prefixMatch("horse"));
         assertEquals(2, cut.transitionOn("horse").size());
         assertEquals(1, cut.transitionOn("horseback").size());
     }
@@ -395,8 +388,8 @@ public class ByteMachineTest {
     public void WHEN_TheSamePatternIsAddedTwice_THEN_ItOnlyCausesOneNamestateJump() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("foo"), nameState);
-        cut.addPattern(Patterns.exactMatch("foo"), nameState);
+        cut.addPattern(Patterns.exactMatch("foo"));
+        cut.addPattern(Patterns.exactMatch("foo"));
 
         Set<NameStateWithPattern> l = cut.transitionOn("foo");
         assertEquals(1, l.size());
@@ -406,7 +399,7 @@ public class ByteMachineTest {
     public void WHEN_AnyThingButPatternsAreAdded_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.anythingButMatch("foo"), nameState);
+        cut.addPattern(Patterns.anythingButMatch("foo"));
         String[] notFoos = { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(1, cut.transitionOn(notFoo).size());
@@ -418,7 +411,7 @@ public class ByteMachineTest {
     public void WHEN_AnyThingButStringListPatternsAreAdded_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.anythingButMatch(new HashSet<>(Arrays.asList("bab","ford"))), nameState);
+        cut.addPattern(Patterns.anythingButMatch(new HashSet<>(Arrays.asList("bab","ford"))));
         String[] notFoos = { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(1, cut.transitionOn(notFoo).size());
@@ -432,9 +425,9 @@ public class ByteMachineTest {
 
         ByteMachine cut = new ByteMachine();
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(1.11, 2d))), nameState);
+                new HashSet<>(Arrays.asList(1.11, 2d))));
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(3.33, 2d))), nameState);
+                new HashSet<>(Arrays.asList(3.33, 2d))));
         String[] notFoos = { "0", "1.1", "5", "9", "112", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(2, cut.transitionOn(notFoo).size());
@@ -468,7 +461,7 @@ public class ByteMachineTest {
         assertTrue(cut.isEmpty());
 
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(3.33, 2d))), nameState);
+                new HashSet<>(Arrays.asList(3.33, 2d))));
         assertEquals(0, cut.transitionOn("2").size());
         assertEquals(0, cut.transitionOn("3.33").size());
         assertEquals(1, cut.transitionOn("2022").size());
@@ -482,26 +475,26 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Patterns p = Patterns.exactMatch("foo");
 
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Patterns.prefixMatch("foo");
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Patterns.anythingButMatch("foo");
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
 
         p = Patterns.numericEquals(3);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.lessThan(3);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.greaterThan(3);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.lessThanOrEqualTo(3);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.greaterThanOrEqualTo(3);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.between(0, false, 8, false);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
         p = Range.between(0, true, 8, true);
-        cut.addPattern(p, nameState);
+        cut.addPattern(p);
 
         String[] notFoos =    { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         int[] notFooMatches = { 1,     1,      1,    1,      1,     1,    2 };
@@ -521,8 +514,8 @@ public class ByteMachineTest {
     public void WHEN_AnythingButIsAPrefixOfAnotherPattern_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("football"), nameState);
-        cut.addPattern(Patterns.anythingButMatch("foo"), nameState);
+        cut.addPattern(Patterns.exactMatch("football"));
+        cut.addPattern(Patterns.anythingButMatch("foo"));
 
         assertEquals(2, cut.transitionOn("football").size());
         assertEquals(0, cut.transitionOn("foo").size());
@@ -531,7 +524,7 @@ public class ByteMachineTest {
     @Test
     public void WHEN_NumericEQIsRequested_THEN_DifferentNumberSyntaxesMatch() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.numericEquals(300.0), nameState);
+        cut.addPattern(Patterns.numericEquals(300.0));
         assertEquals(1, cut.transitionOn("300").size());
         assertEquals(1, cut.transitionOn("300.0000").size());
         assertEquals(1, cut.transitionOn("3.0e+2").size());
@@ -543,9 +536,10 @@ public class ByteMachineTest {
                 1234, 5678.1234, 7890
         };
 
-        ByteMatch cut = new ByteMatch(Range.lessThan(data[0]), nameState);
-        ByteMatch cc = new ByteMatch(Range.lessThan(data[1]), nameState);
-        ByteMatch s2 = new ByteMatch(Range.lessThan(data[2]), nameState);
+        NameState ns = new NameState();
+        ByteMatch cut = new ByteMatch(Range.lessThan(data[0]), ns);
+        ByteMatch cc = new ByteMatch(Range.lessThan(data[1]), ns);
+        ByteMatch s2 = new ByteMatch(Range.lessThan(data[2]), ns);
 
         Range range1 = (Range) cut.getPattern().clone();
         Range range2 = (Range) cc.getPattern().clone();
@@ -566,8 +560,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Range r = Range.between(0, true, 4, false);
         Range r1 = Range.between(1, true, 3, false);
-        cut.addPattern(r, nameState);
-        cut.addPattern(r1, nameState);
+        cut.addPattern(r);
+        cut.addPattern(r1);
 
         String num = String.format("%f", 2.0);
         assertEquals(2, cut.transitionOn(num).size());
@@ -589,10 +583,10 @@ public class ByteMachineTest {
         Range r3 = (Range) r2.clone();
 
         assertEquals(0, cut.transitionOn(num).size());
-        cut.addPattern(r, nameState);
+        cut.addPattern(r);
         assertEquals(1, cut.transitionOn(num).size());
-        cut.addPattern(r1, nameState);
-        cut.addPattern(r2, nameState);
+        cut.addPattern(r1);
+        cut.addPattern(r2);
 
         assertNotNull("must find the range pattern", cut.findPattern(r1));
         assertEquals(cut.findPattern(r1), cut.findPattern(r3));
@@ -619,7 +613,7 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Range r = Range.between(0, true, 4, false);
         assertNull("must NOT find the range pattern", cut.findPattern(r));
-        cut.addPattern(r, nameState);
+        cut.addPattern(r);
         assertNotNull("must find the range pattern", cut.findPattern(r));
 
         for (int i = 0; i < 1000; i++) {
@@ -662,10 +656,10 @@ public class ByteMachineTest {
         }
 
         // other pattern
-        cut.addPattern(Patterns.exactMatch("test"), nameState);
-        cut.addPattern(Patterns.prefixMatch("test"), nameState);
-        cut.addPattern(Patterns.anythingButMatch("test"), nameState);
-        cut.addPattern(Patterns.numericEquals(1.11), nameState);
+        cut.addPattern(Patterns.exactMatch("test"));
+        cut.addPattern(Patterns.prefixMatch("test"));
+        cut.addPattern(Patterns.anythingButMatch("test"));
+        cut.addPattern(Patterns.numericEquals(1.11));
         assertNotNull("must find the pattern", cut.findPattern(Patterns.exactMatch("test")));
         assertNotNull("must find the pattern", cut.findPattern(Patterns.prefixMatch("test")));
         assertNotNull("must find the pattern", cut.findPattern(Patterns.anythingButMatch("test")));
@@ -688,7 +682,7 @@ public class ByteMachineTest {
     public void whenKeyExistencePatternAdded_itCouldBeFound_AndBecomesEmptyWithOneDelete() {
         ByteMachine cut = new ByteMachine();
 
-        cut.addPattern(Patterns.existencePatterns(), nameState);
+        cut.addPattern(Patterns.existencePatterns());
 
         NameState stateFound;
 
@@ -704,7 +698,7 @@ public class ByteMachineTest {
     public void testExistencePatternFindsMatch() {
         ByteMachine cut = new ByteMachine();
 
-        cut.addPattern(Patterns.existencePatterns(), nameState);
+        cut.addPattern(Patterns.existencePatterns());
 
         Set<NameStateWithPattern> matches = cut.transitionOn("someValue");
         assertEquals(1, matches.size());
@@ -728,8 +722,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         String val = "value";
 
-        cut.addPattern(Patterns.existencePatterns(), nameState);
-        cut.addPattern(Patterns.exactMatch(val), nameState);
+        cut.addPattern(Patterns.existencePatterns());
+        cut.addPattern(Patterns.exactMatch(val));
 
         Set<NameStateWithPattern> matches = cut.transitionOn("anotherValue");
         assertEquals(1, matches.size());
@@ -753,7 +747,7 @@ public class ByteMachineTest {
     public void testNonNumericValue_DoesNotMatchNumericPattern() {
         ByteMachine cut = new ByteMachine();
         String val = "0A,";
-        cut.addPattern(Range.greaterThanOrEqualTo(-1e9), nameState);
+        cut.addPattern(Range.greaterThanOrEqualTo(-1e9));
 
         Set<NameStateWithPattern> matches = cut.transitionOn(val);
         assertTrue(matches.isEmpty());
@@ -764,8 +758,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         String val = "value";
 
-        cut.addPattern(Patterns.existencePatterns(), nameState);
-        cut.addPattern(Patterns.exactMatch(val), nameState);
+        cut.addPattern(Patterns.existencePatterns());
+        cut.addPattern(Patterns.exactMatch(val));
 
         Set<NameStateWithPattern> matches = cut.transitionOn("NewValue");
         assertEquals(1, matches.size());
@@ -791,7 +785,7 @@ public class ByteMachineTest {
         String [] values = {"a", "ab", "abc", "abcd", "a", "ab", "abc", "abcd", "ac", "acb", "aabc", "abcdeffg"};
         // add them in ordering, no proxy transition is reburied.
         for (String value : values) {
-            cut.addPattern(Patterns.exactMatch(value), nameState);
+            cut.addPattern(Patterns.exactMatch(value));
         }
         for (String value :values) {
             assertEquals(value + " did not have a match", 1, cut.transitionOn(value).size());
@@ -803,7 +797,7 @@ public class ByteMachineTest {
 
         // add them in reverse ordering, there is only one proxy transition existing.
         for (int i = values.length-1; i >=0; i--) {
-            cut.addPattern(Patterns.exactMatch(values[i]), nameState);
+            cut.addPattern(Patterns.exactMatch(values[i]));
         }
         for (String value :values) {
             assertEquals(1, cut.transitionOn(value).size());
@@ -818,7 +812,7 @@ public class ByteMachineTest {
             //add them in random order, it should work
             randomizeArray(copiedValues);
             for (int i = values.length - 1; i >= 0; i--) {
-                cut.addPattern(Patterns.exactMatch(copiedValues[i]), nameState);
+                cut.addPattern(Patterns.exactMatch(copiedValues[i]));
             }
             for (String value : values) {
                 assertEquals(1, cut.transitionOn(value).size());
@@ -836,12 +830,12 @@ public class ByteMachineTest {
             randomizeArray(copiedValues);
             // add them in ordering, both exactly match and prefix match
             for (String value : copiedValues) {
-                cut.addPattern(Patterns.exactMatch(value), nameState);
+                cut.addPattern(Patterns.exactMatch(value));
             }
             randomizeArray(copiedValues);
             // add them in ordering, both exactly match and prefix match
             for (String value : copiedValues) {
-                cut.addPattern(Patterns.prefixMatch(value), nameState);
+                cut.addPattern(Patterns.prefixMatch(value));
             }
             int[] expected = {2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 3, 6};
             for (int i = 0; i < values.length; i++) {
@@ -870,7 +864,7 @@ public class ByteMachineTest {
     @Test
     public void testSuffixPattern() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.suffixMatch("java"), nameState);
+        cut.addPattern(Patterns.suffixMatch("java"));
         String[] shouldBeMatched = { "java", ".java", "abc.java", "jjjava", "123java" };
         String[] shouldNOTBeMatched = { "vav", "javaa", "xjavax", "foo", "foojaoova" };
         for (String foo : shouldBeMatched) {
@@ -1190,7 +1184,7 @@ public class ByteMachineTest {
     @Test
     public void testWildcardInvalidEscapeCharacter() {
         try {
-            new ByteMachine().addPattern(Patterns.wildcardMatch("he\\llo"), nameState);
+            new ByteMachine().addPattern(Patterns.wildcardMatch("he\\llo"));
             fail("Expected ParseException");
         } catch (ParseException e) {
             assertEquals("Invalid escape character at pos 2", e.getMessage());
@@ -1903,8 +1897,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceLeadingWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("*hello"));
+        cut.addPattern(Patterns.wildcardMatch("*hello"));
         cut.deletePattern(Patterns.wildcardMatch("*hello"));
         assertTrue(cut.isEmpty());
     }
@@ -1912,8 +1906,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceNormalPositionWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("h*llo"));
+        cut.addPattern(Patterns.wildcardMatch("h*llo"));
         cut.deletePattern(Patterns.wildcardMatch("h*llo"));
         assertTrue(cut.isEmpty());
     }
@@ -1921,8 +1915,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceSecondLastCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("hell*o"));
+        cut.addPattern(Patterns.wildcardMatch("hell*o"));
         cut.deletePattern(Patterns.wildcardMatch("hell*o"));
         assertTrue(cut.isEmpty());
     }
@@ -1930,8 +1924,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceTrailingWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("hello*"));
+        cut.addPattern(Patterns.wildcardMatch("hello*"));
         cut.deletePattern(Patterns.wildcardMatch("hello*"));
         assertTrue(cut.isEmpty());
     }
@@ -1939,8 +1933,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceMultipleWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("h*l*o"));
+        cut.addPattern(Patterns.wildcardMatch("h*l*o"));
         cut.deletePattern(Patterns.wildcardMatch("h*l*o"));
         assertTrue(cut.isEmpty());
     }
@@ -1948,8 +1942,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceLastCharAndThirdLastCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("he*l*"));
+        cut.addPattern(Patterns.wildcardMatch("he*l*"));
         cut.deletePattern(Patterns.wildcardMatch("he*l*"));
         assertTrue(cut.isEmpty());
     }
@@ -1957,8 +1951,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceSingleCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
-        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("*"));
+        cut.addPattern(Patterns.wildcardMatch("*"));
         cut.deletePattern(Patterns.wildcardMatch("*"));
         assertTrue(cut.isEmpty());
     }
@@ -1967,13 +1961,13 @@ public class ByteMachineTest {
     public void testWildcardAddTwiceDeleteOnceMixed() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 2; i ++){
-            cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("*"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
-            cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("h*llo"));
+            cut.addPattern(Patterns.wildcardMatch("*"));
+            cut.addPattern(Patterns.wildcardMatch("*hello"));
+            cut.addPattern(Patterns.wildcardMatch("hello*"));
+            cut.addPattern(Patterns.wildcardMatch("hell*o"));
+            cut.addPattern(Patterns.wildcardMatch("h*l*o"));
+            cut.addPattern(Patterns.wildcardMatch("he*l*"));
         }
         cut.deletePattern(Patterns.wildcardMatch("h*llo"));
         cut.deletePattern(Patterns.wildcardMatch("*"));
@@ -1988,7 +1982,7 @@ public class ByteMachineTest {
     @Test
     public void testWildcardMachineNotEmptyWithSingleWildcardCharacterPattern() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("*"));
         assertFalse(cut.isEmpty());
         cut.deletePattern(Patterns.wildcardMatch("*"));
         assertTrue(cut.isEmpty());
@@ -1998,7 +1992,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicated() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*2345"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("1*2345"));
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2007,7 +2001,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsFirstChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("*123"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("*123"));
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2016,7 +2010,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsSecondLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*2"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("1*2"));
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2025,7 +2019,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("1*"));
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2034,7 +2028,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsThirdLastAndLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("12*3*"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("12*3*"));
         }
         assertEquals(3, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2096,11 +2090,63 @@ public class ByteMachineTest {
     @Test
     public void testWildcardNoConsecutiveWildcardCharacters() {
         try {
-            new ByteMachine().addPattern(Patterns.wildcardMatch("h**o"), nameState);
+            new ByteMachine().addPattern(Patterns.wildcardMatch("h**o"));
             fail("Expected ParseException");
         } catch (ParseException e) {
             assertEquals("Consecutive wildcard characters at pos 1", e.getMessage());
         }
+    }
+
+    @Test
+    public void testAddMatchPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.exactMatch("a"), nameState));
+    }
+
+    @Test
+    public void testAddMatchPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.exactMatch("a")));
+    }
+
+    @Test
+    public void testAddExistencePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.existencePatterns(), nameState));
+    }
+
+    @Test
+    public void testAddExistencePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.existencePatterns()));
+    }
+
+    @Test
+    public void testAddAnythingButPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.anythingButMatch("z"), nameState));
+    }
+
+    @Test
+    public void testAddAnythingButPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.anythingButMatch("z")));
+    }
+
+    @Test
+    public void testAddRangePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Range.lessThan(5), nameState));
+    }
+
+    @Test
+    public void testAddRangePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Range.lessThan(5)));
     }
 
     private void testPatternPermutations(PatternMatch ... patternMatches) {
@@ -2161,7 +2207,7 @@ public class ByteMachineTest {
     private void testPatternPermutation(ByteMachine cut, PatternMatch[] additionPermutation,
                                         PatternMatch[] deletionPermutation, Matches matches) {
         for (PatternMatch patternMatch : additionPermutation) {
-            cut.addPattern(matches.registerPattern(patternMatch), nameState);
+            cut.addPattern(matches.registerPattern(patternMatch));
             for (Match match : matches.get()) {
                 assertEquals("Failed on " + match.value,
                         match.getNumPatternsRegistered(), cut.transitionOn(match.value).size());

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -67,7 +67,7 @@ public class ByteMachineTest {
           "foo1",
           "foossssss2sssssssssssss4ssssssssssssss5sssssssssssssss7ssssssssssssssssssssssssssssssssssssssss"
         };
-        Set<NameState> matches;
+        Set<NameStateWithPattern> matches;
         for (String s : shouldMatch) {
             matches = bm.transitionOn(s);
             assertEquals(1, matches.size());
@@ -153,7 +153,7 @@ public class ByteMachineTest {
             cut.addPattern(Range.lessThan(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
-                Set<NameState> matched = cut.transitionOn(num);
+                Set<NameStateWithPattern> matched = cut.transitionOn(num);
                 if (aData < data[i]) {
                     assertEquals(num + " should match < " + data[i], 1, matched.size());
                 } else {
@@ -161,7 +161,7 @@ public class ByteMachineTest {
                 }
             }
             cut.deletePattern(Range.lessThan(data[i]));
-            assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+            assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         }
 
         // <=
@@ -170,7 +170,7 @@ public class ByteMachineTest {
             cut.addPattern(Range.lessThanOrEqualTo(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
-                Set<NameState> matched = cut.transitionOn(num);
+                Set<NameStateWithPattern> matched = cut.transitionOn(num);
                 if (aData <= data[i]) {
                     assertEquals(num + " should match <= " + data[i], 1, matched.size());
                 } else {
@@ -178,7 +178,7 @@ public class ByteMachineTest {
                 }
             }
             cut.deletePattern(Range.lessThanOrEqualTo(data[i]));
-            assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+            assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         }
 
         // >
@@ -187,7 +187,7 @@ public class ByteMachineTest {
             cut.addPattern(Range.greaterThan(data[i]));
             for (double aData : data) {
                 String num = String.format("%f", aData);
-                Set<NameState> matched = cut.transitionOn(num);
+                Set<NameStateWithPattern> matched = cut.transitionOn(num);
                 if (aData > data[i]) {
                     assertEquals(num + " should match > " + data[i], 1, matched.size());
                 } else {
@@ -195,7 +195,7 @@ public class ByteMachineTest {
                 }
             }
             cut.deletePattern(Range.greaterThan(data[i]));
-            assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+            assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         }
 
         // >=
@@ -205,7 +205,7 @@ public class ByteMachineTest {
             cut.addPattern(nr);
             for (double aData : data) {
                 String num = String.format("%f", aData);
-                Set<NameState> matched = cut.transitionOn(num);
+                Set<NameStateWithPattern> matched = cut.transitionOn(num);
                 if (aData >= data[i]) {
                     assertEquals(num + " should match > " + data[i], 1, matched.size());
                 } else {
@@ -213,7 +213,7 @@ public class ByteMachineTest {
                 }
             }
             cut.deletePattern(Range.greaterThanOrEqualTo(data[i]));
-            assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+            assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         }
 
         // open/open range
@@ -224,7 +224,7 @@ public class ByteMachineTest {
                 cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
-                    Set<NameState> matched = cut.transitionOn(num);
+                    Set<NameStateWithPattern> matched = cut.transitionOn(num);
                     if (aData > data[i] && aData < data[j]) {
                         assertEquals(1, matched.size());
                     } else {
@@ -232,7 +232,7 @@ public class ByteMachineTest {
                     }
                 }
                 cut.deletePattern(r);
-                assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+                assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
             }
         }
 
@@ -244,7 +244,7 @@ public class ByteMachineTest {
                 cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
-                    Set<NameState> matched = cut.transitionOn(num);
+                    Set<NameStateWithPattern> matched = cut.transitionOn(num);
                     if (aData > data[i] && aData <= data[j]) {
                         assertEquals(1, matched.size());
                     } else {
@@ -252,7 +252,7 @@ public class ByteMachineTest {
                     }
                 }
                 cut.deletePattern(r);
-                assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+                assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
             }
         }
 
@@ -264,7 +264,7 @@ public class ByteMachineTest {
                 cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
-                    Set<NameState> matched = cut.transitionOn(num);
+                    Set<NameStateWithPattern> matched = cut.transitionOn(num);
                     if (aData >= data[i] && aData < data[j]) {
                         assertEquals(1, matched.size());
                     } else {
@@ -272,7 +272,7 @@ public class ByteMachineTest {
                     }
                 }
                 cut.deletePattern(r);
-                assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+                assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
             }
         }
         // closed/closed range
@@ -283,7 +283,7 @@ public class ByteMachineTest {
                 cut.addPattern(r);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
-                    Set<NameState> matched = cut.transitionOn(num);
+                    Set<NameStateWithPattern> matched = cut.transitionOn(num);
                     if (aData >= data[i] && aData <= data[j]) {
                         assertEquals(1, matched.size());
                     } else {
@@ -291,7 +291,7 @@ public class ByteMachineTest {
                     }
                 }
                 cut.deletePattern(r);
-                assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+                assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
             }
         }
 
@@ -311,7 +311,7 @@ public class ByteMachineTest {
         }
         for (int k = 0; k < data.length; k++) {
             String num = String.format("%f", data[k]);
-            Set<NameState> matched = cut.transitionOn(num);
+            Set<NameStateWithPattern> matched = cut.transitionOn(num);
             assertEquals(containedCount[k], matched.size());
         }
         // delete the range
@@ -330,7 +330,7 @@ public class ByteMachineTest {
         assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         for (int k = 0; k < data.length; k++) {
             String num = String.format("%f", data[k]);
-            Set<NameState> matched = cut.transitionOn(num);
+            Set<NameStateWithPattern> matched = cut.transitionOn(num);
             assertEquals(containedCount[k], matched.size());
             assertEquals(0, matched.size());
         }
@@ -351,7 +351,7 @@ public class ByteMachineTest {
         }
         for (int k = 0; k < data.length; k++) {
             String num = String.format("%f", data[k]);
-            Set<NameState> matched = cut.transitionOn(num);
+            Set<NameStateWithPattern> matched = cut.transitionOn(num);
             assertEquals(containedCount[k], matched.size());
         }
 
@@ -366,10 +366,10 @@ public class ByteMachineTest {
                 }
             }
         }
-        assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+        assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         for (int k = 0; k < data.length; k++) {
             String num = String.format("%f", data[k]);
-            Set<NameState> matched = cut.transitionOn(num);
+            Set<NameStateWithPattern> matched = cut.transitionOn(num);
             assertEquals(containedCount[k], matched.size());
             assertEquals(0, matched.size());
         }
@@ -391,7 +391,7 @@ public class ByteMachineTest {
         cut.addPattern(Patterns.exactMatch("foo"));
         cut.addPattern(Patterns.exactMatch("foo"));
 
-        Set<NameState> l = cut.transitionOn("foo");
+        Set<NameStateWithPattern> l = cut.transitionOn("foo");
         assertEquals(1, l.size());
     }
 
@@ -569,7 +569,7 @@ public class ByteMachineTest {
         assertEquals(1, cut.transitionOn(num).size());
         cut.deletePattern(r1);
         assertEquals(0, cut.transitionOn(num).size());
-        assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+        assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
 
     }
 
@@ -594,9 +594,9 @@ public class ByteMachineTest {
         assertEquals(1, cut.transitionOn(num).size());
         cut.deletePattern(r3);
         assertEquals(0, cut.transitionOn(num).size());
-        assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+        assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
         cut.deletePattern(r);
-        assertTrue("bytMachine must be empty after delete pattern", cut.isEmpty());
+        assertTrue("byteMachine must be empty after delete pattern", cut.isEmpty());
     }
 
     @Test
@@ -700,7 +700,7 @@ public class ByteMachineTest {
 
         cut.addPattern(Patterns.existencePatterns());
 
-        Set<NameState> matches = cut.transitionOn("someValue");
+        Set<NameStateWithPattern> matches = cut.transitionOn("someValue");
         assertEquals(1, matches.size());
 
         cut.deletePattern(Patterns.existencePatterns());
@@ -711,7 +711,7 @@ public class ByteMachineTest {
     public void testIfExistencePatternIsNotAdded_itDoesNotFindMatch() {
         ByteMachine cut = new ByteMachine();
 
-        Set<NameState> matches = cut.transitionOn("someValue");
+        Set<NameStateWithPattern> matches = cut.transitionOn("someValue");
         assertEquals(0, matches.size());
 
         assertTrue(cut.isEmpty());
@@ -725,7 +725,7 @@ public class ByteMachineTest {
         cut.addPattern(Patterns.existencePatterns());
         cut.addPattern(Patterns.exactMatch(val));
 
-        Set<NameState> matches = cut.transitionOn("anotherValue");
+        Set<NameStateWithPattern> matches = cut.transitionOn("anotherValue");
         assertEquals(1, matches.size());
 
         matches = cut.transitionOn(val);
@@ -749,7 +749,7 @@ public class ByteMachineTest {
         String val = "0A,";
         cut.addPattern(Range.greaterThanOrEqualTo(-1e9));
 
-        Set<NameState> matches = cut.transitionOn(val);
+        Set<NameStateWithPattern> matches = cut.transitionOn(val);
         assertTrue(matches.isEmpty());
     }
 
@@ -761,7 +761,7 @@ public class ByteMachineTest {
         cut.addPattern(Patterns.existencePatterns());
         cut.addPattern(Patterns.exactMatch(val));
 
-        Set<NameState> matches = cut.transitionOn("NewValue");
+        Set<NameStateWithPattern> matches = cut.transitionOn("NewValue");
         assertEquals(1, matches.size());
 
         matches = cut.transitionOn(val);
@@ -2134,19 +2134,6 @@ public class ByteMachineTest {
     public void testAddAnythingButPatternNoNameStateGiven() {
         ByteMachine cut = new ByteMachine();
         assertNotNull(cut.addPattern(Patterns.anythingButMatch("z")));
-    }
-
-    @Test
-    public void testAddAnythingButEqualsIgnoreCasePatternGivenNameStateReturned() {
-        NameState nameState = new NameState();
-        ByteMachine cut = new ByteMachine();
-        assertSame(nameState, cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z"), nameState));
-    }
-
-    @Test
-    public void testAddAnythingButEqualsIgnoreCasePatternNoNameStateGiven() {
-        ByteMachine cut = new ByteMachine();
-        assertNotNull(cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z")));
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2094,6 +2095,71 @@ public class ByteMachineTest {
         } catch (ParseException e) {
             assertEquals("Consecutive wildcard characters at pos 1", e.getMessage());
         }
+    }
+
+    @Test
+    public void testAddMatchPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.exactMatch("a"), nameState));
+    }
+
+    @Test
+    public void testAddMatchPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.exactMatch("a")));
+    }
+
+    @Test
+    public void testAddExistencePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.existencePatterns(), nameState));
+    }
+
+    @Test
+    public void testAddExistencePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.existencePatterns()));
+    }
+
+    @Test
+    public void testAddAnythingButPatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.anythingButMatch("z"), nameState));
+    }
+
+    @Test
+    public void testAddAnythingButPatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.anythingButMatch("z")));
+    }
+
+    @Test
+    public void testAddAnythingButEqualsIgnoreCasePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z"), nameState));
+    }
+
+    @Test
+    public void testAddAnythingButEqualsIgnoreCasePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Patterns.anythingButIgnoreCaseMatch("z")));
+    }
+
+    @Test
+    public void testAddRangePatternGivenNameStateReturned() {
+        NameState nameState = new NameState();
+        ByteMachine cut = new ByteMachine();
+        assertSame(nameState, cut.addPattern(Range.lessThan(5), nameState));
+    }
+
+    @Test
+    public void testAddRangePatternNoNameStateGiven() {
+        ByteMachine cut = new ByteMachine();
+        assertNotNull(cut.addPattern(Range.lessThan(5)));
     }
 
     private void testPatternPermutations(PatternMatch ... patternMatches) {

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import software.amazon.event.ruler.input.ParseException;
+import org.junit.Before;
 import org.junit.Test;
 
 import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
@@ -18,11 +19,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ByteMachineTest {
+
+    private NameState nameState;
+
+    @Before
+    public void setup() {
+        nameState = new NameState();
+    }
 
     @Test
     public void WHEN_ManyOverLappingStringsAreAdded_THEN_TheyAreParsedProperly() {
@@ -36,7 +43,7 @@ public class ByteMachineTest {
 
         ByteMachine cut = new ByteMachine();
         for (String pattern : patterns) {
-            cut.addPattern(Patterns.exactMatch(pattern));
+            cut.addPattern(Patterns.exactMatch(pattern), nameState);
         }
 
         for (String pattern : patterns) {
@@ -55,7 +62,7 @@ public class ByteMachineTest {
     public void WHEN_AnythingButPrefixPatternIsAdded_THEN_ItMatchesAppropriately() {
         Patterns abpp = Patterns.anythingButPrefix("foo");
         ByteMachine bm = new ByteMachine();
-        bm.addPattern(abpp);
+        bm.addPattern(abpp, nameState);
         String[] shouldMatch = {
           "f",
           "fo",
@@ -88,7 +95,7 @@ public class ByteMachineTest {
         abs.add("foo");
         AnythingBut ab = AnythingBut.anythingButMatch(abs);
 
-        bm.addPattern(abpp);
+        bm.addPattern(abpp, nameState);
         Patterns[] trickyPatterns = {
                 Patterns.prefixMatch("foo"),
                 Patterns.anythingButPrefix("f"),
@@ -111,7 +118,7 @@ public class ByteMachineTest {
     public void WHEN_NumericEQIsAdded_THEN_ItMatchesMultipleNumericForms() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.numericEquals(300.0));
+        cut.addPattern(Patterns.numericEquals(300.0), nameState);
         String[] threeHundreds = { "300", "3.0e+2", "300.0000" };
         for (String threeHundred : threeHundreds) {
             assertEquals(1, cut.transitionOn(threeHundred).size());
@@ -133,7 +140,7 @@ public class ByteMachineTest {
             int rangeIdx = 0;
             ByteMachine cut = new ByteMachine();
             for (int i = 1; i < data.length; i++) {
-                cut.addPattern(Range.lessThan(data[i]));
+                cut.addPattern(Range.lessThan(data[i]), nameState);
                 ranges[rangeIdx++] = Range.lessThan(data[i]);
             }
             // shuffle the array
@@ -150,7 +157,7 @@ public class ByteMachineTest {
         // first: less than
         for (int i = 1; i < data.length; i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.lessThan(data[i]));
+            cut.addPattern(Range.lessThan(data[i]), nameState);
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -167,7 +174,7 @@ public class ByteMachineTest {
         // <=
         for (int i = 1; i < data.length; i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.lessThanOrEqualTo(data[i]));
+            cut.addPattern(Range.lessThanOrEqualTo(data[i]), nameState);
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -184,7 +191,7 @@ public class ByteMachineTest {
         // >
         for (int i = 0; i < (data.length - 1); i++) {
             ByteMachine cut = new ByteMachine();
-            cut.addPattern(Range.greaterThan(data[i]));
+            cut.addPattern(Range.greaterThan(data[i]), nameState);
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -202,7 +209,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 1); i++) {
             ByteMachine cut = new ByteMachine();
             Range nr = Range.greaterThanOrEqualTo(data[i]);
-            cut.addPattern(nr);
+            cut.addPattern(nr, nameState);
             for (double aData : data) {
                 String num = String.format("%f", aData);
                 Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -221,7 +228,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], true, data[j], true);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -241,7 +248,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], true, data[j], false);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -261,7 +268,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], false, data[j], true);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -280,7 +287,7 @@ public class ByteMachineTest {
             for (int j = i + 2; j < data.length; j++) {
                 ByteMachine cut = new ByteMachine();
                 Range r = Range.between(data[i], false, data[j], false);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (double aData : data) {
                     String num = String.format("%f", aData);
                     Set<NameStateWithPattern> matched = cut.transitionOn(num);
@@ -301,7 +308,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 2); i++) {
             for (int j = i + 2; j < data.length; j++) {
                 Range r = Range.between(data[i], false, data[j], false);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (int k = 0; k < data.length; k++) {
                     if (data[k] >= data[i] && data[k] <= data[j]) {
                         containedCount[k]++;
@@ -341,7 +348,7 @@ public class ByteMachineTest {
         for (int i = 0; i < (data.length - 2); i++) {
             for (int j = i + 2; j < data.length; j++) {
                 Range r = Range.between(data[i], true, data[j], true);
-                cut.addPattern(r);
+                cut.addPattern(r, nameState);
                 for (int k = 0; k < data.length; k++) {
                     if (data[k] > data[i] && data[k] < data[j]) {
                         containedCount[k]++;
@@ -378,8 +385,8 @@ public class ByteMachineTest {
     @Test
     public void WHEN_AnExactMatchAndAPrefixMatchCoincide_THEN_TwoNameStateJumpsAreGenerated() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("horse"));
-        cut.addPattern(Patterns.prefixMatch("horse"));
+        cut.addPattern(Patterns.exactMatch("horse"), nameState);
+        cut.addPattern(Patterns.prefixMatch("horse"), nameState);
         assertEquals(2, cut.transitionOn("horse").size());
         assertEquals(1, cut.transitionOn("horseback").size());
     }
@@ -388,8 +395,8 @@ public class ByteMachineTest {
     public void WHEN_TheSamePatternIsAddedTwice_THEN_ItOnlyCausesOneNamestateJump() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("foo"));
-        cut.addPattern(Patterns.exactMatch("foo"));
+        cut.addPattern(Patterns.exactMatch("foo"), nameState);
+        cut.addPattern(Patterns.exactMatch("foo"), nameState);
 
         Set<NameStateWithPattern> l = cut.transitionOn("foo");
         assertEquals(1, l.size());
@@ -399,7 +406,7 @@ public class ByteMachineTest {
     public void WHEN_AnyThingButPatternsAreAdded_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.anythingButMatch("foo"));
+        cut.addPattern(Patterns.anythingButMatch("foo"), nameState);
         String[] notFoos = { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(1, cut.transitionOn(notFoo).size());
@@ -411,7 +418,7 @@ public class ByteMachineTest {
     public void WHEN_AnyThingButStringListPatternsAreAdded_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.anythingButMatch(new HashSet<>(Arrays.asList("bab","ford"))));
+        cut.addPattern(Patterns.anythingButMatch(new HashSet<>(Arrays.asList("bab","ford"))), nameState);
         String[] notFoos = { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(1, cut.transitionOn(notFoo).size());
@@ -425,9 +432,9 @@ public class ByteMachineTest {
 
         ByteMachine cut = new ByteMachine();
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(1.11, 2d))));
+                new HashSet<>(Arrays.asList(1.11, 2d))), nameState);
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(3.33, 2d))));
+                new HashSet<>(Arrays.asList(3.33, 2d))), nameState);
         String[] notFoos = { "0", "1.1", "5", "9", "112", "fo", "foobar" };
         for (String notFoo : notFoos) {
             assertEquals(2, cut.transitionOn(notFoo).size());
@@ -461,7 +468,7 @@ public class ByteMachineTest {
         assertTrue(cut.isEmpty());
 
         cut.addPattern(Patterns.anythingButNumberMatch(
-                new HashSet<>(Arrays.asList(3.33, 2d))));
+                new HashSet<>(Arrays.asList(3.33, 2d))), nameState);
         assertEquals(0, cut.transitionOn("2").size());
         assertEquals(0, cut.transitionOn("3.33").size());
         assertEquals(1, cut.transitionOn("2022").size());
@@ -475,26 +482,26 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Patterns p = Patterns.exactMatch("foo");
 
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Patterns.prefixMatch("foo");
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Patterns.anythingButMatch("foo");
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
 
         p = Patterns.numericEquals(3);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.lessThan(3);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.greaterThan(3);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.lessThanOrEqualTo(3);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.greaterThanOrEqualTo(3);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.between(0, false, 8, false);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
         p = Range.between(0, true, 8, true);
-        cut.addPattern(p);
+        cut.addPattern(p, nameState);
 
         String[] notFoos =    { "bar", "baz", "for", "too", "fro", "fo", "foobar" };
         int[] notFooMatches = { 1,     1,      1,    1,      1,     1,    2 };
@@ -514,8 +521,8 @@ public class ByteMachineTest {
     public void WHEN_AnythingButIsAPrefixOfAnotherPattern_THEN_TheyWork() {
 
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.exactMatch("football"));
-        cut.addPattern(Patterns.anythingButMatch("foo"));
+        cut.addPattern(Patterns.exactMatch("football"), nameState);
+        cut.addPattern(Patterns.anythingButMatch("foo"), nameState);
 
         assertEquals(2, cut.transitionOn("football").size());
         assertEquals(0, cut.transitionOn("foo").size());
@@ -524,7 +531,7 @@ public class ByteMachineTest {
     @Test
     public void WHEN_NumericEQIsRequested_THEN_DifferentNumberSyntaxesMatch() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.numericEquals(300.0));
+        cut.addPattern(Patterns.numericEquals(300.0), nameState);
         assertEquals(1, cut.transitionOn("300").size());
         assertEquals(1, cut.transitionOn("300.0000").size());
         assertEquals(1, cut.transitionOn("3.0e+2").size());
@@ -536,10 +543,9 @@ public class ByteMachineTest {
                 1234, 5678.1234, 7890
         };
 
-        NameState ns = new NameState();
-        ByteMatch cut = new ByteMatch(Range.lessThan(data[0]), ns);
-        ByteMatch cc = new ByteMatch(Range.lessThan(data[1]), ns);
-        ByteMatch s2 = new ByteMatch(Range.lessThan(data[2]), ns);
+        ByteMatch cut = new ByteMatch(Range.lessThan(data[0]), nameState);
+        ByteMatch cc = new ByteMatch(Range.lessThan(data[1]), nameState);
+        ByteMatch s2 = new ByteMatch(Range.lessThan(data[2]), nameState);
 
         Range range1 = (Range) cut.getPattern().clone();
         Range range2 = (Range) cc.getPattern().clone();
@@ -560,8 +566,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Range r = Range.between(0, true, 4, false);
         Range r1 = Range.between(1, true, 3, false);
-        cut.addPattern(r);
-        cut.addPattern(r1);
+        cut.addPattern(r, nameState);
+        cut.addPattern(r1, nameState);
 
         String num = String.format("%f", 2.0);
         assertEquals(2, cut.transitionOn(num).size());
@@ -583,10 +589,10 @@ public class ByteMachineTest {
         Range r3 = (Range) r2.clone();
 
         assertEquals(0, cut.transitionOn(num).size());
-        cut.addPattern(r);
+        cut.addPattern(r, nameState);
         assertEquals(1, cut.transitionOn(num).size());
-        cut.addPattern(r1);
-        cut.addPattern(r2);
+        cut.addPattern(r1, nameState);
+        cut.addPattern(r2, nameState);
 
         assertNotNull("must find the range pattern", cut.findPattern(r1));
         assertEquals(cut.findPattern(r1), cut.findPattern(r3));
@@ -613,7 +619,7 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         Range r = Range.between(0, true, 4, false);
         assertNull("must NOT find the range pattern", cut.findPattern(r));
-        cut.addPattern(r);
+        cut.addPattern(r, nameState);
         assertNotNull("must find the range pattern", cut.findPattern(r));
 
         for (int i = 0; i < 1000; i++) {
@@ -656,10 +662,10 @@ public class ByteMachineTest {
         }
 
         // other pattern
-        cut.addPattern(Patterns.exactMatch("test"));
-        cut.addPattern(Patterns.prefixMatch("test"));
-        cut.addPattern(Patterns.anythingButMatch("test"));
-        cut.addPattern(Patterns.numericEquals(1.11));
+        cut.addPattern(Patterns.exactMatch("test"), nameState);
+        cut.addPattern(Patterns.prefixMatch("test"), nameState);
+        cut.addPattern(Patterns.anythingButMatch("test"), nameState);
+        cut.addPattern(Patterns.numericEquals(1.11), nameState);
         assertNotNull("must find the pattern", cut.findPattern(Patterns.exactMatch("test")));
         assertNotNull("must find the pattern", cut.findPattern(Patterns.prefixMatch("test")));
         assertNotNull("must find the pattern", cut.findPattern(Patterns.anythingButMatch("test")));
@@ -682,7 +688,7 @@ public class ByteMachineTest {
     public void whenKeyExistencePatternAdded_itCouldBeFound_AndBecomesEmptyWithOneDelete() {
         ByteMachine cut = new ByteMachine();
 
-        cut.addPattern(Patterns.existencePatterns());
+        cut.addPattern(Patterns.existencePatterns(), nameState);
 
         NameState stateFound;
 
@@ -698,7 +704,7 @@ public class ByteMachineTest {
     public void testExistencePatternFindsMatch() {
         ByteMachine cut = new ByteMachine();
 
-        cut.addPattern(Patterns.existencePatterns());
+        cut.addPattern(Patterns.existencePatterns(), nameState);
 
         Set<NameStateWithPattern> matches = cut.transitionOn("someValue");
         assertEquals(1, matches.size());
@@ -722,8 +728,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         String val = "value";
 
-        cut.addPattern(Patterns.existencePatterns());
-        cut.addPattern(Patterns.exactMatch(val));
+        cut.addPattern(Patterns.existencePatterns(), nameState);
+        cut.addPattern(Patterns.exactMatch(val), nameState);
 
         Set<NameStateWithPattern> matches = cut.transitionOn("anotherValue");
         assertEquals(1, matches.size());
@@ -747,7 +753,7 @@ public class ByteMachineTest {
     public void testNonNumericValue_DoesNotMatchNumericPattern() {
         ByteMachine cut = new ByteMachine();
         String val = "0A,";
-        cut.addPattern(Range.greaterThanOrEqualTo(-1e9));
+        cut.addPattern(Range.greaterThanOrEqualTo(-1e9), nameState);
 
         Set<NameStateWithPattern> matches = cut.transitionOn(val);
         assertTrue(matches.isEmpty());
@@ -758,8 +764,8 @@ public class ByteMachineTest {
         ByteMachine cut = new ByteMachine();
         String val = "value";
 
-        cut.addPattern(Patterns.existencePatterns());
-        cut.addPattern(Patterns.exactMatch(val));
+        cut.addPattern(Patterns.existencePatterns(), nameState);
+        cut.addPattern(Patterns.exactMatch(val), nameState);
 
         Set<NameStateWithPattern> matches = cut.transitionOn("NewValue");
         assertEquals(1, matches.size());
@@ -785,7 +791,7 @@ public class ByteMachineTest {
         String [] values = {"a", "ab", "abc", "abcd", "a", "ab", "abc", "abcd", "ac", "acb", "aabc", "abcdeffg"};
         // add them in ordering, no proxy transition is reburied.
         for (String value : values) {
-            cut.addPattern(Patterns.exactMatch(value));
+            cut.addPattern(Patterns.exactMatch(value), nameState);
         }
         for (String value :values) {
             assertEquals(value + " did not have a match", 1, cut.transitionOn(value).size());
@@ -797,7 +803,7 @@ public class ByteMachineTest {
 
         // add them in reverse ordering, there is only one proxy transition existing.
         for (int i = values.length-1; i >=0; i--) {
-            cut.addPattern(Patterns.exactMatch(values[i]));
+            cut.addPattern(Patterns.exactMatch(values[i]), nameState);
         }
         for (String value :values) {
             assertEquals(1, cut.transitionOn(value).size());
@@ -812,7 +818,7 @@ public class ByteMachineTest {
             //add them in random order, it should work
             randomizeArray(copiedValues);
             for (int i = values.length - 1; i >= 0; i--) {
-                cut.addPattern(Patterns.exactMatch(copiedValues[i]));
+                cut.addPattern(Patterns.exactMatch(copiedValues[i]), nameState);
             }
             for (String value : values) {
                 assertEquals(1, cut.transitionOn(value).size());
@@ -830,12 +836,12 @@ public class ByteMachineTest {
             randomizeArray(copiedValues);
             // add them in ordering, both exactly match and prefix match
             for (String value : copiedValues) {
-                cut.addPattern(Patterns.exactMatch(value));
+                cut.addPattern(Patterns.exactMatch(value), nameState);
             }
             randomizeArray(copiedValues);
             // add them in ordering, both exactly match and prefix match
             for (String value : copiedValues) {
-                cut.addPattern(Patterns.prefixMatch(value));
+                cut.addPattern(Patterns.prefixMatch(value), nameState);
             }
             int[] expected = {2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 3, 6};
             for (int i = 0; i < values.length; i++) {
@@ -864,7 +870,7 @@ public class ByteMachineTest {
     @Test
     public void testSuffixPattern() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.suffixMatch("java"));
+        cut.addPattern(Patterns.suffixMatch("java"), nameState);
         String[] shouldBeMatched = { "java", ".java", "abc.java", "jjjava", "123java" };
         String[] shouldNOTBeMatched = { "vav", "javaa", "xjavax", "foo", "foojaoova" };
         for (String foo : shouldBeMatched) {
@@ -1184,7 +1190,7 @@ public class ByteMachineTest {
     @Test
     public void testWildcardInvalidEscapeCharacter() {
         try {
-            new ByteMachine().addPattern(Patterns.wildcardMatch("he\\llo"));
+            new ByteMachine().addPattern(Patterns.wildcardMatch("he\\llo"), nameState);
             fail("Expected ParseException");
         } catch (ParseException e) {
             assertEquals("Invalid escape character at pos 2", e.getMessage());
@@ -1897,8 +1903,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceLeadingWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*hello"));
-        cut.addPattern(Patterns.wildcardMatch("*hello"));
+        cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("*hello"));
         assertTrue(cut.isEmpty());
     }
@@ -1906,8 +1912,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceNormalPositionWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("h*llo"));
-        cut.addPattern(Patterns.wildcardMatch("h*llo"));
+        cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("h*llo"));
         assertTrue(cut.isEmpty());
     }
@@ -1915,8 +1921,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceSecondLastCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("hell*o"));
-        cut.addPattern(Patterns.wildcardMatch("hell*o"));
+        cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("hell*o"));
         assertTrue(cut.isEmpty());
     }
@@ -1924,8 +1930,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceTrailingWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("hello*"));
-        cut.addPattern(Patterns.wildcardMatch("hello*"));
+        cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("hello*"));
         assertTrue(cut.isEmpty());
     }
@@ -1933,8 +1939,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceMultipleWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("h*l*o"));
-        cut.addPattern(Patterns.wildcardMatch("h*l*o"));
+        cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("h*l*o"));
         assertTrue(cut.isEmpty());
     }
@@ -1942,8 +1948,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceLastCharAndThirdLastCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("he*l*"));
-        cut.addPattern(Patterns.wildcardMatch("he*l*"));
+        cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("he*l*"));
         assertTrue(cut.isEmpty());
     }
@@ -1951,8 +1957,8 @@ public class ByteMachineTest {
     @Test
     public void testWildcardAddTwiceDeleteOnceSingleCharWildcard() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*"));
-        cut.addPattern(Patterns.wildcardMatch("*"));
+        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
+        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
         cut.deletePattern(Patterns.wildcardMatch("*"));
         assertTrue(cut.isEmpty());
     }
@@ -1961,13 +1967,13 @@ public class ByteMachineTest {
     public void testWildcardAddTwiceDeleteOnceMixed() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 2; i ++){
-            cut.addPattern(Patterns.wildcardMatch("h*llo"));
-            cut.addPattern(Patterns.wildcardMatch("*"));
-            cut.addPattern(Patterns.wildcardMatch("*hello"));
-            cut.addPattern(Patterns.wildcardMatch("hello*"));
-            cut.addPattern(Patterns.wildcardMatch("hell*o"));
-            cut.addPattern(Patterns.wildcardMatch("h*l*o"));
-            cut.addPattern(Patterns.wildcardMatch("he*l*"));
+            cut.addPattern(Patterns.wildcardMatch("h*llo"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("*"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("*hello"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("hello*"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("hell*o"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("h*l*o"), nameState);
+            cut.addPattern(Patterns.wildcardMatch("he*l*"), nameState);
         }
         cut.deletePattern(Patterns.wildcardMatch("h*llo"));
         cut.deletePattern(Patterns.wildcardMatch("*"));
@@ -1982,7 +1988,7 @@ public class ByteMachineTest {
     @Test
     public void testWildcardMachineNotEmptyWithSingleWildcardCharacterPattern() {
         ByteMachine cut = new ByteMachine();
-        cut.addPattern(Patterns.wildcardMatch("*"));
+        cut.addPattern(Patterns.wildcardMatch("*"), nameState);
         assertFalse(cut.isEmpty());
         cut.deletePattern(Patterns.wildcardMatch("*"));
         assertTrue(cut.isEmpty());
@@ -1992,7 +1998,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicated() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*2345"));
+            cut.addPattern(Patterns.wildcardMatch("1*2345"), nameState);
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2001,7 +2007,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsFirstChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("*123"));
+            cut.addPattern(Patterns.wildcardMatch("*123"), nameState);
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2010,7 +2016,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsSecondLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*2"));
+            cut.addPattern(Patterns.wildcardMatch("1*2"), nameState);
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2019,7 +2025,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("1*"));
+            cut.addPattern(Patterns.wildcardMatch("1*"), nameState);
         }
         assertEquals(2, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2028,7 +2034,7 @@ public class ByteMachineTest {
     public void testWildcardRuleIsNotDuplicatedWildcardIsThirdLastAndLastChar() {
         ByteMachine cut = new ByteMachine();
         for (int i = 0; i < 10; i++) {
-            cut.addPattern(Patterns.wildcardMatch("12*3*"));
+            cut.addPattern(Patterns.wildcardMatch("12*3*"), nameState);
         }
         assertEquals(3, cut.evaluateComplexity(new MachineComplexityEvaluator(Integer.MAX_VALUE)));
     }
@@ -2090,63 +2096,11 @@ public class ByteMachineTest {
     @Test
     public void testWildcardNoConsecutiveWildcardCharacters() {
         try {
-            new ByteMachine().addPattern(Patterns.wildcardMatch("h**o"));
+            new ByteMachine().addPattern(Patterns.wildcardMatch("h**o"), nameState);
             fail("Expected ParseException");
         } catch (ParseException e) {
             assertEquals("Consecutive wildcard characters at pos 1", e.getMessage());
         }
-    }
-
-    @Test
-    public void testAddMatchPatternGivenNameStateReturned() {
-        NameState nameState = new NameState();
-        ByteMachine cut = new ByteMachine();
-        assertSame(nameState, cut.addPattern(Patterns.exactMatch("a"), nameState));
-    }
-
-    @Test
-    public void testAddMatchPatternNoNameStateGiven() {
-        ByteMachine cut = new ByteMachine();
-        assertNotNull(cut.addPattern(Patterns.exactMatch("a")));
-    }
-
-    @Test
-    public void testAddExistencePatternGivenNameStateReturned() {
-        NameState nameState = new NameState();
-        ByteMachine cut = new ByteMachine();
-        assertSame(nameState, cut.addPattern(Patterns.existencePatterns(), nameState));
-    }
-
-    @Test
-    public void testAddExistencePatternNoNameStateGiven() {
-        ByteMachine cut = new ByteMachine();
-        assertNotNull(cut.addPattern(Patterns.existencePatterns()));
-    }
-
-    @Test
-    public void testAddAnythingButPatternGivenNameStateReturned() {
-        NameState nameState = new NameState();
-        ByteMachine cut = new ByteMachine();
-        assertSame(nameState, cut.addPattern(Patterns.anythingButMatch("z"), nameState));
-    }
-
-    @Test
-    public void testAddAnythingButPatternNoNameStateGiven() {
-        ByteMachine cut = new ByteMachine();
-        assertNotNull(cut.addPattern(Patterns.anythingButMatch("z")));
-    }
-
-    @Test
-    public void testAddRangePatternGivenNameStateReturned() {
-        NameState nameState = new NameState();
-        ByteMachine cut = new ByteMachine();
-        assertSame(nameState, cut.addPattern(Range.lessThan(5), nameState));
-    }
-
-    @Test
-    public void testAddRangePatternNoNameStateGiven() {
-        ByteMachine cut = new ByteMachine();
-        assertNotNull(cut.addPattern(Range.lessThan(5)));
     }
 
     private void testPatternPermutations(PatternMatch ... patternMatches) {
@@ -2207,7 +2161,7 @@ public class ByteMachineTest {
     private void testPatternPermutation(ByteMachine cut, PatternMatch[] additionPermutation,
                                         PatternMatch[] deletionPermutation, Matches matches) {
         for (PatternMatch patternMatch : additionPermutation) {
-            cut.addPattern(matches.registerPattern(patternMatch));
+            cut.addPattern(matches.registerPattern(patternMatch), nameState);
             for (Match match : matches.get()) {
                 assertEquals("Failed on " + match.value,
                         match.getNumPatternsRegistered(), cut.transitionOn(match.value).size());

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -422,6 +422,8 @@ public class JsonRuleCompilerTest {
         assertTrue(found.contains("rule2"));
 
         machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
         machine.deleteRule("rule2", rule2);
         found = machine.rulesForJSONEvent(event);
         assertEquals(0, found.size());
@@ -496,7 +498,6 @@ public class JsonRuleCompilerTest {
         assertTrue(rules.isArray());
         assertTrue(machine.isEmpty());
 
-        final int expectedSubRuleSize [] = {1, 1, 1, 1};
         final String expectedCompiledRules [] = {
                 "{$or=[0A000000/0A0000FF:false/false (T:NUMERIC_RANGE)]}",
                 "{$or.namespace=[VP:\"AWS/EC2\" (T:EXACT), VP:\"AWS/ES\" (T:EXACT)], source=[VP:\"aws.cloudwatch\" (T:EXACT)], $or.metricType=[VP:\"MetricType\" (T:EXACT)]}",
@@ -505,7 +506,6 @@ public class JsonRuleCompilerTest {
         };
 
         int i = 0;
-        List<Map<String, List<Patterns>>> compiledRules = null;
 
         // verify the legacy rules with using "$or" as normal field can work correctly with legacy RuleCompiler
         for (final JsonNode rule : rules) {

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -22,18 +22,16 @@ public class MachineComplexityEvaluatorTest {
 
     private static final int MAX_COMPLEXITY = 100;
     private MachineComplexityEvaluator evaluator;
-    private NameState nameState;
 
     @Before
     public void setup() {
         evaluator = new MachineComplexityEvaluator(MAX_COMPLEXITY);
-        nameState = new NameState();
     }
 
     @Test
     public void testEvaluateOnlyWildcard() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*"));
         // "a" is matched by 1 wildcard prefix: "*"
         assertEquals(1, machine.evaluateComplexity(evaluator));
     }
@@ -55,7 +53,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateWildcardPatternWithoutWildcards() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("abc"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abc"));
         // "abc" is matched by 1 wildcard prefix: "abc"
         assertEquals(1, machine.evaluateComplexity(evaluator));
     }
@@ -63,7 +61,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardLeadingCharTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*ab"));
         // "ab" is matched by 2 wildcard prefixes: "*", "*ab"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -71,7 +69,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardLeadingCharTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*aa"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*aa"));
         // "ab" is matched by 3 wildcard prefixes: "*", "*a", "*aa"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -79,7 +77,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*b"));
         // "ab" is matched by 2 wildcard prefixes: "a*", "a*b"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -87,7 +85,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("aa*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aa*"));
         // "aa" is matched by 2 wildcard prefixes: "aa", "aa*"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -95,7 +93,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bc"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bc"));
         // "ab" is matched by 2 wildcard prefixes: "a*", "a*b"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -103,7 +101,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bb"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bb"));
         // "abb" is matched by 3 wildcard prefixes: "a*", "a*b", "a*bb"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -111,7 +109,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionThreeTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bcb"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bcb"));
         // "abcb" is matched by 3 wildcard prefixes: "a*", "a*b", "a*bcb"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -119,7 +117,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionThreeTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bbb"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bbb"));
         // "abbb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*bb", "a*bbb"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -127,7 +125,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndNormalPosition() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*ad"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*ab*ad"));
         // "aba" is matched by 4 wildcard prefixes: "*", "*a", "*ab*", "*ab*a"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -135,7 +133,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*d"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*ab*d"));
         // "abd" is matched by 3 wildcard prefixes: "*", "*ab*", "*ab*d"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -143,7 +141,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*aba*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*aba*"));
         // "aba" is matched by 4 wildcard prefixes: "*", "*a", "*aba", "*aba*"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -151,7 +149,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*bb"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*b*bb"));
         // "abbb" is matched by 5 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*b", "a*b*bb"
         assertEquals(5, machine.evaluateComplexity(evaluator));
     }
@@ -159,7 +157,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*cb"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*b*cb"));
         // "abcb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*cb"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -167,7 +165,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersDifferentLastCharUnique() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*cd"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*b*cd"));
         // "abcd" is matched by 3 wildcard prefixes: "a*", "a*b*", "a*b*cd"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -175,7 +173,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsNormalPositionAndSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*b"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*b*b"));
         // "abb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*b"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -183,7 +181,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsNormalPositionAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bb*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bb*"));
         // "abb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*bb", "a*bb*"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -191,7 +189,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsThirdLastCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("ab*b*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*b*"));
         // "abb" is matched by 3 wildcard prefixes: "ab*", "ab*b", "ab*b*"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -284,7 +282,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateFourWildcardsLeadingCharNormalPositionThirdLastCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*b*b*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*ab*b*b*"));
         // "abbbab" is matched by 7 wildcard prefixes: "*", "*ab", "*ab*", "*ab*b", "*ab*b*", "*ab*b*b", "*ab*b*b*"
         assertEquals(7, machine.evaluateComplexity(evaluator));
     }
@@ -292,7 +290,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateLongSequenceofWildcards() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*a*a*a*a*a*a*a*a*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*a*a*a*a*a*a*a*a*"));
         // "aaaaaaaa" is matched by all 17 wildcard prefixes
         assertEquals(17, machine.evaluateComplexity(evaluator));
     }
@@ -399,38 +397,38 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateQuaminaExploder() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("aahed*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("aal*ii"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("aargh*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("aarti*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*baca"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abaci"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*back"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("ab*acs"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abaf*t"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abaka"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("ab*amp"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*band"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abase"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abash*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abas*k"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("ab*ate"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("aba*ya"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abbas*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abbed*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("ab*bes"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abbey*"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abbot"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("ab*cee"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abea*m"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abe*ar"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*bele"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*bers"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abet*s"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abhor"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("abi*de"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("a*bies"), nameState);
-        machine.addPattern(Patterns.wildcardMatch("*abled"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aahed*"));
+        machine.addPattern(Patterns.wildcardMatch("aal*ii"));
+        machine.addPattern(Patterns.wildcardMatch("aargh*"));
+        machine.addPattern(Patterns.wildcardMatch("aarti*"));
+        machine.addPattern(Patterns.wildcardMatch("a*baca"));
+        machine.addPattern(Patterns.wildcardMatch("*abaci"));
+        machine.addPattern(Patterns.wildcardMatch("a*back"));
+        machine.addPattern(Patterns.wildcardMatch("ab*acs"));
+        machine.addPattern(Patterns.wildcardMatch("abaf*t"));
+        machine.addPattern(Patterns.wildcardMatch("*abaka"));
+        machine.addPattern(Patterns.wildcardMatch("ab*amp"));
+        machine.addPattern(Patterns.wildcardMatch("a*band"));
+        machine.addPattern(Patterns.wildcardMatch("*abase"));
+        machine.addPattern(Patterns.wildcardMatch("abash*"));
+        machine.addPattern(Patterns.wildcardMatch("abas*k"));
+        machine.addPattern(Patterns.wildcardMatch("ab*ate"));
+        machine.addPattern(Patterns.wildcardMatch("aba*ya"));
+        machine.addPattern(Patterns.wildcardMatch("abbas*"));
+        machine.addPattern(Patterns.wildcardMatch("abbed*"));
+        machine.addPattern(Patterns.wildcardMatch("ab*bes"));
+        machine.addPattern(Patterns.wildcardMatch("abbey*"));
+        machine.addPattern(Patterns.wildcardMatch("*abbot"));
+        machine.addPattern(Patterns.wildcardMatch("ab*cee"));
+        machine.addPattern(Patterns.wildcardMatch("abea*m"));
+        machine.addPattern(Patterns.wildcardMatch("abe*ar"));
+        machine.addPattern(Patterns.wildcardMatch("a*bele"));
+        machine.addPattern(Patterns.wildcardMatch("a*bers"));
+        machine.addPattern(Patterns.wildcardMatch("abet*s"));
+        machine.addPattern(Patterns.wildcardMatch("*abhor"));
+        machine.addPattern(Patterns.wildcardMatch("abi*de"));
+        machine.addPattern(Patterns.wildcardMatch("a*bies"));
+        machine.addPattern(Patterns.wildcardMatch("*abled"));
         assertEquals(45, machine.evaluateComplexity(evaluator));
     }
 
@@ -447,7 +445,7 @@ public class MachineComplexityEvaluatorTest {
         for (int i = 0; i < 10000; i++) {
             builder.append("F*e*a*t*u*r*e*");
         }
-        machine.addPattern(Patterns.wildcardMatch(builder.toString()), nameState);
+        machine.addPattern(Patterns.wildcardMatch(builder.toString()));
 
         // Start a complexity evaluation task.
         final int[] complexity = { -1 };
@@ -488,7 +486,7 @@ public class MachineComplexityEvaluatorTest {
         List<Patterns[]> patternPermutations = generateAllPermutations(patterns);
         for (Patterns[] patternPermutation : patternPermutations) {
             for (Patterns pattern : patternPermutation) {
-                machine.addPattern(pattern, nameState);
+                machine.addPattern(pattern);
             }
             assertEquals(expectedComplexity, machine.evaluateComplexity(evaluator));
             for (Patterns pattern : patternPermutation) {

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -22,16 +22,18 @@ public class MachineComplexityEvaluatorTest {
 
     private static final int MAX_COMPLEXITY = 100;
     private MachineComplexityEvaluator evaluator;
+    private NameState nameState;
 
     @Before
     public void setup() {
         evaluator = new MachineComplexityEvaluator(MAX_COMPLEXITY);
+        nameState = new NameState();
     }
 
     @Test
     public void testEvaluateOnlyWildcard() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*"));
+        machine.addPattern(Patterns.wildcardMatch("*"), nameState);
         // "a" is matched by 1 wildcard prefix: "*"
         assertEquals(1, machine.evaluateComplexity(evaluator));
     }
@@ -53,7 +55,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateWildcardPatternWithoutWildcards() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("abc"));
+        machine.addPattern(Patterns.wildcardMatch("abc"), nameState);
         // "abc" is matched by 1 wildcard prefix: "abc"
         assertEquals(1, machine.evaluateComplexity(evaluator));
     }
@@ -61,7 +63,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardLeadingCharTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab"));
+        machine.addPattern(Patterns.wildcardMatch("*ab"), nameState);
         // "ab" is matched by 2 wildcard prefixes: "*", "*ab"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -69,7 +71,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardLeadingCharTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*aa"));
+        machine.addPattern(Patterns.wildcardMatch("*aa"), nameState);
         // "ab" is matched by 3 wildcard prefixes: "*", "*a", "*aa"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -77,7 +79,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b"));
+        machine.addPattern(Patterns.wildcardMatch("a*b"), nameState);
         // "ab" is matched by 2 wildcard prefixes: "a*", "a*b"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -85,7 +87,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("aa*"));
+        machine.addPattern(Patterns.wildcardMatch("aa*"), nameState);
         // "aa" is matched by 2 wildcard prefixes: "aa", "aa*"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -93,7 +95,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bc"));
+        machine.addPattern(Patterns.wildcardMatch("a*bc"), nameState);
         // "ab" is matched by 2 wildcard prefixes: "a*", "a*b"
         assertEquals(2, machine.evaluateComplexity(evaluator));
     }
@@ -101,7 +103,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bb"));
+        machine.addPattern(Patterns.wildcardMatch("a*bb"), nameState);
         // "abb" is matched by 3 wildcard prefixes: "a*", "a*b", "a*bb"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -109,7 +111,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionThreeTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bcb"));
+        machine.addPattern(Patterns.wildcardMatch("a*bcb"), nameState);
         // "abcb" is matched by 3 wildcard prefixes: "a*", "a*b", "a*bcb"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -117,7 +119,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateOneWildcardNormalPositionThreeTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bbb"));
+        machine.addPattern(Patterns.wildcardMatch("a*bbb"), nameState);
         // "abbb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*bb", "a*bbb"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -125,7 +127,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndNormalPosition() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*ad"));
+        machine.addPattern(Patterns.wildcardMatch("*ab*ad"), nameState);
         // "aba" is matched by 4 wildcard prefixes: "*", "*a", "*ab*", "*ab*a"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -133,7 +135,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*d"));
+        machine.addPattern(Patterns.wildcardMatch("*ab*d"), nameState);
         // "abd" is matched by 3 wildcard prefixes: "*", "*ab*", "*ab*d"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -141,7 +143,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsLeadingCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*aba*"));
+        machine.addPattern(Patterns.wildcardMatch("*aba*"), nameState);
         // "aba" is matched by 4 wildcard prefixes: "*", "*a", "*aba", "*aba*"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -149,7 +151,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersEqual() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*bb"));
+        machine.addPattern(Patterns.wildcardMatch("a*b*bb"), nameState);
         // "abbb" is matched by 5 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*b", "a*b*bb"
         assertEquals(5, machine.evaluateComplexity(evaluator));
     }
@@ -157,7 +159,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersDifferent() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*cb"));
+        machine.addPattern(Patterns.wildcardMatch("a*b*cb"), nameState);
         // "abcb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*cb"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -165,7 +167,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsBothNormalPositionTwoTrailingCharactersDifferentLastCharUnique() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*cd"));
+        machine.addPattern(Patterns.wildcardMatch("a*b*cd"), nameState);
         // "abcd" is matched by 3 wildcard prefixes: "a*", "a*b*", "a*b*cd"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -173,7 +175,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsNormalPositionAndSecondLastChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*b*b"));
+        machine.addPattern(Patterns.wildcardMatch("a*b*b"), nameState);
         // "abb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*b*", "a*b*b"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -181,7 +183,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsNormalPositionAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("a*bb*"));
+        machine.addPattern(Patterns.wildcardMatch("a*bb*"), nameState);
         // "abb" is matched by 4 wildcard prefixes: "a*", "a*b", "a*bb", "a*bb*"
         assertEquals(4, machine.evaluateComplexity(evaluator));
     }
@@ -189,7 +191,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateTwoWildcardsThirdLastCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("ab*b*"));
+        machine.addPattern(Patterns.wildcardMatch("ab*b*"), nameState);
         // "abb" is matched by 3 wildcard prefixes: "ab*", "ab*b", "ab*b*"
         assertEquals(3, machine.evaluateComplexity(evaluator));
     }
@@ -282,7 +284,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateFourWildcardsLeadingCharNormalPositionThirdLastCharAndTrailingChar() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*ab*b*b*"));
+        machine.addPattern(Patterns.wildcardMatch("*ab*b*b*"), nameState);
         // "abbbab" is matched by 7 wildcard prefixes: "*", "*ab", "*ab*", "*ab*b", "*ab*b*", "*ab*b*b", "*ab*b*b*"
         assertEquals(7, machine.evaluateComplexity(evaluator));
     }
@@ -290,7 +292,7 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateLongSequenceofWildcards() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("*a*a*a*a*a*a*a*a*"));
+        machine.addPattern(Patterns.wildcardMatch("*a*a*a*a*a*a*a*a*"), nameState);
         // "aaaaaaaa" is matched by all 17 wildcard prefixes
         assertEquals(17, machine.evaluateComplexity(evaluator));
     }
@@ -397,38 +399,38 @@ public class MachineComplexityEvaluatorTest {
     @Test
     public void testEvaluateQuaminaExploder() {
         ByteMachine machine = new ByteMachine();
-        machine.addPattern(Patterns.wildcardMatch("aahed*"));
-        machine.addPattern(Patterns.wildcardMatch("aal*ii"));
-        machine.addPattern(Patterns.wildcardMatch("aargh*"));
-        machine.addPattern(Patterns.wildcardMatch("aarti*"));
-        machine.addPattern(Patterns.wildcardMatch("a*baca"));
-        machine.addPattern(Patterns.wildcardMatch("*abaci"));
-        machine.addPattern(Patterns.wildcardMatch("a*back"));
-        machine.addPattern(Patterns.wildcardMatch("ab*acs"));
-        machine.addPattern(Patterns.wildcardMatch("abaf*t"));
-        machine.addPattern(Patterns.wildcardMatch("*abaka"));
-        machine.addPattern(Patterns.wildcardMatch("ab*amp"));
-        machine.addPattern(Patterns.wildcardMatch("a*band"));
-        machine.addPattern(Patterns.wildcardMatch("*abase"));
-        machine.addPattern(Patterns.wildcardMatch("abash*"));
-        machine.addPattern(Patterns.wildcardMatch("abas*k"));
-        machine.addPattern(Patterns.wildcardMatch("ab*ate"));
-        machine.addPattern(Patterns.wildcardMatch("aba*ya"));
-        machine.addPattern(Patterns.wildcardMatch("abbas*"));
-        machine.addPattern(Patterns.wildcardMatch("abbed*"));
-        machine.addPattern(Patterns.wildcardMatch("ab*bes"));
-        machine.addPattern(Patterns.wildcardMatch("abbey*"));
-        machine.addPattern(Patterns.wildcardMatch("*abbot"));
-        machine.addPattern(Patterns.wildcardMatch("ab*cee"));
-        machine.addPattern(Patterns.wildcardMatch("abea*m"));
-        machine.addPattern(Patterns.wildcardMatch("abe*ar"));
-        machine.addPattern(Patterns.wildcardMatch("a*bele"));
-        machine.addPattern(Patterns.wildcardMatch("a*bers"));
-        machine.addPattern(Patterns.wildcardMatch("abet*s"));
-        machine.addPattern(Patterns.wildcardMatch("*abhor"));
-        machine.addPattern(Patterns.wildcardMatch("abi*de"));
-        machine.addPattern(Patterns.wildcardMatch("a*bies"));
-        machine.addPattern(Patterns.wildcardMatch("*abled"));
+        machine.addPattern(Patterns.wildcardMatch("aahed*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aal*ii"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aargh*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aarti*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*baca"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abaci"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*back"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*acs"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abaf*t"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abaka"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*amp"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*band"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abase"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abash*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abas*k"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*ate"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("aba*ya"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abbas*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abbed*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*bes"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abbey*"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abbot"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("ab*cee"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abea*m"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abe*ar"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bele"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bers"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abet*s"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abhor"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("abi*de"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("a*bies"), nameState);
+        machine.addPattern(Patterns.wildcardMatch("*abled"), nameState);
         assertEquals(45, machine.evaluateComplexity(evaluator));
     }
 
@@ -445,7 +447,7 @@ public class MachineComplexityEvaluatorTest {
         for (int i = 0; i < 10000; i++) {
             builder.append("F*e*a*t*u*r*e*");
         }
-        machine.addPattern(Patterns.wildcardMatch(builder.toString()));
+        machine.addPattern(Patterns.wildcardMatch(builder.toString()), nameState);
 
         // Start a complexity evaluation task.
         final int[] complexity = { -1 };
@@ -486,7 +488,7 @@ public class MachineComplexityEvaluatorTest {
         List<Patterns[]> patternPermutations = generateAllPermutations(patterns);
         for (Patterns[] patternPermutation : patternPermutations) {
             for (Patterns pattern : patternPermutation) {
-                machine.addPattern(pattern);
+                machine.addPattern(pattern, nameState);
             }
             assertEquals(expectedComplexity, machine.evaluateComplexity(evaluator));
             for (Patterns pattern : patternPermutation) {

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2284,7 +2284,7 @@ public class MachineTest {
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-values-" + i, "{ \"many-values-key\" :  [ \"value" + i + " \" ] }");
         }
-        assertEquals(5108, machine.approximateObjectCount());
+        assertEquals(4109, machine.approximateObjectCount());
     }
 
     @Test
@@ -2316,7 +2316,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name7\",\"Name8\",\"Name9\",\"Name10\",\"Name11\",\"Name12\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(63, machine.approximateObjectCount());
+        assertEquals(57, machine.approximateObjectCount());
     }
 
     @Test
@@ -2347,7 +2347,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name6\",\"Name7\",\"Name8\",\"Name9\",\"Name10\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(90, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -807,16 +807,16 @@ public class MachineTest {
         Rule rule3;
 
         rule = new Rule("R1");
-        rule.setKeys("a", "b","c");
-        rule.setExactMatchValues("11", "21","31");
+        rule.setKeys("a", "b", "c");
+        rule.setExactMatchValues("11", "21", "31");
         //test whether duplicated rule could be added
         machine.addPatternRule(rule.name, rule.fields);
         machine.addPatternRule(rule.name, rule.fields);
         machine.addPatternRule(rule.name, rule.fields);
 
         rule1 = new Rule("R1");
-        rule1.setKeys("a", "b","zoo");
-        rule1.setExactMatchValues("11", "21","keeper");
+        rule1.setKeys("a", "b", "zoo");
+        rule1.setExactMatchValues("11", "21", "keeper");
         machine.addPatternRule(rule1.name, rule1.fields);
 
         List<String> actual1 = machine.rulesForEvent(e.mTokens);
@@ -859,15 +859,13 @@ public class MachineTest {
         machine.addPatternRule(rule.name, rule.fields);
         List<String> actual = machine.rulesForEvent(e.mTokens);
         assertEquals(1, actual.size());
-        //System.out.println("matched rule:" + actual);
 
         rule1 = new Rule("R1");
-        rule1.setKeys("a", "b","gamma");
-        rule1.setExactMatchValues("11", "21","41");
+        rule1.setKeys("a", "b", "gamma");
+        rule1.setExactMatchValues("11", "21", "41");
         machine.addPatternRule(rule1.name, rule1.fields);
         List<String> actual1 = machine.rulesForEvent(e.mTokens);
         assertEquals(1, actual1.size());
-        //System.out.println("matched rule:" + actual1);
 
 
         // delete R1 subset with rule.fields
@@ -875,7 +873,6 @@ public class MachineTest {
 
         List<String> actual2 = machine.rulesForEvent(e.mTokens);
         assertEquals(1, actual2.size());
-        //System.out.println("matched rule:" + actual2);
 
         // delete R1 subset with rule1 fields, after this step,
         // the machine will become empty as if no rule was added before.
@@ -883,8 +880,6 @@ public class MachineTest {
 
         List<String> actual3 = machine.rulesForEvent(e.mTokens);
         assertEquals(0, actual3.size());
-        //System.out.println("matched rule:" + actual3);
-
     }
 
     /**
@@ -904,7 +899,7 @@ public class MachineTest {
     public void testMultipleThreadReadAddRule() {
         Machine machine = new Machine();
         List<String> event = new ArrayList<>();
-        List <Rule> rules = new ArrayList<>();
+        List<Rule> rules = new ArrayList<>();
 
         for (int i = 0; i< 100; i++) {
             event.add(String.format("key-%03d",i));
@@ -1538,6 +1533,27 @@ public class MachineTest {
         assertTrue(machine.isEmpty());
     }
 
+    @Test
+    public void testExists() throws Exception {
+        String rule1 = "{\"abc\": [{\"exists\": false}]}";
+        String rule2 = "{\"abc\": [{\"exists\": true}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event1 = "{\"abc\": \"xyz\"}";
+        String event2 = "{\"xyz\": \"abc\"}";
+
+        List<String> matches = machine.rulesForEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
     public void testAddAndDeleteTwoRulesSamePattern() throws Exception {
         final Machine machine = new Machine();
         String event = "{\n" +
@@ -1555,16 +1571,16 @@ public class MachineTest {
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
-        List<String> found = machine.rulesForJSONEvent(event);
+        List<String> found = machine.rulesForEvent(event);
         assertEquals(2, found.size());
         assertTrue(found.contains("rule1"));
         assertTrue(found.contains("rule2"));
 
         machine.deleteRule("rule1", rule1);
-        found = machine.rulesForJSONEvent(event);
+        found = machine.rulesForEvent(event);
         assertEquals(1, found.size());
         machine.deleteRule("rule2", rule2);
-        found = machine.rulesForJSONEvent(event);
+        found = machine.rulesForEvent(event);
         assertEquals(0, found.size());
         assertTrue(machine.isEmpty());
     }
@@ -1587,18 +1603,404 @@ public class MachineTest {
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
-        List<String> found = machine.rulesForJSONEvent(event);
+        List<String> found = machine.rulesForEvent(event);
         assertEquals(2, found.size());
         assertTrue(found.contains("rule1"));
         assertTrue(found.contains("rule2"));
 
         machine.deleteRule("rule1", rule1);
-        found = machine.rulesForJSONEvent(event);
+        found = machine.rulesForEvent(event);
         assertEquals(1, found.size());
         machine.deleteRule("rule2", rule2);
-        found = machine.rulesForJSONEvent(event);
+        found = machine.rulesForEvent(event);
         assertEquals(0, found.size());
         assertTrue(machine.isEmpty());
+    }
+
+    public void testDuplicateKeyLastOneWins() throws Exception {
+        final Machine machine = new Machine();
+        String event1 = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+        String event2 = "{\n" +
+                "  \"x\": \"z\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ \"y\" ],\n" +
+                "  \"x\": [ \"z\" ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+
+        List<String> found = machine.rulesForEvent(event1);
+        assertEquals(0, found.size());
+        found = machine.rulesForEvent(event2);
+        assertEquals(1, found.size());
+        assertTrue(found.contains("rule1"));
+    }
+
+    @Test
+    public void testSharedNameState() throws Exception {
+        // "bar" will be the first key (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"x\"]}";
+        String rule3 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"y\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Ensure rule3 does not piggyback on rule1's shared NameState accessed by both "x" and "y" for "bar"
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testRuleDeletionFromSharedNameState() throws Exception {
+        // "bar" will be the first key (alphabetical) and both rules have a match on "x", leading to a shared NameState
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"foo\":[\"b\"], \"bar\":[\"x\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event1 = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+        String event2 = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"y\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+
+        // Shared NameState will remain as it is used by rule1
+        machine.deleteRule("rule2", rule2);
+
+        matches = machine.rulesForEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForEvent(event2);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+
+        // "y" also leads to the shared NameState. The shared NameState will get extended by rule2's "foo" field. By
+        // checking that only events with a "bar" of "y" and not a "bar" of "x", we verify that no remnants of the
+        // original rule2 were left in the shared NameState.
+        String rule2b = "{\"foo\":[\"a\"], \"bar\":[\"y\"]}";
+
+        machine.addRule("rule2", rule2b);
+
+        matches = machine.rulesForEvent(event1);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForEvent(event2);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testPrefixRuleDeletionFromSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"zoo\":[\"1\"], \"foo\":[\"a\"], \"bar\":[\"x\"]}";
+        String rule2 = "{\"foo\":[\"a\"], \"bar\":[\"x\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+
+        // Delete rule2, which is a subpath/prefix of rule1, and ensure full path still exists for rule1 to match
+        machine.deleteRule("rule2", rule2);
+
+        matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testDifferentValuesFromOrRuleBothGoThroughSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"zoo\":[\"1\"], \"bar\":[\"x\"]}";
+        String rule2b = "{\"foo\":[\"a\"], \"bar\":[\"y\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule2", rule2b);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testDifferentValuesFromExplicitOrRuleBothGoThroughSharedNameState() throws Exception {
+        // "bar", "foo", "zoo" will be the key order (alphabetical)
+        String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
+        String rule2 = "{\"$or\":[{\"zoo\":[\"1\"], \"bar\":[\"x\"]}, {\"foo\":[\"a\"], \"bar\":[\"y\"]}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"x\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRule() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRule() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRuleWithPrecedingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"1\"," +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRuleWithPrecedingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"1\"," +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsSingleItemSubsetOfOtherRuleWithFollowingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
+        String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testRuleIsMultipleItemSubsetOfOtherRuleWithFollowingKey() throws Exception {
+        // Second rule added pertains to same field as first rule but has a subset of the allowed values.
+        String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
+        String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"1\"," +
+                "\"foo\": \"e\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsFalseAsFinalKeyAfterSharedNameState() throws Exception {
+        // Second rule added uses same NameState for bar, but then has a final key, foo, that must not exist.
+        String rule1 = "{\"bar\": [\"a\", \"b\"]}";
+        String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": false}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsTrueAsFinalKeyAfterSharedNameState() throws Exception {
+        // Second rule added uses same NameState for bar, but then has a final key, foo, that must exist.
+        String rule1 = "{\"bar\": [\"a\", \"b\"]}";
+        String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": true}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"bar\": \"a\"," +
+                "\"foo\": \"1\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsFalseNameStateSharedWithSpecificValueMatch() throws Exception {
+        // First rule adds a NameState for exists=false. Second rule will use this same NameState and add a value of "1"
+        // to it. Third rule will now use this same shared NameState as well due to its value of "1".
+        String rule1 = "{\"foo\": [\"a\"], \"bar\": [{\"exists\": false}]}";
+        String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": false}, \"1\"]}";
+        String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"" +
+                "}";
+
+        // Only rule1 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testExistsTrueNameStateSharedWithSpecificValueMatch() throws Exception {
+        // First rule adds a NameState for exists=true. Second rule will use this same NameState and add a value of "1"
+        // to it. Third rule will now use this same shared NameState as well due to its value of "1".
+        String rule1 = "{\"foo\": [\"a\"], \"bar\": [{\"exists\": true}]}";
+        String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": true}, \"1\"]}";
+        String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        String event = "{" +
+                "\"foo\": \"a\"," +
+                "\"bar\": \"1\"" +
+                "}";
+
+        // Only rule1 and rule3 should match
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule3"));
     }
 
     @Test
@@ -1752,4 +2154,5 @@ public class MachineTest {
                         "}");
         assertEquals(251, machine.approximateObjectCount());
     }
+
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2169,13 +2169,13 @@ public class MachineTest {
 
         Machine machine = new Machine();
         machine.addRule("r1", rule1);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
 
         // Adding the same rule multiple times should not increase object count
         for (int i = 0; i < 100; i++) {
             machine.addRule("r1", rule1);
         }
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
     }
 
     @Test
@@ -2185,11 +2185,11 @@ public class MachineTest {
 
         Machine machine = new Machine();
         machine.addRule("r1", rule1a);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
 
         // Adding rule with terminal key having subset of values will be treated as same rule and thus increase size
         machine.addRule("r1", rule1b);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
     }
 
     @Test
@@ -2199,11 +2199,11 @@ public class MachineTest {
 
         Machine machine = new Machine();
         machine.addRule("r1", rule1a);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
 
         // Adding rule with non-terminal key having subset of values will be treated as same rule and not affect count
         machine.addRule("r1", rule1b);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
     }
 
     @Test
@@ -2213,11 +2213,11 @@ public class MachineTest {
 
         Machine machine = new Machine();
         machine.addRule("r1", rule1a);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
 
         // Adding rule with terminal key having superset of values will be treated as new rule and increase count
         machine.addRule("r1", rule1b);
-        assertEquals(91, machine.approximateObjectCount());
+        assertEquals(89, machine.approximateObjectCount());
     }
 
     @Test
@@ -2227,11 +2227,11 @@ public class MachineTest {
 
         Machine machine = new Machine();
         machine.addRule("r1", rule1a);
-        assertEquals(80, machine.approximateObjectCount());
+        assertEquals(79, machine.approximateObjectCount());
 
         // Adding rule with non-terminal key having superset of values will be treated as new rule and increase count
         machine.addRule("r1", rule1b);
-        assertEquals(91, machine.approximateObjectCount());
+        assertEquals(89, machine.approximateObjectCount());
     }
 
     @Test
@@ -2263,7 +2263,7 @@ public class MachineTest {
                         "    \"c\": [{ \"numeric\": [\">\", 50] }]\n" +
                         "}");
 
-        assertEquals(518, machine.approximateObjectCount());
+        assertEquals(517, machine.approximateObjectCount());
     }
 
     @Test
@@ -2314,7 +2314,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(26, machine.approximateObjectCount());
+        assertEquals(25, machine.approximateObjectCount());
 
         machine.addRule("rule-with-six-elements",
                 "{\n" +
@@ -2323,7 +2323,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\",\"Name6\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(37, machine.approximateObjectCount());
+        assertEquals(35, machine.approximateObjectCount());
 
 
         machine.addRule("rule-with-six-more-elements",
@@ -2333,7 +2333,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name7\",\"Name8\",\"Name9\",\"Name10\",\"Name11\",\"Name12\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(63, machine.approximateObjectCount());
+        assertEquals(60, machine.approximateObjectCount());
     }
 
     @Test
@@ -2346,7 +2346,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(36, machine.approximateObjectCount());
+        assertEquals(35, machine.approximateObjectCount());
 
         machine.addRule("rule-with-two-more-source-and-eventNames",
                 "{\n" +
@@ -2355,7 +2355,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(50, machine.approximateObjectCount());
+        assertEquals(48, machine.approximateObjectCount());
 
         machine.addRule("rule-with-more-unique-source-and-eventNames",
                 "{\n" +
@@ -2364,7 +2364,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name6\",\"Name7\",\"Name8\",\"Name9\",\"Name10\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(90, machine.approximateObjectCount());
+        assertEquals(87, machine.approximateObjectCount());
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2060,6 +2060,77 @@ public class MachineTest {
     }
 
     @Test
+    public void testApproxSizeForDuplicatedRules() throws Exception {
+        String rule1 = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6] }";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule1);
+        assertEquals(80, machine.approximateObjectCount());
+
+        // Adding the same rule multiple times should not increase object count
+        for (int i = 0; i < 100; i++) {
+            machine.addRule("r1", rule1);
+        }
+        assertEquals(80, machine.approximateObjectCount());
+    }
+
+    @Test
+    public void testApproxSizeForAddingDuplicateRuleExceptTerminalKeyIsSubset() throws Exception {
+        String rule1a = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6] }";
+        String rule1b = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5] }";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule1a);
+        assertEquals(80, machine.approximateObjectCount());
+
+        // Adding rule with terminal key having subset of values will be treated as same rule and thus increase size
+        machine.addRule("r1", rule1b);
+        assertEquals(80, machine.approximateObjectCount());
+    }
+
+    @Test
+    public void testApproxSizeForAddingDuplicateRuleExceptNonTerminalKeyIsSubset() throws Exception {
+        String rule1a = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6] }";
+        String rule1b = "{ \"a\" : [ 1, 2 ], \"b\" : [4, 5, 6] }";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule1a);
+        assertEquals(80, machine.approximateObjectCount());
+
+        // Adding rule with non-terminal key having subset of values will be treated as same rule and not affect count
+        machine.addRule("r1", rule1b);
+        assertEquals(80, machine.approximateObjectCount());
+    }
+
+    @Test
+    public void testApproxSizeForAddingDuplicateRuleExceptTerminalKeyIsSuperset() throws Exception {
+        String rule1a = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6] }";
+        String rule1b = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6, 7] }";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule1a);
+        assertEquals(80, machine.approximateObjectCount());
+
+        // Adding rule with terminal key having superset of values will be treated as new rule and increase count
+        machine.addRule("r1", rule1b);
+        assertEquals(91, machine.approximateObjectCount());
+    }
+
+    @Test
+    public void testApproxSizeForAddingDuplicateRuleExceptNonTerminalKeyIsSuperset() throws Exception {
+        String rule1a = "{ \"a\" : [ 1, 2, 3 ], \"b\" : [4, 5, 6] }";
+        String rule1b = "{ \"a\" : [ 1, 2, 3, 7 ], \"b\" : [4, 5, 6] }";
+
+        Machine machine = new Machine();
+        machine.addRule("r1", rule1a);
+        assertEquals(80, machine.approximateObjectCount());
+
+        // Adding rule with non-terminal key having superset of values will be treated as new rule and increase count
+        machine.addRule("r1", rule1b);
+        assertEquals(87, machine.approximateObjectCount());
+    }
+
+    @Test
     public void testSuffixChineseMatch() throws Exception {
         Machine m = new Machine();
         String rule = "{\n" +

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2013,13 +2013,13 @@ public class MachineTest {
         assertEquals(1, machine.approximateObjectCount());
 
         machine.addRule("r1", rule1);
-        assertEquals(20, machine.approximateObjectCount());
+        assertEquals(22, machine.approximateObjectCount());
 
         machine.addRule("r2", rule2);
-        assertEquals(40, machine.approximateObjectCount());
+        assertEquals(43, machine.approximateObjectCount());
 
         machine.addRule("r3", rule3);
-        assertEquals(60, machine.approximateObjectCount());
+        assertEquals(64, machine.approximateObjectCount());
     }
 
     @Test
@@ -2051,7 +2051,7 @@ public class MachineTest {
                         "    \"c\": [{ \"numeric\": [\">\", 50] }]\n" +
                         "}");
 
-        assertEquals(514, machine.approximateObjectCount());
+        assertEquals(517, machine.approximateObjectCount());
     }
 
     @Test
@@ -2061,35 +2061,35 @@ public class MachineTest {
 
 
         machine.addRule("single-rule", "{ \"key\" :  [ \"value\" ] }");
-        assertEquals(7, machine.approximateObjectCount());
+        assertEquals(8, machine.approximateObjectCount());
 
         // every new rule also is considered as part of the end-state
         machine = new Machine();
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-rule-" + i, "{ \"key\" :  [ \"value\" ] }");
         }
-        assertEquals(1006, machine.approximateObjectCount());
+        assertEquals(1007, machine.approximateObjectCount());
 
         // new unique rules create new states
         machine = new Machine();
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-key-values-" + i, "{ \"many-kv-" + i + "\" :  [ \"value" + i + "\" ] }");
         }
-        assertEquals(6001, machine.approximateObjectCount());
+        assertEquals(7001, machine.approximateObjectCount());
 
         // new unique rule keys create same states as unique rules
         machine = new Machine();
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-keys-" + i, "{ \"many-key-" + i + "\" :  [ \"value\" ] }");
         }
-        assertEquals(6001, machine.approximateObjectCount());
+        assertEquals(6002, machine.approximateObjectCount());
 
         // new unique rule with many values are smaller
         machine = new Machine();
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-values-" + i, "{ \"many-values-key\" :  [ \"value" + i + " \" ] }");
         }
-        assertEquals(4108, machine.approximateObjectCount());
+        assertEquals(5108, machine.approximateObjectCount());
     }
 
     @Test
@@ -2102,7 +2102,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(33, machine.approximateObjectCount());
+        assertEquals(25, machine.approximateObjectCount());
 
         machine.addRule("rule-with-six-elements",
                 "{\n" +
@@ -2111,7 +2111,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\",\"Name6\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(58, machine.approximateObjectCount());
+        assertEquals(35, machine.approximateObjectCount());
 
 
         machine.addRule("rule-with-six-more-elements",
@@ -2121,7 +2121,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name7\",\"Name8\",\"Name9\",\"Name10\",\"Name11\",\"Name12\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(107, machine.approximateObjectCount());
+        assertEquals(60, machine.approximateObjectCount());
     }
 
     @Test
@@ -2134,7 +2134,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(63, machine.approximateObjectCount());
+        assertEquals(35, machine.approximateObjectCount());
 
         machine.addRule("rule-with-two-more-source-and-eventNames",
                 "{\n" +
@@ -2143,7 +2143,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(130, machine.approximateObjectCount());
+        assertEquals(48, machine.approximateObjectCount());
 
         machine.addRule("rule-with-more-unique-source-and-eventNames",
                 "{\n" +
@@ -2152,7 +2152,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name6\",\"Name7\",\"Name8\",\"Name9\",\"Name10\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(251, machine.approximateObjectCount());
+        assertEquals(87, machine.approximateObjectCount());
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1538,6 +1538,69 @@ public class MachineTest {
         assertTrue(machine.isEmpty());
     }
 
+    public void testAddAndDeleteTwoRulesSamePattern() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ \"y\" ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
+    public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternEqualsIgnoreCase() throws Exception {
+        final Machine machine = new Machine();
+        String event = "{\n" +
+                "  \"x\": \"y\"\n" +
+                "}";
+
+        String rule1 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"y\" } ]\n" +
+                "}";
+
+        String rule2 = "{\n" +
+                "  \"x\": [ { \"equals-ignore-case\": \"Y\" } ]\n" +
+                "}";
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        List<String> found = machine.rulesForJSONEvent(event);
+        assertEquals(2, found.size());
+        assertTrue(found.contains("rule1"));
+        assertTrue(found.contains("rule2"));
+
+        machine.deleteRule("rule1", rule1);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(1, found.size());
+        machine.deleteRule("rule2", rule2);
+        found = machine.rulesForJSONEvent(event);
+        assertEquals(0, found.size());
+        assertTrue(machine.isEmpty());
+    }
+
     @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2026,6 +2026,21 @@ public class MachineTest {
     }
 
     @Test
+    public void testSharedNameStateForMultipleAnythingButPatterns() throws Exception {
+        // Every event will match this rule because any bar that is "a" cannot also be "b".
+        String rule1 = "{\"bar\": [{\"anything-but\": \"a\"}, {\"anything-but\": \"b\"}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+
+        String event = "{\"bar\": \"b\"}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2301,7 +2301,7 @@ public class MachineTest {
         for(int i = 0 ; i < 1000; i ++) {
             machine.addRule("lots-values-" + i, "{ \"many-values-key\" :  [ \"value" + i + " \" ] }");
         }
-        assertEquals(4109, machine.approximateObjectCount());
+        assertEquals(5108, machine.approximateObjectCount());
     }
 
     @Test
@@ -2333,7 +2333,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name7\",\"Name8\",\"Name9\",\"Name10\",\"Name11\",\"Name12\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(57, machine.approximateObjectCount());
+        assertEquals(63, machine.approximateObjectCount());
     }
 
     @Test
@@ -2364,7 +2364,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name6\",\"Name7\",\"Name8\",\"Name9\",\"Name10\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(79, machine.approximateObjectCount());
+        assertEquals(90, machine.approximateObjectCount());
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -1617,6 +1617,7 @@ public class MachineTest {
         assertTrue(machine.isEmpty());
     }
 
+    @Test
     public void testDuplicateKeyLastOneWins() throws Exception {
         final Machine machine = new Machine();
         String event1 = "{\n" +

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2088,7 +2088,7 @@ public class MachineTest {
                         "    \"c\": [{ \"numeric\": [\">\", 50] }]\n" +
                         "}");
 
-        assertEquals(517, machine.approximateObjectCount());
+        assertEquals(518, machine.approximateObjectCount());
     }
 
     @Test
@@ -2139,7 +2139,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(25, machine.approximateObjectCount());
+        assertEquals(26, machine.approximateObjectCount());
 
         machine.addRule("rule-with-six-elements",
                 "{\n" +
@@ -2148,7 +2148,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\",\"Name6\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(35, machine.approximateObjectCount());
+        assertEquals(37, machine.approximateObjectCount());
 
 
         machine.addRule("rule-with-six-more-elements",
@@ -2158,7 +2158,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name7\",\"Name8\",\"Name9\",\"Name10\",\"Name11\",\"Name12\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(60, machine.approximateObjectCount());
+        assertEquals(63, machine.approximateObjectCount());
     }
 
     @Test
@@ -2171,7 +2171,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(35, machine.approximateObjectCount());
+        assertEquals(36, machine.approximateObjectCount());
 
         machine.addRule("rule-with-two-more-source-and-eventNames",
                 "{\n" +
@@ -2180,7 +2180,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name1\",\"Name2\",\"Name3\",\"Name4\",\"Name5\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(48, machine.approximateObjectCount());
+        assertEquals(50, machine.approximateObjectCount());
 
         machine.addRule("rule-with-more-unique-source-and-eventNames",
                 "{\n" +
@@ -2189,7 +2189,7 @@ public class MachineTest {
                         "        \"eventName\": [\"Name6\",\"Name7\",\"Name8\",\"Name9\",\"Name10\"]\n" +
                         "    }\n" +
                         "}");
-        assertEquals(87, machine.approximateObjectCount());
+        assertEquals(90, machine.approximateObjectCount());
     }
 
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2145,6 +2145,26 @@ public class MachineTest {
     }
 
     @Test
+    public void testInitialSharedNameStateAlreadyExistsWithNonLeadingValue() throws Exception {
+        // When rule2 is added, a NameState will already exist for bar=b. Adding bar=a will lead to a new initial
+        // NameState, and then the existing NameState for bar=b will be encountered.
+        String rule1 = "{\"bar\" :[\"b\"], \"foo\": [\"c\"]}";
+        String rule2 = "{\"bar\": [\"a\", \"b\"], \"foo\": [\"c\"]}";
+
+        Machine machine = new Machine();
+
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{\"bar\": \"a\"," +
+                "\"foo\": \"c\"}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2005,6 +2005,27 @@ public class MachineTest {
     }
 
     @Test
+    public void testInitialSharedNameStateWithTwoMustNotExistsIsTerminalForOnlyOne() throws Exception {
+        // Initial NameState has two different (bar and foo) exists=false patterns. One is terminal, whereas the other
+        // leads to another NameState with another key (zoo).
+        String rule1 = "{\"bar\": [{\"exists\": false}]}";
+        String rule2 = "{\"foo\": [{\"exists\": false}], \"zoo\": [\"a\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"zoo\": \"a\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(2, matches.size());
+        assertTrue(matches.contains("rule1"));
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2128,6 +2128,23 @@ public class MachineTest {
     }
 
     @Test
+    public void testSharedNameStateWithTwoSubRulesDifferingAtFirstNameState() throws Exception {
+        // Two different sub-rules here with a NameState after bar and after foo: (bar=1, foo=a) and (bar=2, foo=a).
+        String rule1 = "{\"$or\": [{\"bar\": [\"1\"]}, {\"bar\": [\"2\"]}]," +
+                        "\"foo\": [\"a\"] }";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+
+        String event = "{\"bar\": \"2\"," +
+                        "\"foo\": \"a\"}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";
@@ -2214,7 +2231,7 @@ public class MachineTest {
 
         // Adding rule with non-terminal key having superset of values will be treated as new rule and increase count
         machine.addRule("r1", rule1b);
-        assertEquals(87, machine.approximateObjectCount());
+        assertEquals(91, machine.approximateObjectCount());
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class NameStateTest {
@@ -20,12 +21,10 @@ public class NameStateTest {
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
         nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(asList(1.0, 3.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(asList(2.0)), nameState.getSubRuleIds(Patterns.exactMatch("b"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds(Patterns.exactMatch("c"), true));
-        // Implementation detail: non-terminal returns null instead of empty set
-        assertEquals(null, nameState.getSubRuleIds(Patterns.exactMatch("a"), false));
-        assertEquals(null, nameState.getSubRuleIds(Patterns.exactMatch("b"), false));
+        assertEquals(new HashSet<>(asList(1.0, 3.0)),
+                nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(asList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
+        assertNull(nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
@@ -33,17 +32,15 @@ public class NameStateTest {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertFalse(nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true));
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertFalse(nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertFalse(nameState.deleteSubRule("rule1", 2.0, Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertFalse(nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), false));
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
-        assertTrue(nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule(1.0, Patterns.exactMatch("b"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule(2.0, Patterns.exactMatch("a"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), false);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), true);
+        assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
@@ -60,54 +57,40 @@ public class NameStateTest {
     }
 
     @Test
-    public void testGetTerminalSubRulesForPattern() {
+    public void testGetNonTerminalPatterns() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), false);
+
+        Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
+                Patterns.exactMatch("a"), Patterns.exactMatch("c")));
+        assertEquals(expectedPatterns, nameState.getNonTerminalPatterns());
+    }
+
+    @Test
+    public void testGetTerminalSubRuleIdsForPattern() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), true);
         nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("b"), false);
         nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("a"), true);
 
-        Set<NameState.SubRule> expectedSubRules = new HashSet<>(Arrays.asList(
-                new NameState.SubRule("rule1", 2.0), new NameState.SubRule("rule3", 4.0)));
-        assertEquals(expectedSubRules, nameState.getTerminalSubRulesForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(Arrays.asList(2.0, 4.0)),
+                nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
-    public void testGetNonTerminalSubRulesForPattern() {
+    public void testGetNonTerminalSubRuleIdsForPattern() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
         nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
         nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("b"), false);
 
-        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 3.0));
-        assertEquals(expectedSubRuleIds, nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
-    }
-
-    @Test
-    public void testGetSubRuleIdsForNonTerminal() {
-        NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule1", 4.0, Patterns.exactMatch("b"), false);
-        nameState.addSubRule("rule1", 5.0, Patterns.exactMatch("a"), false);
-
-        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 3.0, 5.0));
-        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds(Patterns.exactMatch("a"), false));
-    }
-
-    @Test
-    public void testGetSubRuleIdsForTerminal() {
-        NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 4.0, Patterns.exactMatch("b"), false);
-        nameState.addSubRule("rule1", 5.0, Patterns.exactMatch("a"), true);
-
-        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(1.0, 3.0, 5.0));
-        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(Arrays.asList(2.0, 3.0)),
+                nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class NameStateTest {
@@ -59,19 +57,6 @@ public class NameStateTest {
         Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
                 Patterns.exactMatch("a"), Patterns.exactMatch("c")));
         assertEquals(expectedPatterns, nameState.getTerminalPatterns());
-    }
-
-    @Test
-    public void testGetNonTerminalPatterns() {
-        NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), false);
-
-        Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
-                Patterns.exactMatch("a"), Patterns.exactMatch("c")));
-        assertEquals(expectedPatterns, nameState.getNonTerminalPatterns());
     }
 
     @Test
@@ -137,17 +122,5 @@ public class NameStateTest {
         assertTrue(nameState.containsRule("rule1", Patterns.exactMatch("b")));
         assertFalse(nameState.containsRule("rule3", Patterns.exactMatch("a")));
         assertFalse(nameState.containsRule("rule1", Patterns.exactMatch("c")));
-    }
-
-    @Test
-    public void testGetNextNameState() {
-        NameState nameState = new NameState();
-        NameState nextNameState1 = new NameState();
-
-        nameState.addNextNameState("key1", nextNameState1);
-        assertSame(nextNameState1, nameState.getNextNameState("key1"));
-        assertNull(nameState.getNextNameState("key2"));
-        nameState.removeNextNameState("key1");
-        assertNull(nameState.getNextNameState("key1"));
     }
 }

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -31,16 +31,25 @@ public class NameStateTest {
     public void testDeleteSubRule() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", 2.0, Patterns.exactMatch("b"), true);
 
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(asList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
         nameState.deleteSubRule(1.0, Patterns.exactMatch("b"), true);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(asList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
+        nameState.deleteSubRule(2.0, Patterns.exactMatch("b"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
         nameState.deleteSubRule(2.0, Patterns.exactMatch("a"), true);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
         nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), false);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
         nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), true);
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -8,26 +8,24 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class NameStateTest {
 
     @Test
-    public void tesAddSubRule() {
+    public void testAddSubRule() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
         nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(asList(2.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("b"), true));
-        assertEquals(new HashSet<>(asList(3.0)), nameState.getSubRuleIds("rule2", Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("c"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule2", Patterns.exactMatch("b"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule3", Patterns.exactMatch("a"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule3", Patterns.exactMatch("b"), true));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), false));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("b"), false));
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule2", Patterns.exactMatch("a"), false));
+        assertEquals(new HashSet<>(asList(1.0, 3.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(2.0)), nameState.getSubRuleIds(Patterns.exactMatch("b"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds(Patterns.exactMatch("c"), true));
+        // Implementation detail: non-terminal returns null instead of empty set
+        assertEquals(null, nameState.getSubRuleIds(Patterns.exactMatch("a"), false));
+        assertEquals(null, nameState.getSubRuleIds(Patterns.exactMatch("b"), false));
     }
 
     @Test
@@ -35,17 +33,17 @@ public class NameStateTest {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true);
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), true);
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        nameState.deleteSubRule("rule1", 2.0, Patterns.exactMatch("a"), true);
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), false);
-        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
-        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertFalse(nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertFalse(nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertFalse(nameState.deleteSubRule("rule1", 2.0, Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertFalse(nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), false));
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
+        assertTrue(nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
     }
 
     @Test
@@ -82,13 +80,12 @@ public class NameStateTest {
         nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
         nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("b"), false);
 
-        Set<NameState.SubRule> expectedSubRules = new HashSet<>(Arrays.asList(
-                new NameState.SubRule("rule1", 2.0), new NameState.SubRule("rule2", 3.0)));
-        assertEquals(expectedSubRules, nameState.getNonTerminalSubRulesForPattern(Patterns.exactMatch("a")));
+        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 3.0));
+        assertEquals(expectedSubRuleIds, nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
-    public void testGetSubRuleIds() {
+    public void testGetSubRuleIdsForNonTerminal() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
@@ -96,7 +93,20 @@ public class NameStateTest {
         nameState.addSubRule("rule1", 4.0, Patterns.exactMatch("b"), false);
         nameState.addSubRule("rule1", 5.0, Patterns.exactMatch("a"), false);
 
-        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 5.0));
-        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), false));
+        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 3.0, 5.0));
+        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds(Patterns.exactMatch("a"), false));
+    }
+
+    @Test
+    public void testGetSubRuleIdsForTerminal() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 4.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule1", 5.0, Patterns.exactMatch("a"), true);
+
+        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(1.0, 3.0, 5.0));
+        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
     }
 }

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -109,4 +109,18 @@ public class NameStateTest {
         Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(1.0, 3.0, 5.0));
         assertEquals(expectedSubRuleIds, nameState.getSubRuleIds(Patterns.exactMatch("a"), true));
     }
+
+    @Test
+    public void testContainsTerminalSubRule() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", 2.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), false);
+
+        assertTrue(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("a")));
+        assertFalse(nameState.containsTerminalSubRule("rule2", Patterns.exactMatch("a")));
+        assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("b")));
+        assertFalse(nameState.containsTerminalSubRule("rule3", Patterns.exactMatch("a")));
+        assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("c")));
+    }
 }

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -126,17 +126,17 @@ public class NameStateTest {
     }
 
     @Test
-    public void testContainsTerminalSubRule() {
+    public void testContainsRule() {
         NameState nameState = new NameState();
         nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
         nameState.addSubRule("rule2", 2.0, Patterns.exactMatch("a"), false);
         nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), false);
 
-        assertTrue(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("a")));
-        assertFalse(nameState.containsTerminalSubRule("rule2", Patterns.exactMatch("a")));
-        assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("b")));
-        assertFalse(nameState.containsTerminalSubRule("rule3", Patterns.exactMatch("a")));
-        assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("c")));
+        assertTrue(nameState.containsRule("rule1", Patterns.exactMatch("a")));
+        assertTrue(nameState.containsRule("rule2", Patterns.exactMatch("a")));
+        assertTrue(nameState.containsRule("rule1", Patterns.exactMatch("b")));
+        assertFalse(nameState.containsRule("rule3", Patterns.exactMatch("a")));
+        assertFalse(nameState.containsRule("rule1", Patterns.exactMatch("c")));
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -1,0 +1,102 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class NameStateTest {
+
+    @Test
+    public void tesAddSubRule() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
+
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(asList(2.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("b"), true));
+        assertEquals(new HashSet<>(asList(3.0)), nameState.getSubRuleIds("rule2", Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("c"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule2", Patterns.exactMatch("b"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule3", Patterns.exactMatch("a"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule3", Patterns.exactMatch("b"), true));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), false));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("b"), false));
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule2", Patterns.exactMatch("a"), false));
+    }
+
+    @Test
+    public void testDeleteSubRule() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        nameState.deleteSubRule("rule1", 2.0, Patterns.exactMatch("a"), true);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        nameState.deleteSubRule("rule2", 1.0, Patterns.exactMatch("a"), false);
+        assertEquals(new HashSet<>(asList(1.0)), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        assertEquals(new HashSet<>(), nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), true));
+    }
+
+    @Test
+    public void testGetTerminalPatterns() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), true);
+
+        Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
+                Patterns.exactMatch("a"), Patterns.exactMatch("c")));
+        assertEquals(expectedPatterns, nameState.getTerminalPatterns());
+    }
+
+    @Test
+    public void testGetTerminalSubRulesForPattern() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("a"), true);
+
+        Set<NameState.SubRule> expectedSubRules = new HashSet<>(Arrays.asList(
+                new NameState.SubRule("rule1", 2.0), new NameState.SubRule("rule3", 4.0)));
+        assertEquals(expectedSubRules, nameState.getTerminalSubRulesForPattern(Patterns.exactMatch("a")));
+    }
+
+    @Test
+    public void testGetNonTerminalSubRulesForPattern() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("b"), false);
+
+        Set<NameState.SubRule> expectedSubRules = new HashSet<>(Arrays.asList(
+                new NameState.SubRule("rule1", 2.0), new NameState.SubRule("rule2", 3.0)));
+        assertEquals(expectedSubRules, nameState.getNonTerminalSubRulesForPattern(Patterns.exactMatch("a")));
+    }
+
+    @Test
+    public void testGetSubRuleIds() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", 4.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule1", 5.0, Patterns.exactMatch("a"), false);
+
+        Set<Double> expectedSubRuleIds = new HashSet<>(Arrays.asList(2.0, 5.0));
+        assertEquals(expectedSubRuleIds, nameState.getSubRuleIds("rule1", Patterns.exactMatch("a"), false));
+    }
+}

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class NameStateTest {
@@ -57,6 +59,19 @@ public class NameStateTest {
         Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
                 Patterns.exactMatch("a"), Patterns.exactMatch("c")));
         assertEquals(expectedPatterns, nameState.getTerminalPatterns());
+    }
+
+    @Test
+    public void testGetNonTerminalPatterns() {
+        NameState nameState = new NameState();
+        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), false);
+
+        Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
+                Patterns.exactMatch("a"), Patterns.exactMatch("c")));
+        assertEquals(expectedPatterns, nameState.getNonTerminalPatterns());
     }
 
     @Test
@@ -122,5 +137,17 @@ public class NameStateTest {
         assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("b")));
         assertFalse(nameState.containsTerminalSubRule("rule3", Patterns.exactMatch("a")));
         assertFalse(nameState.containsTerminalSubRule("rule1", Patterns.exactMatch("c")));
+    }
+
+    @Test
+    public void testGetNextNameState() {
+        NameState nameState = new NameState();
+        NameState nextNameState1 = new NameState();
+
+        nameState.addNextNameState("key1", nextNameState1);
+        assertSame(nextNameState1, nameState.getNextNameState("key1"));
+        assertNull(nameState.getNextNameState("key2"));
+        nameState.removeNextNameState("key1");
+        assertNull(nameState.getNextNameState("key1"));
     }
 }

--- a/src/test/software/amazon/event/ruler/NameStateWithPatternTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateWithPatternTest.java
@@ -1,0 +1,64 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class NameStateWithPatternTest {
+
+    @Test
+    public void testNullNameState() {
+        try {
+            new NameStateWithPattern(null, Patterns.existencePatterns());
+            fail("Expected NullPointerException");
+        } catch (NullPointerException e) { }
+    }
+
+    @Test
+    public void testNullPattern() {
+        // null pattern is allowed due to the case that the NameState is the starting state of a Machine.
+        new NameStateWithPattern(new NameState(), null);
+    }
+
+    @Test
+    public void testGetters() {
+        NameState nameState = new NameState();
+        Patterns pattern = Patterns.exactMatch("abc");
+        NameStateWithPattern nameStateWithPattern = new NameStateWithPattern(nameState, pattern);
+        assertSame(nameState, nameStateWithPattern.getNameState());
+        assertSame(pattern, nameStateWithPattern.getPattern());
+    }
+
+    @Test
+    public void testEquals() {
+        NameState nameState1 = new NameState();
+        NameState nameState2 = new NameState();
+        Patterns pattern1 = Patterns.exactMatch("abc");
+        Patterns pattern2 = Patterns.exactMatch("def");
+        assertTrue(new NameStateWithPattern(nameState1, pattern1).equals(
+                new NameStateWithPattern(nameState1, pattern1)));
+        assertFalse(new NameStateWithPattern(nameState1, pattern1).equals(
+                new NameStateWithPattern(nameState2, pattern1)));
+        assertFalse(new NameStateWithPattern(nameState1, pattern1).equals(
+                new NameStateWithPattern(nameState1, pattern2)));
+    }
+
+    @Test
+    public void testHashCode() {
+        NameState nameState1 = new NameState();
+        NameState nameState2 = new NameState();
+        Patterns pattern1 = Patterns.exactMatch("abc");
+        Patterns pattern2 = Patterns.exactMatch("def");
+        assertEquals(new NameStateWithPattern(nameState1, pattern1).hashCode(),
+                new NameStateWithPattern(nameState1, pattern1).hashCode());
+        assertNotEquals(new NameStateWithPattern(nameState1, pattern1).hashCode(),
+                new NameStateWithPattern(nameState2, pattern1).hashCode());
+        assertNotEquals(new NameStateWithPattern(nameState1, pattern1).hashCode(),
+                new NameStateWithPattern(nameState1, pattern2).hashCode());
+    }
+}

--- a/src/test/software/amazon/event/ruler/SetOperationsTest.java
+++ b/src/test/software/amazon/event/ruler/SetOperationsTest.java
@@ -1,0 +1,36 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static software.amazon.event.ruler.SetOperations.intersection;
+
+public class SetOperationsTest {
+
+    @Test
+    public void testIntersection() {
+        Set<String> set1 = new HashSet<>(Arrays.asList("a", "b", "c"));
+        Set<String> set2 = new HashSet<>(Arrays.asList("b", "c", "d"));
+
+        Set<String> result = new HashSet<>();
+        intersection(set1, set2, result);
+
+        assertEquals(new HashSet<>(Arrays.asList("b", "c")), result);
+    }
+
+    @Test
+    public void testIntersectionDifferentResultType() {
+        String indexString = "abcd";
+        Set<String> set1 = new HashSet<>(Arrays.asList("a", "b", "c"));
+        Set<String> set2 = new HashSet<>(Arrays.asList("b", "c", "d"));
+
+        Set<Integer> result = new HashSet<>();
+        intersection(set1, set2, result, s -> indexString.indexOf(s));
+
+        assertEquals(new HashSet<>(Arrays.asList(1, 2)), result);
+    }
+}

--- a/src/test/software/amazon/event/ruler/SingleStateNameMatcherTest.java
+++ b/src/test/software/amazon/event/ruler/SingleStateNameMatcherTest.java
@@ -17,7 +17,7 @@ public class SingleStateNameMatcherTest {
 
     @Before
     public void setup() {
-        nameMatcher.addPattern(Patterns.absencePatterns(), () -> nameState);
+        nameMatcher.addPattern(Patterns.absencePatterns(), nameState);
     }
 
     @After
@@ -29,7 +29,7 @@ public class SingleStateNameMatcherTest {
     public void testInsertingSamePatternTwice_returnsThePreviouslyAddedNameState() {
         NameState anotherNameState = new NameState();
 
-        NameState state = nameMatcher.addPattern(Patterns.absencePatterns(), () -> anotherNameState);
+        NameState state = nameMatcher.addPattern(Patterns.absencePatterns(), anotherNameState);
         assertThat(state, is(equalTo(nameState)));
     }
 
@@ -38,7 +38,7 @@ public class SingleStateNameMatcherTest {
         nameMatcher.deletePattern(Patterns.absencePatterns());
 
         NameState anotherNameState = new NameState();
-        NameState state = nameMatcher.addPattern(Patterns.absencePatterns(), () -> anotherNameState);
+        NameState state = nameMatcher.addPattern(Patterns.absencePatterns(), anotherNameState);
         assertThat(state, is(equalTo(anotherNameState)));
     }
 

--- a/src/test/software/amazon/event/ruler/SubRuleContextTest.java
+++ b/src/test/software/amazon/event/ruler/SubRuleContextTest.java
@@ -1,0 +1,63 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SubRuleContextTest {
+
+    @Test
+    public void testGenerate() {
+        SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
+        SubRuleContext contextA1 = generatorA.generate();
+        SubRuleContext contextA2 = generatorA.generate();
+
+        SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
+        SubRuleContext contextB1 = generatorB.generate();
+        SubRuleContext contextB2 = generatorB.generate();
+        SubRuleContext contextB3 = generatorB.generate();
+
+        SubRuleContext contextA3 = generatorA.generate();
+
+        double expected1 = -Double.MAX_VALUE;
+        double expected2 = Math.nextUp(expected1);
+        double expected3 = Math.nextUp(expected2);
+        assertTrue(expected1 < expected2);
+        assertTrue(expected2 < expected3);
+        assertTrue(expected1 == contextA1.getId());
+        assertTrue(expected1 == contextB1.getId());
+        assertTrue(expected2 == contextA2.getId());
+        assertTrue(expected2 == contextB2.getId());
+        assertTrue(expected3 == contextA3.getId());
+        assertTrue(expected3 == contextB3.getId());
+    }
+
+    @Test
+    public void testEquals() {
+        SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
+        SubRuleContext contextA1 = generatorA.generate();
+        SubRuleContext contextA2 = generatorA.generate();
+
+        SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
+        SubRuleContext contextB1 = generatorB.generate();
+
+        assertTrue(contextA1.equals(contextB1));
+        assertFalse(contextA2.equals(contextB1));
+    }
+
+    @Test
+    public void testHashCode() {
+        SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
+        SubRuleContext contextA1 = generatorA.generate();
+        SubRuleContext contextA2 = generatorA.generate();
+
+        SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
+        SubRuleContext contextB1 = generatorB.generate();
+
+        assertEquals(contextA1.hashCode(), contextB1.hashCode());
+        assertNotEquals(contextA2.hashCode(), contextB1.hashCode());
+    }
+}


### PR DESCRIPTION
### Description of changes:

This is a continuation of https://github.com/aws/event-ruler/pull/75. I have closed out that pull request and opened this open.

Previously, Ruler would create a new NameState for every pattern. Now, NameStates are re-used across patterns for a given field.

The NameState is accessed via the pattern's ByteMatch at the end of the ByteMachine and provides access to the ByteMachine for the next field. So picture a rule with many fields, and for each of these fields, an array of many elements. Each array element is a pattern for the field. So this turns into a rapidly/exponentially expanding tree of NameStates and ByteMachines. But it's all unnecessary. Since the next field and its patterns will be the same no matter what value we use to match the current field, there is no reason not to re-use NameStates (and thus ByteMachines). This collapses an exponentially-expanding tree into a line. Or to word it another way, this changes Ruler's memory complexity from O(product of all array sizes) to O(sum of all array sizes).

This introduced the concept of "sub-rules". These already existed in Ruler as different parts of an "or" disjunction (whether explicitly with $or or implicitly by specifying the same rule name multiple times). But these sub-rules were often described as "rules" in the Ruler code. It became important to capture the distinction in this CR so we could ensure a machine traversal is satisfying a single sub-rule and not different parts of many sub-rules.

#### Benchmark / Performance (for source code changes):
Testing against one event with several large arrays, there was a 99.5% reduction in the number of ByteMatches created.

This is already running in a production environment and is achieving the same match results as the previous version of Ruler. This has led to a 70% reduction in GC activity, 45% reduction in heap usage, and 28% reduction in CPU. Latency to create a Ruler machine is down 35-90% at high percentiles, depending on the percentile.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
