### PR TITLE
Fixing shortcut expansion bug caused by equality comparison between InputByte and InputMultiByteSet

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -831,13 +831,12 @@ class ByteMachine {
         }
 
         // Scenario 2 where multiple transitions will later converge: equals_ignore_case lower and upper case paths.
-        // Parse the next Java character into lower and upper case multibyte representations. Check if there are
-        // multiple multibytes (paths) and that there exists a transition that both lead to.
+        // Parse the next Java character into lower and upper case representations. Check if there are multiple
+        // multibytes (paths) and that there exists a transition that both lead to.
         String value = extractNextJavaCharacterFromInputCharacters(characters, i);
         InputCharacter[] inputCharacters = getParser().parse(MatchType.EQUALS_IGNORE_CASE, value);
-        InputMultiByteSet inputMultiByteSet = InputMultiByteSet.cast(inputCharacters[0]);
-        ByteTransition transition = getTransition(byteState, inputMultiByteSet);
-        return inputMultiByteSet.getMultiBytes().size() > 1 && transition != null;
+        ByteTransition transition = getTransition(byteState, inputCharacters[0]);
+        return inputCharacters[0] instanceof InputMultiByteSet && transition != null;
     }
 
     private boolean isNextCharacterFirstByteOfMultiByte(InputCharacter[] characters, int i) {

--- a/src/main/software/amazon/event/ruler/input/EqualsIgnoreCaseParser.java
+++ b/src/main/software/amazon/event/ruler/input/EqualsIgnoreCaseParser.java
@@ -1,33 +1,42 @@
 package software.amazon.event.ruler.input;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
 /**
- * A parser to be used specifically for equals-ignore-case rules.
+ * A parser to be used specifically for equals-ignore-case rules. For Java characters where lower and upper case UTF-8
+ * representations do not differ, we will parse into InputBytes. Otherwise, we will use InputMultiByteSet.
  *
  * Note that there are actually characters whose upper-case/lower-case UTF-8 representations differ in number of bytes.
  * One example where length differs by 1: ⱥ, Ⱥ
  * One example where length differs by 4: ΰ, Ϋ́
- * To deal with differing byte lengths per Java character, we will parse each Java character into an InputMultiByteSet.
+ * InputMultiByteSet handles differing byte lengths per Java character.
  */
-public class EqualsIgnoreCaseParser implements StringValueParser {
+public class EqualsIgnoreCaseParser {
 
     EqualsIgnoreCaseParser() { }
 
-    public InputCharacter[] parse(final String value) {
-        int i = 0;
-        final InputCharacter[] result = new InputCharacter[value.length()];
+    public InputCharacter[] parse(String value) {
+        List<InputCharacter> result = new ArrayList<>(value.length());
         for (char c : value.toCharArray()) {
-            byte[] lower = String.valueOf(c).toLowerCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8);
-            byte[] upper = String.valueOf(c).toUpperCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8);
-            Set<MultiByte> multi = new HashSet<>();
-            multi.add(new MultiByte(lower));
-            multi.add(new MultiByte(upper));
-            result[i++] = new InputMultiByteSet(multi);
+            byte[] lowerCaseUtf8bytes = String.valueOf(c).toLowerCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8);
+            byte[] upperCaseUtf8bytes = String.valueOf(c).toUpperCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8);
+            if (Arrays.equals(lowerCaseUtf8bytes, upperCaseUtf8bytes)) {
+                for (int i = 0; i < lowerCaseUtf8bytes.length; i++) {
+                    result.add(new InputByte(lowerCaseUtf8bytes[i]));
+                }
+            } else {
+                Set<MultiByte> multiBytes = new HashSet<>();
+                multiBytes.add(new MultiByte(lowerCaseUtf8bytes));
+                multiBytes.add(new MultiByte(upperCaseUtf8bytes));
+                result.add(new InputMultiByteSet(multiBytes));
+            }
         }
-        return result;
+        return result.toArray(new InputCharacter[0]);
     }
 }

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -1061,6 +1061,17 @@ public class ByteMachineTest {
     }
 
     @Test
+    public void testEqualsIgnoreCaseWithExactMatchLeadingCharacterSameLowerAndUpperCase() {
+        String[] noMatches = new String[] { "", "!", "!A", "a", "A", "b", "B" };
+        testPatternPermutations(noMatches,
+                new PatternMatch(Patterns.equalsIgnoreCaseMatch("!b"),
+                        "!b", "!B"),
+                new PatternMatch(Patterns.exactMatch("!a"),
+                        "!a")
+        );
+    }
+
+    @Test
     public void testWildcardSingleWildcardCharacter() {
         testPatternPermutations(
                 new PatternMatch(Patterns.wildcardMatch("*"),

--- a/src/test/software/amazon/event/ruler/input/EqualsIgnoreCaseParserTest.java
+++ b/src/test/software/amazon/event/ruler/input/EqualsIgnoreCaseParserTest.java
@@ -36,22 +36,22 @@ public class EqualsIgnoreCaseParserTest {
     public void testParseSimpleStringWithNonLetters() {
         assertArrayEquals(new InputCharacter[] {
                 set(new MultiByte((byte) 97), new MultiByte((byte) 65)),
-                set(new MultiByte((byte) 49)),
+                new InputByte((byte) 49),
                 set(new MultiByte((byte) 98), new MultiByte((byte) 66)),
-                set(new MultiByte((byte) 50)),
+                new InputByte((byte) 50),
                 set(new MultiByte((byte) 99), new MultiByte((byte) 67)),
-                set(new MultiByte((byte) 33)),
+                new InputByte((byte) 33),
         }, parser.parse("a1B2c!"));
     }
 
     @Test
     public void testParseStringWithSingleBytesMultiBytesCharactersNonCharactersAndDifferingLengthMultiBytes() {
         assertArrayEquals(new InputCharacter[] {
-                set(new MultiByte((byte) 49)),
+                new InputByte((byte) 49),
                 set(new MultiByte((byte) 97), new MultiByte((byte) 65)),
                 set(new MultiByte((byte) 97), new MultiByte((byte) 65)),
-                set(new MultiByte((byte) 42)),
-                set(new MultiByte((byte) -30, (byte) -128, (byte) -96)),
+                new InputByte((byte) 42),
+                new InputByte((byte) -30), new InputByte((byte) -128), new InputByte((byte) -96),
                 set(new MultiByte((byte) -61, (byte) -87), new MultiByte((byte) -61, (byte) -119)),
                 set(new MultiByte((byte) -30, (byte) -79, (byte) -91), new MultiByte((byte) -56, (byte) -70))
         }, parser.parse("1aA*†Éⱥ"));


### PR DESCRIPTION
### Description of changes:

The bug occurred when a shortcut transition existed, then an equals-ignore-case rule gets added and tries to expand the shortcut. This logic involves an equals comparison between each InputCharacter from the original value added and the current value added. This occurs on ByteMachine line 1402. Since a shortcut transition came from an exact match, it will be represented by InputBytes, where as the equals-ignore-case match will be represented by InputMultiByteSets. This means the equality check will always return false. I considered changing the equality checks to allow a single byte InputMultiByteSet to equal an InputByte, but that would be a misleading equals implementation. Instead, I changed the equals-ignore-case parser to parse into InputBytes when lower and upper case representations are the same. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
