### PR TITLE
Adding transitionStore optimization back to ByteState

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteState.java
+++ b/src/main/software/amazon/event/ruler/ByteState.java
@@ -1,10 +1,13 @@
 package software.amazon.event.ruler;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a state in a state machine and maps utf-8 bytes to transitions. One byte can have many transitions,
@@ -13,7 +16,12 @@ import java.util.Set;
 @ThreadSafe
 class ByteState extends SingleByteTransition {
 
-    private final ByteMap map = new ByteMap();
+    /**
+     * The field is a {@link ByteMap}, however, to optimize on memory, this field may be {@code null} when this state
+     * contains no transitions, and may be a {@link SingleByteTransitionEntry} when this state contains one transition.
+     */
+    @Nullable
+    private volatile Object transitionStore;
 
     /* True if this state's placement in the machine means there is more than one possible value that can be matched on
      * a traversal from the start state to this state. This will happen, for example, when a wildcard or regex
@@ -51,7 +59,7 @@ class ByteState extends SingleByteTransition {
      * @return {@code true} if this state contains no transitions
      */
     boolean hasNoTransitions() {
-        return map.isEmpty();
+        return transitionStore == null;
     }
 
     /**
@@ -64,16 +72,40 @@ class ByteState extends SingleByteTransition {
      */
     @Override
     ByteTransition getTransition(byte utf8byte) {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return null;
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            return utf8byte == entry.utf8byte ? entry.transition : null;
+        }
+        ByteMap map = (ByteMap) transitionStore;
         return map.getTransition(utf8byte);
     }
 
     @Override
     ByteTransition getTransitionForAllBytes() {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null || transitionStore instanceof SingleByteTransitionEntry) {
+            return ByteMachine.EmptyByteTransition.INSTANCE;
+        }
+        ByteMap map = (ByteMap) transitionStore;
         return map.getTransitionForAllBytes();
     }
 
     @Override
     Set<ByteTransition> getTransitions() {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return Collections.emptySet();
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            return Stream.of(entry.transition).collect(Collectors.toSet());
+        }
+        ByteMap map = (ByteMap) transitionStore;
         return map.getTransitions();
     }
 
@@ -85,7 +117,24 @@ class ByteState extends SingleByteTransition {
      * @param transition the transition to be associated with the given byte value
      */
     void putTransition(byte utf8byte, @Nonnull SingleByteTransition transition) {
-        map.putTransition(utf8byte, transition);
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            this.transitionStore = new SingleByteTransitionEntry(utf8byte, transition);
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            if (utf8byte == entry.utf8byte) {
+                entry.transition = transition;
+            } else {
+                ByteMap map = new ByteMap();
+                map.putTransition(entry.utf8byte, entry.transition);
+                map.putTransition(utf8byte, transition);
+                this.transitionStore = map;
+            }
+        } else {
+            ByteMap map = (ByteMap) transitionStore;
+            map.putTransition(utf8byte, transition);
+        }
     }
 
     /**
@@ -95,7 +144,9 @@ class ByteState extends SingleByteTransition {
      * @param transition the transition to be associated with the given byte value
      */
     void putTransitionForAllBytes(@Nonnull SingleByteTransition transition) {
+        ByteMap map = new ByteMap();
         map.putTransitionForAllBytes(transition);
+        this.transitionStore = map;
     }
 
     /**
@@ -106,7 +157,20 @@ class ByteState extends SingleByteTransition {
      * @param transition the transition to be associated with the given byte value
      */
     void addTransition(byte utf8byte, @Nonnull SingleByteTransition transition) {
-        map.addTransition(utf8byte, transition);
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            this.transitionStore = new SingleByteTransitionEntry(utf8byte, transition);
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            ByteMap map = new ByteMap();
+            map.addTransition(entry.utf8byte, entry.transition);
+            map.addTransition(utf8byte, transition);
+            this.transitionStore = map;
+        } else {
+            ByteMap map = (ByteMap) transitionStore;
+            map.addTransition(utf8byte, transition);
+        }
     }
 
     /**
@@ -116,16 +180,47 @@ class ByteState extends SingleByteTransition {
      * @param transition the transition to be associated with all possible byte values
      */
     void addTransitionForAllBytes(final SingleByteTransition transition) {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        ByteMap map;
+        if (transitionStore instanceof ByteMap) {
+            map = (ByteMap) transitionStore;
+        } else {
+            map = new ByteMap();
+        }
+        if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            map.addTransition(entry.utf8byte, entry.transition);
+        }
         map.addTransitionForAllBytes(transition);
+        this.transitionStore = map;
     }
 
     /**
-     * Removes all transitions for the given byte value from this state.
+     * Removes provided transition for the given byte value from this state.
      *
-     * @param utf8byte the byte value whose transitions are to be removed from the state
+     * @param utf8byte the byte value for which to remove transition from the state
+     * @param transition remove this transition for provided byte value from the state
      */
     void removeTransition(byte utf8byte, SingleByteTransition transition) {
-        map.removeTransition(utf8byte, transition);
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return;
+        }
+
+        if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            if (utf8byte == entry.utf8byte && transition.equals(entry.transition)) {
+                this.transitionStore = null;
+            }
+        } else {
+            ByteMap map = (ByteMap) transitionStore;
+            map.removeTransition(utf8byte, transition);
+            if (map.isEmpty()) {
+                this.transitionStore = null;
+            }
+        }
     }
 
     /**
@@ -134,7 +229,24 @@ class ByteState extends SingleByteTransition {
      * @param transition the transition to be removed for all possible byte values
      */
     void removeTransitionForAllBytes(final SingleByteTransition transition) {
-        map.removeTransitionForAllBytes(transition);
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return;
+        }
+
+        if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            if (transition.equals(entry.transition)) {
+                this.transitionStore = null;
+            }
+        } else {
+            ByteMap map = (ByteMap) transitionStore;
+            map.removeTransitionForAllBytes(transition);
+            if (map.isEmpty()) {
+                this.transitionStore = null;
+            }
+        }
     }
 
     @Override
@@ -152,20 +264,64 @@ class ByteState extends SingleByteTransition {
      * @return True if this state has a self-referential transition and no others, false otherwise.
      */
     boolean hasOnlySelfReferentialTransition() {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return false;
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            return this.equals(entry.transition);
+        }
+        ByteMap map = (ByteMap) transitionStore;
         return map.numberOfTransitions() == 1 && map.hasTransition(this);
     }
 
     /**
-     * Gets all the ceiling values contained in the ByteMap.
+     * Gets all the ceiling values contained in the ByteMap or SingleByteTransitionEntry.
      *
-     * @return All the ceiling values contained in the ByteMap.
+     * @return All the ceiling values contained in the ByteMap or SingleByteTransitionEntry.
      */
     Set<Integer> getCeilings() {
+        // Saving the value to avoid reading an updated value
+        Object transitionStore = this.transitionStore;
+        if (transitionStore == null) {
+            return Collections.emptySet();
+        } else if (transitionStore instanceof SingleByteTransitionEntry) {
+            SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
+            int index = entry.utf8byte & 0xFF;
+            if (index == 0) {
+                return Stream.of(index + 1, 256).collect(Collectors.toSet());
+            } else if (index == 255) {
+                return Stream.of(index, index + 1).collect(Collectors.toSet());
+            } else {
+                return Stream.of(index, index + 1, 256).collect(Collectors.toSet());
+            }
+        }
+        ByteMap map = (ByteMap) transitionStore;
         return map.getCeilings();
     }
 
     @Override
     public String toString() {
-        return "BS: " + map;
+        return "BS: " + transitionStore;
+    }
+
+
+    private static final class SingleByteTransitionEntry {
+
+        final byte utf8byte;
+        volatile SingleByteTransition transition;
+
+        SingleByteTransitionEntry(byte utf8byte, SingleByteTransition transition) {
+            this.utf8byte = utf8byte;
+            this.transition = transition;
+        }
+
+        @Override
+        public String toString() {
+            ByteState next = transition.getNextByteState();
+            String nextLabel = (next == null) ? "null" : Integer.toString(next.hashCode());
+            return "SBTE: " + (char) utf8byte + "=>" + nextLabel;
+        }
     }
 }


### PR DESCRIPTION
### Description of changes:

I removed transitionStore in favor of ByteMap when adding wildcard matching.

transitionStore was an Object that could be null if 0 transitions were present, a simple object if 1 transition was present, or a Map if 2 transitions were present. I had replaced this with the new class ByteMap, which greatly simplified the code. However, it is not as memory efficient to always allocate a ByteMap. Hence, I am re-introducing transitionStore, which again, can be null, a simple object, or a ByteMap (for 2+ transitions). The downside of this is it does bloat the code quite a bit.

Through some crude testing, I expect this to replace nearly 50% of ByteMaps with the simple object SingleByteTransitionEntry. In this case (1 transition), my back-of-the-napkin math suggests ByteMap would require 96 bytes and SingleByteTransitionEntry would require 8 bytes, a 12x difference. So this is, on average, a 44 bytes saving for each ByteState.

I have run this in a high volume production environment and have observed a modest improvement in GC activity (maybe a 10% reduction).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
