### PR TITLE
Surfacing wildcard parse exceptions during JSON rule compilation time…

### DIFF
--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import software.amazon.event.ruler.input.ParseException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -14,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static software.amazon.event.ruler.input.DefaultParser.getParser;
 
 /**
  * Represents a updated compiler comparing to RuleCompiler class, it parses a rule described by a JSON string into
@@ -494,7 +498,13 @@ public class JsonRuleCompiler {
                 barf(parser, "wildcard match pattern must be a string");
             }
             final String parserText = parser.getText();
-            final Patterns pattern = Patterns.wildcardMatch('"' + parserText + '"');
+            String value = '"' + parserText + '"';
+            try {
+                getParser().parse(MatchType.WILDCARD, value);
+            } catch (ParseException e) {
+                barf(parser, e.getLocalizedMessage());
+            }
+            final Patterns pattern = Patterns.wildcardMatch(value);
             if (parser.nextToken() != JsonToken.END_OBJECT) {
                 barf(parser, "Only one key allowed in match expression");
             }

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import software.amazon.event.ruler.input.ParseException;
+
+import static software.amazon.event.ruler.input.DefaultParser.getParser;
 
 /**
  * Compiles Rules, expressed in JSON, for use in Ruler.
@@ -393,7 +396,13 @@ public final class RuleCompiler {
                 barf(parser, "wildcard match pattern must be a string");
             }
             final String parserText = parser.getText();
-            final Patterns pattern = Patterns.wildcardMatch('"' + parserText + '"');
+            String value = '"' + parserText + '"';
+            try {
+                getParser().parse(MatchType.WILDCARD, value);
+            } catch (ParseException e) {
+                barf(parser, e.getLocalizedMessage());
+            }
+            final Patterns pattern = Patterns.wildcardMatch(value);
             if (parser.nextToken() != JsonToken.END_OBJECT) {
                 barf(parser, "Only one key allowed in match expression");
             }

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -3,6 +3,7 @@ package software.amazon.event.ruler;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -14,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JsonRuleCompilerTest {
 
@@ -535,4 +537,27 @@ public class JsonRuleCompilerTest {
         assertTrue(machine.isEmpty());
     }
 
+    @Test
+    public void testWildcardConsecutiveWildcards() throws IOException {
+        try {
+            JsonRuleCompiler.compile("{\"key\": [{\"wildcard\": \"abc**def\"}]}");
+            fail("Expected JSONParseException");
+        } catch (JsonParseException e) {
+            assertEquals("Consecutive wildcard characters at pos 4\n" +
+                            " at [Source: (String)\"{\"key\": [{\"wildcard\": \"abc**def\"}]}\"; line: 1, column: 33]",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWildcardInvalidEscapeCharacter() throws IOException {
+        try {
+            JsonRuleCompiler.compile("{\"key\": [{\"wildcard\": \"a*c\\def\"}]}");
+            fail("Expected JSONParseException");
+        } catch (JsonParseException e) {
+            assertEquals("Unrecognized character escape 'd' (code 100)\n" +
+                            " at [Source: (String)\"{\"key\": [{\"wildcard\": \"a*c\\def\"}]}\"; line: 1, column: 29]",
+                    e.getMessage());
+        }
+    }
 }

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -1,6 +1,8 @@
 package software.amazon.event.ruler;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -532,6 +534,30 @@ public class RuleCompilerTest {
 
         multiThreadedTestHelper(rules, events, 1);
 
+    }
+
+    @Test
+    public void testWildcardConsecutiveWildcards() throws IOException {
+        try {
+            RuleCompiler.compile("{\"key\": [{\"wildcard\": \"abc**def\"}]}");
+            fail("Expected JSONParseException");
+        } catch (JsonParseException e) {
+            assertEquals("Consecutive wildcard characters at pos 4\n" +
+                    " at [Source: (String)\"{\"key\": [{\"wildcard\": \"abc**def\"}]}\"; line: 1, column: 33]",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWildcardInvalidEscapeCharacter() throws IOException {
+        try {
+            RuleCompiler.compile("{\"key\": [{\"wildcard\": \"a*c\\def\"}]}");
+            fail("Expected JSONParseException");
+        } catch (JsonParseException e) {
+            assertEquals("Unrecognized character escape 'd' (code 100)\n" +
+                    " at [Source: (String)\"{\"key\": [{\"wildcard\": \"a*c\\def\"}]}\"; line: 1, column: 29]",
+                    e.getMessage());
+        }
     }
 
     private void multiThreadedTestHelper(List<String> rules,


### PR DESCRIPTION
… so these exceptions can get channelled into existing exception mapping

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
