### PR TITLE
Fixing CIDR matching to use floor of provided range

### DIFF
--- a/src/main/software/amazon/event/ruler/CIDR.java
+++ b/src/main/software/amazon/event/ruler/CIDR.java
@@ -75,8 +75,8 @@ public class CIDR {
     }
 
     /**
-     * Converts a string to an IP address literal to isCIDR format Range if this is possible.  If not
-     *  possible, returns null
+     * Converts a string to an IP address literal to isCIDR format Range if this is possible.
+     * If not possible, returns null.
      * @param ip String that might be an IP address literal
      * @return Range with isCIDR as true
      */
@@ -106,7 +106,7 @@ public class CIDR {
                 openTop = true;
             }
             return new Range(bottom, openBottom, top, openTop, true);
-        } catch (Exception e){
+        } catch (Exception e) {
             return null;
         }
     }

--- a/src/main/software/amazon/event/ruler/CIDR.java
+++ b/src/main/software/amazon/event/ruler/CIDR.java
@@ -11,7 +11,17 @@ import static software.amazon.event.ruler.Constants.MAX_DIGIT;
  */
 public class CIDR {
 
-    private final static byte[] TRAILING_MAX_BITS = { 0x0, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f };
+    /**
+     * Binary representation of these bytes is 1's followed by all 0's. The number of 0's is equal to the array index.
+     * So the binary values are: 11111111, 11111110, 11111100, 11111000, 11110000, 11100000, 11000000, 10000000, 00000000
+     */
+    private final static byte[] LEADING_MIN_BITS = { (byte) 0xff, (byte) 0xfe, (byte) 0xfc, (byte) 0xf8, (byte) 0xf0, (byte) 0xe0, (byte) 0xc0, (byte) 0x80, 0x00 };
+
+    /**
+     * Binary representation of these bytes is 0's followed by all 1's. The number of 1's is equal to the array index.
+     * So the binary values are: 00000000, 00000001, 00000011, 00000111, 00001111, 00011111, 00111111, 01111111, 11111111
+     */
+    private final static byte[] TRAILING_MAX_BITS = { 0x0, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, (byte) 0xff };
 
     private CIDR() { }
 
@@ -65,8 +75,8 @@ public class CIDR {
     }
 
     /**
-     * Converts a string to an IP address literal to isCIDR format Range if this is possible.
-     * If not possible, returns null.
+     * Converts a string to an IP address literal to isCIDR format Range if this is possible.  If not
+     *  possible, returns null
      * @param ip String that might be an IP address literal
      * @return Range with isCIDR as true
      */
@@ -96,7 +106,7 @@ public class CIDR {
                 openTop = true;
             }
             return new Range(bottom, openBottom, top, openTop, true);
-        } catch (Exception e) {
+        } catch (Exception e){
             return null;
         }
     }
@@ -128,8 +138,8 @@ public class CIDR {
             barf("Malformed CIDR, mask bits must not be negative");
         }
 
-        byte[] ip = ipToBytes(slashed[0]);
-        if (ip.length == 4) {
+        byte[] providedIp = ipToBytes(slashed[0]);
+        if (providedIp.length == 4) {
             if (maskBits > 31) {
                 barf("IPv4 mask bits must be < 32");
             }
@@ -139,32 +149,91 @@ public class CIDR {
             }
         }
 
-        byte[] maxBytes;
-        maxBytes = computeTopBytes(ip, maskBits);
-
-        return new Range(toHexDigits(ip), false, toHexDigits(maxBytes), false, true);
+        byte[] minBytes = computeBottomBytes(providedIp, maskBits);
+        byte[] maxBytes = computeTopBytes(providedIp, maskBits);
+        return new Range(toHexDigits(minBytes), false, toHexDigits(maxBytes), false, true);
     }
 
-    private static byte[] computeTopBytes(final byte[] baseBytes, int maskBits) {
+    /**
+     * Calculate the byte representation of the lowest IP address covered by the provided CIDR.
+     *
+     * @param baseBytes The byte representation of the IP address (left-of-slash) component of the provided CIDR.
+     * @param maskBits The integer (right-of-slash) of the provided CIDR.
+     * @return The byte representation of the lowest IP address covered by the provided CIDR.
+     */
+    private static byte[] computeBottomBytes(final byte[] baseBytes, final int maskBits) {
 
-        if (baseBytes.length == 4) {
-            maskBits = 32 - maskBits;
-        } else {
-            maskBits = 128 - maskBits;
-        }
-        byte[] maxBytes = new byte[baseBytes.length];
+        int variableBits = computeVariableBits(baseBytes, maskBits);
 
+        // Calculate the byte representation of the lowest IP address covered by the provided CIDR.
+        // Iterate from the least significant byte (right hand side) back to the most significant byte (left hand side).
+        byte[] minBytes = new byte[baseBytes.length];
         for (int i = baseBytes.length - 1; i >= 0; i--) {
-            if (maskBits >= 8) {
-                maxBytes[i] = (byte) 0xff;
-            } else if (maskBits <= 0) {
-                maxBytes[i] = baseBytes[i];
+
+            // This is the case where some or all of the byte is variable. So the min byte value possible is equal to
+            // the original IP address's bits for the leading non-variable bits and equal to all 0's for the trailing
+            // variable bits.
+            if (variableBits > 0) {
+                minBytes[i] = (byte) (baseBytes[i] & LEADING_MIN_BITS[Math.min(8, variableBits)]);
+
+                // There is no variable component to this byte. Thus, it must equal the byte from the original IP address in
+                // the provided CIDR.
             } else {
-                maxBytes[i] = (byte) (baseBytes[i] | TRAILING_MAX_BITS[maskBits]);
+                minBytes[i] = baseBytes[i];
             }
-            maskBits -= 8;
+
+            // Subtract 8 variable bits. We're effectively chopping off the least significant byte for next iteration.
+            variableBits -= 8;
         }
+
+        return minBytes;
+    }
+
+    /**
+     * Calculate the byte representation of the highest IP address covered by the provided CIDR.
+     *
+     * @param baseBytes The byte representation of the IP address (left-of-slash) component of the provided CIDR.
+     * @param maskBits The integer (right-of-slash) of the provided CIDR.
+     * @return The byte representation of the highest IP address covered by the provided CIDR.
+     */
+    private static byte[] computeTopBytes(final byte[] baseBytes, final int maskBits) {
+
+        int variableBits = computeVariableBits(baseBytes, maskBits);
+
+        // Calculate the byte representation of the highest IP address covered by the provided CIDR.
+        // Iterate from the least significant byte (right hand side) back to the most significant byte (left hand side).
+        byte[] maxBytes = new byte[baseBytes.length];
+        for (int i = baseBytes.length - 1; i >= 0; i--) {
+
+            // This is the case where some or all of the byte is variable. So the max byte value possible is equal to
+            // the original IP address's bits for the leading non-variable bits and equal to all 1's for the trailing
+            // variable bits.
+            if (variableBits > 0) {
+                maxBytes[i] = (byte) (baseBytes[i] | TRAILING_MAX_BITS[Math.min(8, variableBits)]);
+
+                // There is no variable component to this byte. Thus, it must equal the byte from the original IP address in
+                // the provided CIDR.
+            } else {
+                maxBytes[i] = baseBytes[i];
+            }
+
+            // Subtract 8 variable bits. We're effectively chopping off the least significant byte for next iteration.
+            variableBits -= 8;
+        }
+
         return maxBytes;
+    }
+
+    /**
+     * The maskBits in a provided CIDR refer to the number of leading bits in the binary representation of the IP
+     * address component that are fixed. Thus, variableBits refers to the number of remaining (trailing) bits.
+     *
+     * @param baseBytes The byte representation of the IP address (left-of-slash) component of the provided CIDR.
+     * @param maskBits The integer (right-of-slash) of the provided CIDR.
+     * @return The number of variable (trailing) bits after the fixed maskBits bits.
+     */
+    private static int computeVariableBits(final byte[] baseBytes, final int maskBits) {
+        return (baseBytes.length == 4 ? 32 : 128) - maskBits;
     }
 
     private static void barf(final String msg) throws IllegalArgumentException {

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -73,46 +73,46 @@ public class ACMachineTest {
 
     @Test
     public void testIPAddressOfCIDRIsEqualToMaximumOfRange() throws Exception {
-        String rule1 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.163.171/31\"}]}";
-        String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.164.255/24\"}]}";
-        String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"172.31.39.225/31\"}]}";
+        String rule1 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.153.171/31\"}]}";
+        String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.154.255/24\"}]}";
+        String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.59.225/31\"}]}";
 
         Machine machine = new Machine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
 
-        List<String> matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.170\"}");
+        List<String> matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.153.170\"}");
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.171\"}");
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.153.171\"}");
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.169\"}");
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.153.169\"}");
         assertTrue(matches.isEmpty());
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.172\"}");
-        assertTrue(matches.isEmpty());
-
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.164.0\"}");
-        assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule2"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.164.255\"}");
-        assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule2"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.255\"}");
-        assertTrue(matches.isEmpty());
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.165.0\"}");
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.153.172\"}");
         assertTrue(matches.isEmpty());
 
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.224\"}");
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.154.0\"}");
         assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule3"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.225\"}");
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.154.255\"}");
         assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule3"));
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.223\"}");
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.153.255\"}");
         assertTrue(matches.isEmpty());
-        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.226\"}");
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.155.0\"}");
+        assertTrue(matches.isEmpty());
+
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.59.224\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.59.225\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.59.223\"}");
+        assertTrue(matches.isEmpty());
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"220.160.59.226\"}");
         assertTrue(matches.isEmpty());
     }
 

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -71,6 +71,51 @@ public class ACMachineTest {
         }
     }
 
+    @Test
+    public void testIPAddressOfCIDRIsEqualToMaximumOfRange() throws Exception {
+        String rule1 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.163.171/31\"}]}";
+        String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.164.255/24\"}]}";
+        String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"172.31.39.225/31\"}]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+        machine.addRule("rule3", rule3);
+
+        List<String> matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.170\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.171\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.169\"}");
+        assertTrue(matches.isEmpty());
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.172\"}");
+        assertTrue(matches.isEmpty());
+
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.164.0\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.164.255\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.163.255\"}");
+        assertTrue(matches.isEmpty());
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"190.149.165.0\"}");
+        assertTrue(matches.isEmpty());
+
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.224\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.225\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.223\"}");
+        assertTrue(matches.isEmpty());
+        matches = machine.rulesForJSONEvent("{\"sourceIPAddress\": \"172.31.39.226\"}");
+        assertTrue(matches.isEmpty());
+    }
+
     private static final String JSON_FROM_README = "{\n" +
             "  \"version\": \"0\",\n" +
             "  \"id\": \"ddddd4-aaaa-7777-4444-345dd43cc333\",\n" +

--- a/src/test/software/amazon/event/ruler/CIDRTest.java
+++ b/src/test/software/amazon/event/ruler/CIDRTest.java
@@ -143,9 +143,8 @@ public class CIDRTest {
     public void TestCorrectRanges() {
 
         String[] addresses = {
-                // these first few aren't real CIDRs beause the IP address should end with the
-                //  right number of zeroes. But they're here to check the accuacy of the IP-address
-                //  parsing.
+                // The first few do not specify the minimum IP address of the CIDR range. But these are still real
+                // CIDRs. We must calculate the floor of the CIDR range ourselves.
                 "0011:2233:4455:6677:8899:aabb:ccdd:eeff/24",
                 "2001:db8::ff00:42:8329/24",
                 "::1/24",
@@ -162,11 +161,11 @@ public class CIDRTest {
                 "2600:1F14::/35"
         };
         String[] wanted = {
-                "00112233445566778899AABBCCDDEEFF/001122FFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
-                "20010DB8000000000000FF0000428329/20010DFFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
-                "00000000000000000000000000000001/000000FFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
+                "00112200000000000000000000000000/001122FFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
+                "20010D00000000000000000000000000/20010DFFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
+                "00000000000000000000000000000000/000000FFFFFFFFFFFFFFFFFFFFFFFFFF:false/false (T:NUMERIC_RANGE)",
                 "0A000000/0A0000FF:false/false (T:NUMERIC_RANGE)",
-                "36F0C4AB/36F0C4FF:false/false (T:NUMERIC_RANGE)",
+                "36F0C400/36F0C4FF:false/false (T:NUMERIC_RANGE)",
                 "C0000200/C00002FF:false/false (T:NUMERIC_RANGE)",
                 "0D200000/0D21FFFF:false/false (T:NUMERIC_RANGE)",
                 "1B000000/1B0003FF:false/false (T:NUMERIC_RANGE)",

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -74,46 +74,46 @@ public class MachineTest {
 
     @Test
     public void testIPAddressOfCIDRIsEqualToMaximumOfRange() throws Exception {
-        String rule1 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.163.171/31\"}]}";
-        String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"190.149.164.255/24\"}]}";
-        String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"172.31.39.225/31\"}]}";
+        String rule1 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.153.171/31\"}]}";
+        String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.154.255/24\"}]}";
+        String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.59.225/31\"}]}";
 
         Machine machine = new Machine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
 
-        List<String> matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.163.170\"}");
+        List<String> matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.153.170\"}");
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.163.171\"}");
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.153.171\"}");
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.163.169\"}");
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.153.169\"}");
         assertTrue(matches.isEmpty());
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.163.172\"}");
-        assertTrue(matches.isEmpty());
-
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.164.0\"}");
-        assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule2"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.164.255\"}");
-        assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule2"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.163.255\"}");
-        assertTrue(matches.isEmpty());
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"190.149.165.0\"}");
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.153.172\"}");
         assertTrue(matches.isEmpty());
 
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"172.31.39.224\"}");
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.154.0\"}");
         assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule3"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"172.31.39.225\"}");
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.154.255\"}");
         assertEquals(1, matches.size());
-        assertTrue(matches.contains("rule3"));
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"172.31.39.223\"}");
+        assertTrue(matches.contains("rule2"));
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.153.255\"}");
         assertTrue(matches.isEmpty());
-        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"172.31.39.226\"}");
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.155.0\"}");
+        assertTrue(matches.isEmpty());
+
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.59.224\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.59.225\"}");
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule3"));
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.59.223\"}");
+        assertTrue(matches.isEmpty());
+        matches = machine.rulesForEvent("{\"sourceIPAddress\": \"220.160.59.226\"}");
         assertTrue(matches.isEmpty());
     }
 


### PR DESCRIPTION
### Description of changes:

Previously, we would treat CIDR (of the form IP/bits) as a range from IP to maxBytes(IP, bits). But from my understanding of CIDR, the floor of the range should be a floored version of the provided IP, where the number of specified leading bits are fixed and the rest of the bits are set to 0's. So 255.255.255.127/24 means the whole last 8 bits, or last byte, or "127", is variable, so the CIDR range should be 255.255.255.0 to 255.255.255.255, not 255.255.255.127 to 255.255.255.255.

As a consequence of the current implementation, it is possible to create a CIDR that translates into a numeric range where the floor equals the ceiling. For example, 255.255.255.255/31. This violates assumptions built into numeric ranges in Ruler and leads to an ArrayIndexOutOfBoundsException. But if CIDRs get floored as described above, then it is no longer possible for the bottom to equal the top in the numeric range.

The gotchya with this change is that, by definition, we will now match a greater range of IP addresses to a CIDR. So this isn't entirely backwards compatible. However, looking internally at a (very large) usage of Ruler, CIDR is lightly used, and all but two uses of it specify the floor of the range as the provided IP anyway. Thus, I think it's sane to merge this change, as it is a more correct/expected handling of CIDR, and there is a very small potential of impact.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
