### PR TITLE
Fixing GenericMachine/Machine Builder visibility so it is usable from outside packages

### DIFF
--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -706,7 +706,7 @@ public class GenericMachine<T> {
         return new Builder();
     }
 
-    protected static class Builder<T extends GenericMachine> {
+    public static class Builder<T extends GenericMachine> {
 
         /**
          * Normally, NameStates are re-used for a given key subsequence and pattern if this key subsequence and pattern have
@@ -718,6 +718,8 @@ public class GenericMachine<T> {
          * which Ruler sometimes iterates over, which can cause a modest runtime performance regression.
          */
         private boolean additionalNameStateReuse = false;
+
+        Builder() {}
 
         public Builder<T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
             this.additionalNameStateReuse = additionalNameStateReuse;

--- a/src/main/software/amazon/event/ruler/Machine.java
+++ b/src/main/software/amazon/event/ruler/Machine.java
@@ -26,7 +26,10 @@ public class Machine extends GenericMachine<String> {
         return new Builder();
     }
 
-    protected static class Builder extends GenericMachine.Builder<Machine> {
+    public static class Builder extends GenericMachine.Builder<Machine> {
+
+        private Builder() {}
+
         @Override
         public Machine build() {
             return new Machine(buildConfig());


### PR DESCRIPTION
### Description of changes:
Otherwise, outside packages can't access the withAdditionalNameStateReuse method.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
