### PR TITLE
Address JDK17 compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <jdk.version>1.8</jdk.version>
+    <jdk.release.version>8</jdk.release.version>
     <jackson.version>2.15.0</jackson.version>
     <jsr.version>3.0.2</jsr.version>
     <junit.version>4.13.2</junit.version>
@@ -110,8 +111,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler.plugin.version}</version>
         <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
+          <!-- JDK11+ warn about rulesForEvent() being deprecated -->
+          <release>${jdk.release.version}</release>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -225,7 +225,7 @@ public class GenericMachine<T> {
      *  want to remove partial rule from rule name.
      *
      * @param name ARN of the rule
-     * @param namevals names & values which make up the rule
+     * @param namevals names and values which make up the rule
      */
     public void deletePatternRule(final T name, final Map<String, List<Patterns>> namevals) {
         if (namevals.size() > MAXIMUM_RULE_SIZE) {


### PR DESCRIPTION
These showed up as part of https://github.com/aws/event-ruler/pull/95

You can see the errors in "Verify with Maven" step in builds https://github.com/aws/event-ruler/actions/runs/4934093826/jobs/8818724018?pr=95

```
[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @
event-ruler ---
[INFO] Changes detected - recompiling the module! :source
[INFO] Compiling 52 source files with javac [debug target 1.8] to
target/classes
Warning:  bootstrap class path not set in conjunction with -source 8
```

```
Warning:  Javadoc Warnings
Warning: [WARNING] warning: The code being documented uses modules but the
packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the
unnamed module.
Warning:
/home/runner/work/event-ruler/event-ruler/src/main/software/amazon/event/ruler/GenericMachine.java:228:
warning: invalid input: '&'
Warning:  * @param namevals names & values which make up the rule
Warning:  ^
Warning: [WARNING] 2 warnings
```

This change fixes these errors.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
