### PR TITLE
Optimize CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,5 @@
 name: Java Build
+permissions: {}
 
 on:
   push:
@@ -7,16 +8,24 @@ on:
   pull_request:
     branches: ["main", "release-*"]
 
+concurrency:
+  group: java-build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        java: [ "8", "11", "17" ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
       - name: Verify with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn --batch-mode --errors --update-snapshots verify


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:

- Replaces `adopt` with `temurin` due to [1]
- Use `matrix` strategy testing to simplify the workflow file and allow for extensibility (easily add Java and OS versions)
- Also test against Java 11 (throws warnings due to `1.8` setting in `pom.xml` - nothing to worry, unless we want to change the configuration to avoid those)
- Log maven errors with `--errors`
- Uses caching for dependencies to speed up decrease execution times
- Uses `concurrency` setting to cancel running workflows when new commits are pushed to the PR (reduce usage/resource waste)
- Explicitly define permissions for the workflow to reduce attack surface (`{}` i.e. none)

[1]

> NOTE: AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt and adopt-openj9, to temurin and semeru respectively, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

Source: https://github.com/actions/setup-java

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
