### PR TITLE
Cidr bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.6.0</version>
+  <version>1.7.0</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2308,4 +2308,95 @@ public class ACMachineTest {
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule2"));
     }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": \"10.0.1.200\"}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+        "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButPrefixRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"prefix\": \"10.0.\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+        "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButSuffixRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"suffix\": \"1.200\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+        "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButEqualsIgnoreCaseRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"equals-ignore-case\": \"10.0.1.200\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+        "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithNumericRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"numeric\": [\">\", 0, \"<=\", 5]}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+        "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2169,6 +2169,96 @@ public class MachineTest {
     }
 
     @Test
+    public void testCIDRRuleWithMatchingAnythingButRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": \"10.0.1.200\"}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButPrefixRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"prefix\": \"10.0.\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButSuffixRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"suffix\": \"1.200\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithMatchingAnythingButEqualsIgnoreCaseRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"anything-but\": {\"equals-ignore-case\": \"10.0.1.200\"}}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
+    public void testCIDRRuleWithNumericRule() throws Exception {
+        String rule1 = "{\"ip\": [{\"numeric\": [\">\", 0, \"<=\", 5]}]}";
+        String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
+
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule1);
+        machine.addRule("rule2", rule2);
+
+        String event = "{" +
+                "\"ip\": \"10.0.1.200\"" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule2"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2179,7 +2179,7 @@ public class MachineTest {
 
         String event = "{" +
                 "\"ip\": \"10.0.1.200\"" +
-                "}";
+        "}";
 
         List<String> matches = machine.rulesForEvent(event);
         assertEquals(1, matches.size());
@@ -2197,7 +2197,7 @@ public class MachineTest {
 
         String event = "{" +
                 "\"ip\": \"10.0.1.200\"" +
-                "}";
+        "}";
 
         List<String> matches = machine.rulesForEvent(event);
         assertEquals(1, matches.size());
@@ -2215,7 +2215,7 @@ public class MachineTest {
 
         String event = "{" +
                 "\"ip\": \"10.0.1.200\"" +
-                "}";
+        "}";
 
         List<String> matches = machine.rulesForEvent(event);
         assertEquals(1, matches.size());
@@ -2233,7 +2233,7 @@ public class MachineTest {
 
         String event = "{" +
                 "\"ip\": \"10.0.1.200\"" +
-                "}";
+        "}";
 
         List<String> matches = machine.rulesForEvent(event);
         assertEquals(1, matches.size());
@@ -2251,7 +2251,7 @@ public class MachineTest {
 
         String event = "{" +
                 "\"ip\": \"10.0.1.200\"" +
-                "}";
+        "}";
 
         List<String> matches = machine.rulesForEvent(event);
         assertEquals(1, matches.size());


### PR DESCRIPTION
### Description of changes:

There were two bugs with CIDR:

1. When an IP pattern was present and the incoming value was also an IP, we would convert the IP to a hex string before performing matching. Problem with this was that if there was also a rule present that used anything-but on this same field, the anything-but would always be satisfied, since the anything-but does not specify our internal hex format.
2. When both a CIDR pattern and a numeric pattern were present and the incoming value was an IP, we would attempt to convert to a numeric value first, which would fail, and cause us to skip over CIDR matching and go straight to String matching.

#### Benchmark / Performance (for source code changes):

```
EXACT events/sec: 169505.2
WILDCARD events/sec: 127968.8
PREFIX events/sec: 166981.2
PREFIX_EQUALS_IGNORE_CASE_RULES events/sec: 177113.9
SUFFIX events/sec: 190579.6
SUFFIX_EQUALS_IGNORE_CASE_RULES events/sec: 194051.0
EQUALS_IGNORE_CASE events/sec: 174075.2
NUMERIC events/sec: 115359.0
ANYTHING-BUT events/sec: 126524.9
ANYTHING-BUT-IGNORE-CASE events/sec: 115109.7
ANYTHING-BUT-PREFIX events/sec: 128509.0
ANYTHING-BUT-SUFFIX events/sec: 130716.6
COMPLEX_ARRAYS events/sec: 30098.6
PARTIAL_COMBO events/sec: 51279.9
COMBO events/sec: 19901.7
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
