### PR TITLE
Performance improvements on the addPattern code path. Avoiding lots of unnecessary Set creations.

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -264,7 +264,7 @@ class ByteMachine {
             ByteTransition skipWildcardTransition = getTransition(byteState, characters[charIndex + 1]);
             for (SingleByteTransition eachTrans : skipWildcardTransition.expand()) {
                 ByteState skipWildcardState = eachTrans.getNextByteState();
-                if (eachTrans.getMatches().isEmpty() && skipWildcardState != null &&
+                if (!eachTrans.getMatches().iterator().hasNext() && skipWildcardState != null &&
                         (skipWildcardState.hasNoTransitions() ||
                          skipWildcardState.hasOnlySelfReferentialTransition())) {
                     removeTransition(byteState, characters[charIndex + 1], eachTrans);
@@ -1926,7 +1926,7 @@ class ByteMachine {
         }
     }
 
-    private static ByteMatch findMatch(Set<ByteMatch> matches, Patterns pattern) {
+    private static ByteMatch findMatch(Iterable<ByteMatch> matches, Patterns pattern) {
         for (ByteMatch match : matches) {
             if (match.getPattern().equals(pattern)) {
                 return match;

--- a/src/main/software/amazon/event/ruler/ByteMap.java
+++ b/src/main/software/amazon/event/ruler/ByteMap.java
@@ -1,5 +1,6 @@
 package software.amazon.event.ruler;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -47,7 +48,7 @@ class ByteMap {
         for (Map.Entry<Integer, ByteTransition> entry : newMap.entrySet()) {
             Set<SingleByteTransition> newSingles = new HashSet<>();
             ByteTransition storedTransition = entry.getValue();
-            newSingles.addAll(expand(storedTransition));
+            expand(storedTransition).forEach(single -> newSingles.add(single));
             newSingles.add(transition);
             entry.setValue(coalesce(newSingles));
         }
@@ -63,7 +64,7 @@ class ByteMap {
         for (Map.Entry<Integer, ByteTransition> entry : newMap.entrySet()) {
             Set<SingleByteTransition> newSingles = new HashSet<>();
             ByteTransition storedTransition = entry.getValue();
-            newSingles.addAll(expand(storedTransition));
+            expand(storedTransition).forEach(single -> newSingles.add(single));
             newSingles.remove(transition);
             entry.setValue(coalesce(newSingles));
         }
@@ -71,57 +72,42 @@ class ByteMap {
     }
 
     /**
-     *  Updates one ceiling=>transition mapping and leaves the map in a consistent state.
-     *  It's a two-step process. First of all, we go through the map and find the entry that contains the byte value.
-     *  Then we figure out whether the new byte value is at the bottom and/or the top of the entry (can be both if it's
-     *  a singleton mapping). If it's not at the bottom, we write a new entry representing the part of the entry less
-     *  than the byte value. Then we write a new entry for the byte value. Then if not at the top we write a new entry
-     *  representing the proportion greater than the byte value. Then we merge entries mapping to the same transition.
-     *  One effect is that you can remove the transition at position X by putting (X, null). An earlier implementation
-     *  expanded the map to a ByteMapExtent[256] array of singletons, did the update, then contracted it, but that drove
-     *  the compute/memory cost up so much that addRule and deleteRule were showing up in the profiler. Another earlier
-     *  implementation tried to do the merging at the same time as the entry wrangling and dissolved into an
-     *  incomprehensible pile of special-case code.
+     *  Updates one ceiling=>transition mapping and leaves the map in a consistent state. We go through the map and find
+     *  the entry that contains the byte value. If the new byte value is not at the bottom of the entry, we write a new
+     *  entry representing the part of the entry less than the byte value. Then we write a new entry for the byte value.
+     *  Then we merge entries mapping to the same transition.
      */
     private void updateTransition(final byte utf8byte, final SingleByteTransition transition, Operation operation) {
         final int index = utf8byte & 0xFF;
-        final NavigableMap<Integer, ByteTransition> newMap = new TreeMap<>();
+        ByteTransition target =  map.higherEntry(index).getValue();
 
-        newMap.putAll(map.headMap(index, true));
-        Map.Entry<Integer, ByteTransition> targetEntry = map.higherEntry(index);
-        int targetCeiling = targetEntry.getKey();
-        ByteTransition target = targetEntry.getValue();
-
-        final boolean atBottom = (index == 0) || (!newMap.isEmpty() && newMap.lastKey() == index);
-        if (!atBottom) {
-            newMap.put(index, target);
-        }
-
-        Set<SingleByteTransition> singles = new HashSet<>();
-        if (operation != Operation.PUT) {
-            singles.addAll(expand(target));
-        }
-        if (operation == Operation.REMOVE) {
-            singles.remove(transition);
+        ByteTransition coalesced;
+        if (operation == Operation.PUT) {
+            coalesced = coalesce(transition);
         } else {
-            singles.add(transition);
+            Iterable<SingleByteTransition> targetIterable = expand(target);
+            if (!targetIterable.iterator().hasNext()) {
+                coalesced = operation == Operation.ADD ? coalesce(transition) : null;
+            } else {
+                Set<SingleByteTransition> singles = new HashSet<>();
+                targetIterable.forEach(single -> singles.add(single));
+                if (operation == Operation.ADD) {
+                    singles.add(transition);
+                } else {
+                    singles.remove(transition);
+                }
+                coalesced = coalesce(singles);
+            }
         }
-        ByteTransition coalesced = coalesce(singles);
-        newMap.put(index + 1, coalesced);
 
-        final boolean atTop = index == targetCeiling - 1;
-        if (!atTop) {
-            newMap.put(targetCeiling, target);
+        final boolean atBottom = index == 0 || map.containsKey(index);
+        if (!atBottom) {
+            map.put(index, target);
         }
-
-        newMap.putAll(map.tailMap(targetCeiling, false));
+        map.put(index + 1, coalesced);
 
         // Merge adjacent mappings with the same transition.
-        mergeAdjacentInMapIfNeeded(newMap);
-
-        // Update map in last step to enforce the happen-before relationship.
-        // We don't update content in map directly to avoid change being felt by other threads before complete.
-        map = newMap;
+        mergeAdjacentInMapIfNeeded(map);
     }
 
     /**
@@ -129,7 +115,7 @@ class ByteMap {
      *
      * @param inputMap The map on which we merge adjacent entries with equal transitions.
      */
-    private void mergeAdjacentInMapIfNeeded(final NavigableMap<Integer, ByteTransition> inputMap) {
+    private static void mergeAdjacentInMapIfNeeded(final NavigableMap<Integer, ByteTransition> inputMap) {
         Iterator<Map.Entry<Integer, ByteTransition>> iterator = inputMap.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Integer, ByteTransition> next1 = iterator.next();
@@ -169,14 +155,35 @@ class ByteMap {
         if (firstByteTransition == null) {
             return ByteMachine.EmptyByteTransition.INSTANCE;
         }
-        candidates.addAll(firstByteTransition.expand());
+        firstByteTransition.expand().forEach(single -> candidates.add(single));
 
         while (iterator.hasNext()) {
             ByteTransition nextByteTransition = iterator.next();
             if (nextByteTransition == null) {
                 return ByteMachine.EmptyByteTransition.INSTANCE;
             }
-            candidates.retainAll(nextByteTransition.expand());
+            Iterable<SingleByteTransition> singles = nextByteTransition.expand();
+            if (singles instanceof Set) {
+                candidates.retainAll((Set) singles);
+            } else if (singles instanceof SingleByteTransition) {
+                SingleByteTransition single = (SingleByteTransition) singles;
+                if (candidates.contains(single)) {
+                    if (candidates.size() > 1) {
+                        candidates.clear();
+                        candidates.add(single);
+                    }
+                } else {
+                    if (!candidates.isEmpty()) {
+                        candidates.clear();
+                    }
+                }
+            } else {
+                // singles should always be a Set or SingleByteTransition. Thus, this "else" is expected to be dead code
+                // but it is here for logical correctness if anything changes in the future.
+                Set<SingleByteTransition> set = new HashSet<>();
+                singles.forEach(single -> set.add(single));
+                candidates.retainAll(set);
+            }
             if (candidates.isEmpty()) {
                 return ByteMachine.EmptyByteTransition.INSTANCE;
             }
@@ -218,15 +225,15 @@ class ByteMap {
         Set<SingleByteTransition> allTransitions = new HashSet<>();
         for (ByteTransition transition : map.values()) {
             if (transition != null) {
-                allTransitions.addAll(expand(transition));
+                expand(transition).forEach(single -> allTransitions.add(single));
             }
         }
         return allTransitions;
     }
 
-    private static Set<SingleByteTransition> expand(ByteTransition transition) {
+    private static Iterable<SingleByteTransition> expand(ByteTransition transition) {
         if (transition == null) {
-            return new HashSet<>();
+            return Collections.EMPTY_SET;
         }
         return transition.expand();
     }

--- a/src/main/software/amazon/event/ruler/ByteState.java
+++ b/src/main/software/amazon/event/ruler/ByteState.java
@@ -96,14 +96,14 @@ class ByteState extends SingleByteTransition {
     }
 
     @Override
-    Set<ByteTransition> getTransitions() {
+    Iterable<ByteTransition> getTransitions() {
         // Saving the value to avoid reading an updated value
         Object transitionStore = this.transitionStore;
         if (transitionStore == null) {
             return Collections.emptySet();
         } else if (transitionStore instanceof SingleByteTransitionEntry) {
             SingleByteTransitionEntry entry = (SingleByteTransitionEntry) transitionStore;
-            return Stream.of(entry.transition).collect(Collectors.toSet());
+            return entry.transition;
         }
         ByteMap map = (ByteMap) transitionStore;
         return map.getTransitions();

--- a/src/main/software/amazon/event/ruler/ByteTransition.java
+++ b/src/main/software/amazon/event/ruler/ByteTransition.java
@@ -36,31 +36,31 @@ abstract class ByteTransition implements Cloneable {
     /**
      * Get all the unique transitions (single or compound) reachable from this transition by any UTF-8 byte value.
      *
-     * @return Set of all transitions reachable from this transition.
+     * @return Iterable of all transitions reachable from this transition.
      */
-    abstract Set<ByteTransition> getTransitions();
+    abstract Iterable<ByteTransition> getTransitions();
 
     /**
      * Returns matches that are triggered if this transition is made. This is a convenience function that traverses the
-     * linked list of matches and returns all of them in a Set.
+     * linked list of matches and returns all of them in an Iterable.
      *
      * @return matches that are triggered if this transition is made.
      */
-    abstract Set<ByteMatch> getMatches();
+    abstract Iterable<ByteMatch> getMatches();
 
     /**
      * Returns all shortcuts that are available if this transition is made.
      *
      * @return all shortcuts
      */
-    abstract Set<ShortcutTransition> getShortcuts();
+    abstract Iterable<ShortcutTransition> getShortcuts();
 
     /**
      * Get all transitions represented by this transition (can be more than one if this is a compound transition).
      *
-     * @return A set of all transitions represented by this transition.
+     * @return An iterable of all transitions represented by this transition.
      */
-    abstract Set<SingleByteTransition> expand();
+    abstract Iterable<SingleByteTransition> expand();
 
     /**
      * Get a transition that represents all of the next byte states for this transition.
@@ -93,7 +93,7 @@ abstract class ByteTransition implements Cloneable {
      * @return boolean
      */
     boolean isEmpty() {
-        return getMatches().isEmpty() && getNextByteState() == null;
+        return !getMatches().iterator().hasNext() && getNextByteState() == null;
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/ShortcutTransition.java
+++ b/src/main/software/amazon/event/ruler/ShortcutTransition.java
@@ -78,8 +78,8 @@ public class ShortcutTransition extends SingleByteTransition {
     }
 
     @Override
-    public Set<ShortcutTransition> getShortcuts() {
-        return Collections.singleton(this);
+    public Iterable<ShortcutTransition> getShortcuts() {
+        return this;
     }
 
     @Override

--- a/src/main/software/amazon/event/ruler/SingleByteTransition.java
+++ b/src/main/software/amazon/event/ruler/SingleByteTransition.java
@@ -1,13 +1,15 @@
 package software.amazon.event.ruler;
 
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
  * This class represents a singular ByteTransition. This is in contrast to a compound ByteTransition that represents
  * having taken multiple distinct transitions simultaneously (i.e. for NFA traversal).
  */
-abstract class SingleByteTransition extends ByteTransition {
+abstract class SingleByteTransition extends ByteTransition implements Iterable {
 
     /**
      * Returns the match that is triggered if this transition is made.
@@ -36,22 +38,43 @@ abstract class SingleByteTransition extends ByteTransition {
     abstract ByteTransition getTransitionForAllBytes();
 
     @Override
-    Set<ByteMatch> getMatches() {
+    Iterable<ByteMatch> getMatches() {
         ByteMatch match = getMatch();
         if (match == null) {
             return Collections.emptySet();
         }
-        return Collections.singleton(match);
+        return match;
     }
 
     /**
      * Get all transitions represented by this transition, which is simply this as this is a single byte transition.
      *
-     * @return A set of all transitions represented by this transition.
+     * @return An iterable of all transitions represented by this transition.
      */
     @Override
-    Set<SingleByteTransition> expand() {
-        return Collections.singleton(this);
+    Iterable<SingleByteTransition> expand() {
+        return this;
+    }
+
+    @Override
+    public Iterator<SingleByteTransition> iterator() {
+        return new Iterator<SingleByteTransition>() {
+            private boolean hasNext = true;
+
+            @Override
+            public boolean hasNext() {
+                return hasNext;
+            }
+
+            @Override
+            public SingleByteTransition next() {
+                if (!hasNext) {
+                    throw new NoSuchElementException();
+                }
+                hasNext = false;
+                return SingleByteTransition.this;
+            }
+        };
     }
 
     @Override

--- a/src/test/software/amazon/event/ruler/ByteMapTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMapTest.java
@@ -310,7 +310,37 @@ public class ByteMapTest {
     }
 
     @Test
-    public void testGetTransitionForAllBytes() {
+    public void testGetTransitionForAllBytesAllOneTransitionExceptOneWithTwo() {
+        map.addTransitionForAllBytes(trans1);
+        map.addTransition((byte) 'a', trans2);
+        assertEquals(coalesce(new HashSet<>(Arrays.asList(trans1))), map.getTransitionForAllBytes());
+    }
+
+    @Test
+    public void testGetTransitionForAllBytesAllTwoTransitionsExceptOneWithOne() {
+        map.addTransitionForAllBytes(trans1);
+        map.addTransitionForAllBytes(trans2);
+        map.removeTransition((byte) 'a', trans2);
+        assertEquals(coalesce(new HashSet<>(Arrays.asList(trans1))), map.getTransitionForAllBytes());
+    }
+
+    @Test
+    public void testGetTransitionForAllBytesAllOneTransitionExceptOneWithZero() {
+        map.addTransitionForAllBytes(trans1);
+        map.removeTransition((byte) 'a', trans1);
+        assertEquals(ByteMachine.EmptyByteTransition.INSTANCE, map.getTransitionForAllBytes());
+    }
+
+    @Test
+    public void testGetTransitionForAllBytesAllOneTransitionExceptOneDifferent() {
+        map.addTransitionForAllBytes(trans1);
+        map.removeTransition((byte) 'a', trans1);
+        map.addTransition((byte) 'a', trans2);
+        assertEquals(ByteMachine.EmptyByteTransition.INSTANCE, map.getTransitionForAllBytes());
+    }
+
+    @Test
+    public void testGetTransitionForAllBytesAllThreeTransitionsExceptOneWithTwo() {
         map.addTransitionForAllBytes(trans1);
         map.addTransitionForAllBytes(trans2);
         map.addTransitionForAllBytes(trans3);

--- a/src/test/software/amazon/event/ruler/ByteMatchTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMatchTest.java
@@ -10,9 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ByteMatchTest {
 
@@ -43,7 +40,7 @@ public class ByteMatchTest {
 
         assertTrue(transition instanceof CompositeByteTransition);
         assertSame(nextState, transition.getNextByteState());
-        assertEquals(Stream.of(match).collect(Collectors.toSet()), transition.getMatches());
+        assertEquals(match, transition.getMatches());
     }
 
     @Test
@@ -54,8 +51,7 @@ public class ByteMatchTest {
 
     @Test
     public void getMatchesShouldReturnThisMatch() {
-        Set<ByteMatch> actualMatches = match.getMatches();
-        assertEquals(Stream.of(match).collect(Collectors.toSet()), actualMatches);
+        assertEquals(match, match.getMatches());
     }
 
     @Test
@@ -72,7 +68,7 @@ public class ByteMatchTest {
 
     @Test
     public void expandShouldReturnMatch() {
-        assertEquals(Stream.of(match).collect(Collectors.toSet()), match.expand());
+        assertEquals(match, match.expand());
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/ByteStateTest.java
+++ b/src/test/software/amazon/event/ruler/ByteStateTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 import static org.junit.Assert.assertEquals;
@@ -68,7 +66,7 @@ public class ByteStateTest {
 
         assertTrue(transition instanceof CompositeByteTransition);
         assertSame(state, transition.getNextByteState());
-        assertEquals(new HashSet<>(Arrays.asList(match)), transition.getMatches());
+        assertEquals(match, transition.getMatches());
     }
 
     @Test
@@ -428,7 +426,7 @@ public class ByteStateTest {
     public void getTransitionsWithSingleByteTransitionEntryShouldReturnExpectedTransition() {
         SingleByteTransition trans1 = new ByteState();
         state.addTransition((byte) 'a', trans1);
-        assertEquals(Stream.of(trans1).collect(Collectors.toSet()), state.getTransitions());
+        assertEquals(trans1, state.getTransitions());
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/CompositeByteTransitionTest.java
+++ b/src/test/software/amazon/event/ruler/CompositeByteTransitionTest.java
@@ -3,9 +3,7 @@ package software.amazon.event.ruler;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,8 +52,8 @@ public class CompositeByteTransitionTest {
     }
 
     @Test
-    public void getMatchesShouldReturnSetMatch() {
-        assertEquals(new HashSet<>(Arrays.asList(match)), compositeTransition.getMatches());
+    public void getMatchesShouldReturnMatch() {
+        assertEquals(match, compositeTransition.getMatches());
     }
 
     @Test
@@ -97,7 +95,7 @@ public class CompositeByteTransitionTest {
 
     @Test
     public void expandShouldReturnComposite() {
-        assertEquals(new HashSet<>(Arrays.asList(compositeTransition)), compositeTransition.expand());
+        assertEquals(compositeTransition, compositeTransition.expand());
     }
 
     @Test


### PR DESCRIPTION
### Description of changes:

Main strategy was turning SingleByteTransition into an Iterable of itself, and then changing many methods that returned Sets to return Iterables, so that in the n=1 case, we can return a SingleByteTransition instead of a single-element set and avoid the set creation. Also, revised updateTransition in ByteMap to work on the same TreeMap instead of creating a replacement.

In my testing, this gives up to a 25% reduction in GC activity, and a 50% reduction in machine creation latency at p99.9.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
