### PR TITLE
Disable wildcard imports within the package.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -18,6 +18,7 @@
     <module name="OneStatementPerLine"/>
     <module name="NoFinalizer"/>
     <module name="RedundantImport"/>
+    <module name="AvoidStarImport"/>
     <module name="DefaultComesLast"/>
     <module name="SuppressWarningsHolder" />
   </module>

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -7,6 +7,7 @@ import software.amazon.event.ruler.input.InputCharacterType;
 import software.amazon.event.ruler.input.InputMultiByteSet;
 import software.amazon.event.ruler.input.MultiByte;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -20,16 +21,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.concurrent.ThreadSafe;
 
 import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
+import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_SUFFIX;
 import static software.amazon.event.ruler.MatchType.EQUALS_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.EXACT;
 import static software.amazon.event.ruler.MatchType.EXISTS;
 import static software.amazon.event.ruler.MatchType.SUFFIX;
-import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_SUFFIX;
 import static software.amazon.event.ruler.MatchType.SUFFIX_EQUALS_IGNORE_CASE;
-
+import static software.amazon.event.ruler.input.DefaultParser.getParser;
 import static software.amazon.event.ruler.input.MultiByte.MAX_CONTINUATION_BYTE;
 import static software.amazon.event.ruler.input.MultiByte.MAX_FIRST_BYTE_FOR_ONE_BYTE_CHAR;
 import static software.amazon.event.ruler.input.MultiByte.MAX_FIRST_BYTE_FOR_TWO_BYTE_CHAR;
@@ -37,7 +37,6 @@ import static software.amazon.event.ruler.input.MultiByte.MAX_NON_FIRST_BYTE;
 import static software.amazon.event.ruler.input.MultiByte.MIN_CONTINUATION_BYTE;
 import static software.amazon.event.ruler.input.MultiByte.MIN_FIRST_BYTE_FOR_ONE_BYTE_CHAR;
 import static software.amazon.event.ruler.input.MultiByte.MIN_FIRST_BYTE_FOR_TWO_BYTE_CHAR;
-import static software.amazon.event.ruler.input.DefaultParser.getParser;
 
 /**
  * Represents a UTF8-byte-level state machine that matches a Ruler state machine's field values.

--- a/src/main/software/amazon/event/ruler/ByteState.java
+++ b/src/main/software/amazon/event/ruler/ByteState.java
@@ -3,7 +3,6 @@ package software.amazon.event.ruler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -2,6 +2,8 @@ package software.amazon.event.ruler;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
+
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -16,7 +18,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 /**
  *  Represents a state machine used to match name/value patterns to rules.

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -1,6 +1,10 @@
 package software.amazon.event.ruler;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadFeature;
 import software.amazon.event.ruler.input.ParseException;
 
 import java.io.IOException;

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -1,10 +1,10 @@
 package software.amazon.event.ruler;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Represents a state in the machine.

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -1,5 +1,12 @@
 package software.amazon.event.ruler;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import software.amazon.event.ruler.input.ParseException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -11,9 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.fasterxml.jackson.core.*;
-import software.amazon.event.ruler.input.ParseException;
 
 import static software.amazon.event.ruler.input.DefaultParser.getParser;
 

--- a/src/main/software/amazon/event/ruler/Ruler.java
+++ b/src/main/software/amazon/event/ruler/Ruler.java
@@ -1,16 +1,15 @@
 package software.amazon.event.ruler;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * The core idea of Ruler is to match rules to events at a rate that's independent of the number of rules.  This is

--- a/src/main/software/amazon/event/ruler/input/DefaultParser.java
+++ b/src/main/software/amazon/event/ruler/input/DefaultParser.java
@@ -4,9 +4,9 @@ import software.amazon.event.ruler.MatchType;
 
 import java.nio.charset.StandardCharsets;
 
+import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_SUFFIX;
 import static software.amazon.event.ruler.MatchType.EQUALS_IGNORE_CASE;
-import static software.amazon.event.ruler.MatchType.ANYTHING_BUT_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.PREFIX_EQUALS_IGNORE_CASE;
 import static software.amazon.event.ruler.MatchType.SUFFIX;
 import static software.amazon.event.ruler.MatchType.SUFFIX_EQUALS_IGNORE_CASE;

--- a/src/test/software/amazon/event/ruler/ArrayMembershipTest.java
+++ b/src/test/software/amazon/event/ruler/ArrayMembershipTest.java
@@ -2,7 +2,10 @@ package software.amazon.event.ruler;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ArrayMembershipTest {
     @Test

--- a/src/test/software/amazon/event/ruler/BigEventTest.java
+++ b/src/test/software/amazon/event/ruler/BigEventTest.java
@@ -1,7 +1,9 @@
 package software.amazon.event.ruler;
 
-import java.util.List;
 import org.junit.Test;
+
+import java.util.List;
+
 import static org.junit.Assert.assertTrue;
 
 public class BigEventTest {

--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -1,5 +1,8 @@
 package software.amazon.event.ruler;
 
+import org.junit.Test;
+import software.amazon.event.ruler.input.ParseException;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -9,10 +12,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import software.amazon.event.ruler.input.ParseException;
-import org.junit.Test;
-
-import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -21,6 +20,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
 
 public class ByteMachineTest {
 

--- a/src/test/software/amazon/event/ruler/ByteMapTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMapTest.java
@@ -1,7 +1,7 @@
 package software.amazon.event.ruler;
 
-import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -10,12 +10,11 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 
 public class ByteMapTest {
 

--- a/src/test/software/amazon/event/ruler/ByteMatchTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMatchTest.java
@@ -1,15 +1,15 @@
 package software.amazon.event.ruler;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Collections;
 
 public class ByteMatchTest {
 

--- a/src/test/software/amazon/event/ruler/ByteStateTest.java
+++ b/src/test/software/amazon/event/ruler/ByteStateTest.java
@@ -7,12 +7,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
-import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 
 public class ByteStateTest {
 

--- a/src/test/software/amazon/event/ruler/CompoundByteTransitionTest.java
+++ b/src/test/software/amazon/event/ruler/CompoundByteTransitionTest.java
@@ -5,13 +5,13 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.CompoundByteTransition.coalesce;
 
 public class CompoundByteTransitionTest {
 

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -2,6 +2,8 @@ package software.amazon.event.ruler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -10,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -2,6 +2,8 @@ package software.amazon.event.ruler;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,7 +11,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
 
 /**
  * For each test, for illustrative purposes, I will provide one input string that results in the maximum number of

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -1,6 +1,8 @@
 package software.amazon.event.ruler;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,8 +20,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/software/amazon/event/ruler/input/InputByteTest.java
+++ b/src/test/software/amazon/event/ruler/input/InputByteTest.java
@@ -2,13 +2,13 @@ package software.amazon.event.ruler.input;
 
 import org.junit.Test;
 
-import static software.amazon.event.ruler.input.InputCharacterType.BYTE;
-import static software.amazon.event.ruler.input.DefaultParser.ASTERISK_BYTE;
-import static software.amazon.event.ruler.input.DefaultParser.BACKSLASH_BYTE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.input.DefaultParser.ASTERISK_BYTE;
+import static software.amazon.event.ruler.input.DefaultParser.BACKSLASH_BYTE;
+import static software.amazon.event.ruler.input.InputCharacterType.BYTE;
 
 public class InputByteTest {
 

--- a/src/test/software/amazon/event/ruler/input/InputMultiByteSetTest.java
+++ b/src/test/software/amazon/event/ruler/input/InputMultiByteSetTest.java
@@ -6,12 +6,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static software.amazon.event.ruler.input.InputCharacterType.MULTI_BYTE_SET;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.input.InputCharacterType.MULTI_BYTE_SET;
 
 public class InputMultiByteSetTest {
 

--- a/src/test/software/amazon/event/ruler/input/InputWildcardTest.java
+++ b/src/test/software/amazon/event/ruler/input/InputWildcardTest.java
@@ -2,11 +2,11 @@ package software.amazon.event.ruler.input;
 
 import org.junit.Test;
 
-import static software.amazon.event.ruler.input.InputCharacterType.WILDCARD;
-import static software.amazon.event.ruler.input.DefaultParser.ASTERISK_BYTE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.input.DefaultParser.ASTERISK_BYTE;
+import static software.amazon.event.ruler.input.InputCharacterType.WILDCARD;
 
 public class InputWildcardTest {
 

--- a/src/test/software/amazon/event/ruler/input/MultiByteTest.java
+++ b/src/test/software/amazon/event/ruler/input/MultiByteTest.java
@@ -4,14 +4,14 @@ import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static software.amazon.event.ruler.input.DefaultParser.NINE_BYTE;
-import static software.amazon.event.ruler.input.DefaultParser.ZERO_BYTE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static software.amazon.event.ruler.input.DefaultParser.NINE_BYTE;
+import static software.amazon.event.ruler.input.DefaultParser.ZERO_BYTE;
 
 public class MultiByteTest {
 

--- a/src/test/software/amazon/event/ruler/input/ParserTest.java
+++ b/src/test/software/amazon/event/ruler/input/ParserTest.java
@@ -1,12 +1,12 @@
 package software.amazon.event.ruler.input;
 
-import software.amazon.event.ruler.MatchType;
 import org.junit.Test;
+import software.amazon.event.ruler.MatchType;
 
-import static software.amazon.event.ruler.input.DefaultParser.getParser;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static software.amazon.event.ruler.input.DefaultParser.getParser;
 
 public class ParserTest {
 


### PR DESCRIPTION


### Issue #, if available:

### Description of changes:

See https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.html for more context

>  Rationale: Importing all classes from a package or static members from a class leads to tight coupling between packages or classes and might lead to problems when a new version of
a library introduces name clashes.

Also ran IDE-based optimize imports. Fixes a missed comment from a previous PR https://github.com/aws/event-ruler/pull/129#discussion_r1403574719

#### Benchmark / Performance (for source code changes):

N/A
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
