### PR TITLE
Fixing bug where sub-rule would not be considered new if its keys and…

### DIFF
--- a/src/main/software/amazon/event/ruler/ACTask.java
+++ b/src/main/software/amazon/event/ruler/ACTask.java
@@ -57,7 +57,8 @@ class ACTask {
         return new ArrayList<>(matchingRules);
     }
 
-    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern) {
+    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
+                      final SubRuleContext.Generator subRuleContextGenerator) {
         Set<Double> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
         if (terminalSubRuleIds == null) {
             return;
@@ -66,10 +67,11 @@ class ACTask {
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
         if (candidateSubRuleIds == null || candidateSubRuleIds.isEmpty()) {
             for (Double terminalSubRuleId : terminalSubRuleIds) {
-                matchingRules.add(nameState.getRule(terminalSubRuleId));
+                matchingRules.add(subRuleContextGenerator.getNameForGeneratedId(terminalSubRuleId));
             }
         } else {
-            intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules, id -> nameState.getRule(id));
+            intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules,
+                    id -> subRuleContextGenerator.getNameForGeneratedId(id));
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/SubRuleContext.java
+++ b/src/main/software/amazon/event/ruler/SubRuleContext.java
@@ -1,5 +1,10 @@
 package software.amazon.event.ruler;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * This class stores context regarding a sub-rule.
  *
@@ -39,13 +44,30 @@ public class SubRuleContext {
 
         private double nextId = -Double.MAX_VALUE;
 
-        public SubRuleContext generate() {
+        private Map<Object, Set<Double>> nameToIds = new ConcurrentHashMap<>();
+        private Map<Double, Object> idToName = new ConcurrentHashMap<>();
+
+        public SubRuleContext generate(Object ruleName) {
             assert nextId < Double.MAX_VALUE : "SubRuleContext.Generator's nextId reached Double.MAX_VALUE - " +
                     "this required the equivalent of calling generate() at 6 billion TPS for 100 years";
 
             SubRuleContext subRuleContext = new SubRuleContext(nextId);
+            if (!nameToIds.containsKey(ruleName)) {
+                nameToIds.put(ruleName, new HashSet<>());
+            }
+            nameToIds.get(ruleName).add(nextId);
+            idToName.put(nextId, ruleName);
+
             nextId = Math.nextUp(nextId);
             return subRuleContext;
+        }
+
+        public Set<Double> getIdsGeneratedForName(Object ruleName) {
+            return nameToIds.get(ruleName);
+        }
+
+        public Object getNameForGeneratedId(Double id) {
+            return idToName.get(id);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/Task.java
+++ b/src/main/software/amazon/event/ruler/Task.java
@@ -80,7 +80,8 @@ class Task {
         return new ArrayList<>(matchingRules);
     }
 
-    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern) {
+    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
+                      final SubRuleContext.Generator subRuleContextGenerator) {
         Set<Double> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
         if (terminalSubRuleIds == null) {
             return;
@@ -89,10 +90,11 @@ class Task {
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
         if (candidateSubRuleIds == null || candidateSubRuleIds.isEmpty()) {
             for (Double terminalSubRuleId : terminalSubRuleIds) {
-                matchingRules.add(nameState.getRule(terminalSubRuleId));
+                matchingRules.add(subRuleContextGenerator.getNameForGeneratedId(terminalSubRuleId));
             }
         } else {
-            intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules, id -> nameState.getRule(id));
+            intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules,
+                    id -> subRuleContextGenerator.getNameForGeneratedId(id));
         }
     }
 }

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2399,4 +2399,55 @@ public class ACMachineTest {
         assertTrue(matches.contains("rule2"));
     }
 
+    @Test
+    public void testAdditionalNameSateReuseAllKeysAndPatternsEncounteredInPreviousSubRules() throws Exception {
+        String rule1 = "{\"$or\":[\n" +
+                "         {\"foo\": [\"a\"],\n" +
+                "          \"bar\": [\"1\"]\n" +
+                "         },\n" +
+                "         {\"foo\": [\"b\"],\n" +
+                "          \"bar\": [\"2\"]\n" +
+                "         },\n" +
+                "         {\"foo\": [\"b\"],\n" +
+                "          \"bar\": [\"1\"]\n" +
+                "         }\n" +
+                "       ]}";
+
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        machine.addRule("rule1", rule1);
+
+        String event = "{" +
+                "  \"foo\": [\"b\"]," +
+                "  \"bar\": [\"1\"]" +
+                "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testAdditionalNameStateReuseSecondSubRuleSubsetOfFirstSubRule() throws Exception {
+        String rule1 = "{\"$or\":[\n" +
+                "         {\"bar\": [\"1\"],\n" +
+                "          \"foo\": [\"a\"],\n" +
+                "          \"zoo\": [\"x\"]\n" +
+                "         },\n" +
+                "         {\"bar\": [\"1\"],\n" +
+                "          \"zoo\": [\"x\"]\n" +
+                "         }\n" +
+                "       ]}";
+
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        machine.addRule("rule1", rule1);
+
+        String event = "{" +
+                "  \"bar\": [\"1\"]," +
+                "  \"zoo\": [\"x\"]" +
+                "}";
+
+        List<String> matches = machine.rulesForJSONEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2259,6 +2259,58 @@ public class MachineTest {
     }
 
     @Test
+    public void testAdditionalNameSateReuseAllKeysAndPatternsEncounteredInPreviousSubRules() throws Exception {
+        String rule1 = "{\"$or\":[\n" +
+                "         {\"foo\": [\"a\"],\n" +
+                "          \"bar\": [\"1\"]\n" +
+                "         },\n" +
+                "         {\"foo\": [\"b\"],\n" +
+                "          \"bar\": [\"2\"]\n" +
+                "         },\n" +
+                "         {\"foo\": [\"b\"],\n" +
+                "          \"bar\": [\"1\"]\n" +
+                "         }\n" +
+                "       ]}";
+
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        machine.addRule("rule1", rule1);
+
+        String event = "{" +
+                "  \"foo\": [\"b\"]," +
+                "  \"bar\": [\"1\"]" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
+    public void testAdditionalNameStateReuseSecondSubRuleSubsetOfFirstSubRule() throws Exception {
+        String rule1 = "{\"$or\":[\n" +
+                "         {\"bar\": [\"1\"],\n" +
+                "          \"foo\": [\"a\"],\n" +
+                "          \"zoo\": [\"x\"]\n" +
+                "         },\n" +
+                "         {\"bar\": [\"1\"],\n" +
+                "          \"zoo\": [\"x\"]\n" +
+                "         }\n" +
+                "       ]}";
+
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        machine.addRule("rule1", rule1);
+
+        String event = "{" +
+                "  \"bar\": [\"1\"]," +
+                "  \"zoo\": [\"x\"]" +
+                "}";
+
+        List<String> matches = machine.rulesForEvent(event);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("rule1"));
+    }
+
+    @Test
     public void testApproxSizeForSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";
@@ -2331,7 +2383,7 @@ public class MachineTest {
 
         // Adding rule with terminal key having superset of values will be treated as new rule and increase count
         machine.addRule("r1", rule1b);
-        assertEquals(90, machine.approximateObjectCount(10000));
+        assertEquals(87, machine.approximateObjectCount(10000));
     }
 
     @Test
@@ -2345,7 +2397,7 @@ public class MachineTest {
 
         // Adding rule with non-terminal key having superset of values will be treated as new rule and increase count
         machine.addRule("r1", rule1b);
-        assertEquals(90, machine.approximateObjectCount(10000));
+        assertEquals(87, machine.approximateObjectCount(10000));
     }
 
     @Test

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -35,19 +35,19 @@ public class NameStateTest {
 
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertEquals(new HashSet<>(asList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule(1.0, Patterns.exactMatch("b"), true);
+        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertEquals(new HashSet<>(asList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule(2.0, Patterns.exactMatch("b"), true);
+        nameState.deleteSubRule("rule2", 2.0, Patterns.exactMatch("b"), true);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule(2.0, Patterns.exactMatch("a"), true);
+        nameState.deleteSubRule("rule2", 2.0, Patterns.exactMatch("a"), true);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), false);
+        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
         assertEquals(new HashSet<>(asList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule(1.0, Patterns.exactMatch("a"), true);
+        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
     }
@@ -117,22 +117,12 @@ public class NameStateTest {
     }
 
     @Test
-    public void testNextNameStateWithoutAdditionalNameStateReuse() {
-        NameState nameState = new NameState();
-        NameState nextNameState = new NameState();
-        GenericMachineConfiguration withoutAdditionalNameStateReuse = new GenericMachineConfiguration(false);
-        nameState.addNextNameState("key", nextNameState, withoutAdditionalNameStateReuse);
-        assertNull(nameState.getNextNameState("key"));
-    }
-
-    @Test
     public void testNextNameStateWithAdditionalNameStateReuse() {
         NameState nameState = new NameState();
         NameState nextNameState = new NameState();
-        GenericMachineConfiguration withAdditionalNameStateReuse = new GenericMachineConfiguration(true);
-        nameState.addNextNameState("key", nextNameState, withAdditionalNameStateReuse);
+        nameState.addNextNameState("key", nextNameState);
         assertEquals(nextNameState, nameState.getNextNameState("key"));
-        nameState.removeNextNameState("key", withAdditionalNameStateReuse);
+        nameState.removeNextNameState("key");
         assertNull(nameState.getNextNameState("key"));
     }
 }

--- a/src/test/software/amazon/event/ruler/SubRuleContextTest.java
+++ b/src/test/software/amazon/event/ruler/SubRuleContextTest.java
@@ -2,6 +2,9 @@ package software.amazon.event.ruler;
 
 import org.junit.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -9,18 +12,20 @@ import static org.junit.Assert.assertTrue;
 
 public class SubRuleContextTest {
 
+    private static final String NAME = "name";
+
     @Test
     public void testGenerate() {
         SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
-        SubRuleContext contextA1 = generatorA.generate();
-        SubRuleContext contextA2 = generatorA.generate();
+        SubRuleContext contextA1 = generatorA.generate(NAME);
+        SubRuleContext contextA2 = generatorA.generate(NAME);
 
         SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
-        SubRuleContext contextB1 = generatorB.generate();
-        SubRuleContext contextB2 = generatorB.generate();
-        SubRuleContext contextB3 = generatorB.generate();
+        SubRuleContext contextB1 = generatorB.generate(NAME);
+        SubRuleContext contextB2 = generatorB.generate(NAME);
+        SubRuleContext contextB3 = generatorB.generate(NAME);
 
-        SubRuleContext contextA3 = generatorA.generate();
+        SubRuleContext contextA3 = generatorA.generate(NAME);
 
         double expected1 = -Double.MAX_VALUE;
         double expected2 = Math.nextUp(expected1);
@@ -36,13 +41,23 @@ public class SubRuleContextTest {
     }
 
     @Test
+    public void testGetters() {
+        SubRuleContext.Generator generator = new SubRuleContext.Generator();
+        SubRuleContext context = generator.generate(NAME);
+        assertEquals(NAME, generator.getNameForGeneratedId(context.getId()));
+        Set<Double> expectedIds = new HashSet<>();
+        expectedIds.add(context.getId());
+        assertEquals(expectedIds, generator.getIdsGeneratedForName(NAME));
+    }
+
+    @Test
     public void testEquals() {
         SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
-        SubRuleContext contextA1 = generatorA.generate();
-        SubRuleContext contextA2 = generatorA.generate();
+        SubRuleContext contextA1 = generatorA.generate(NAME);
+        SubRuleContext contextA2 = generatorA.generate(NAME);
 
         SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
-        SubRuleContext contextB1 = generatorB.generate();
+        SubRuleContext contextB1 = generatorB.generate(NAME);
 
         assertTrue(contextA1.equals(contextB1));
         assertFalse(contextA2.equals(contextB1));
@@ -51,11 +66,11 @@ public class SubRuleContextTest {
     @Test
     public void testHashCode() {
         SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
-        SubRuleContext contextA1 = generatorA.generate();
-        SubRuleContext contextA2 = generatorA.generate();
+        SubRuleContext contextA1 = generatorA.generate(NAME);
+        SubRuleContext contextA2 = generatorA.generate(NAME);
 
         SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
-        SubRuleContext contextB1 = generatorB.generate();
+        SubRuleContext contextB1 = generatorB.generate(NAME);
 
         assertEquals(contextA1.hashCode(), contextB1.hashCode());
         assertNotEquals(contextA2.hashCode(), contextB1.hashCode());


### PR DESCRIPTION
… patterns were contained in its sibling sub-rules, even if no sibling contained all of the keys and patterns by itself.

### Description of changes:

Fixing bug where sub-rule would not be considered new if its keys and patterns were contained in its sibling sub-rules, even if no sibling contained all of the keys and patterns by itself. This would result in that sub-rule not being matchable. To avoid adversely affecting performance, this required adding a mapping of sub-rule name to IDs in SubRuleContext.Generator. While doing this, I also moved the mapping of sub-rule ID to name out of NameState and into SubRuleContext.Generator. For most cases, this will be a net memory improvement (despite the additional mapping), as there is a single SubRuleContext.Generator at the Machine level, where as there are many NameStates at the Machine level, so the ID to name mapping would be stored redundantly many times.

#### Benchmark / Performance (for source code changes):

```
EXACT events/sec: 207871.2
WILDCARD events/sec: 153728.7
PREFIX events/sec: 204479.8
PREFIX_EQUALS_IGNORE_CASE_RULES events/sec: 205465.8
SUFFIX events/sec: 200818.1
SUFFIX_EQUALS_IGNORE_CASE_RULES events/sec: 203503.3
EQUALS_IGNORE_CASE events/sec: 179652.6
NUMERIC events/sec: 119768.4
ANYTHING-BUT events/sec: 126150.4
ANYTHING-BUT-IGNORE-CASE events/sec: 122102.0
ANYTHING-BUT-PREFIX events/sec: 133167.5
ANYTHING-BUT-SUFFIX events/sec: 131038.1
COMPLEX_ARRAYS events/sec: 26159.4
PARTIAL_COMBO events/sec: 49355.6
COMBO events/sec: 16895.4
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
