### PR TITLE
Giving Machine.Builder a package-private constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/Machine.java
+++ b/src/main/software/amazon/event/ruler/Machine.java
@@ -28,7 +28,7 @@ public class Machine extends GenericMachine<String> {
 
     public static class Builder extends GenericMachine.Builder<Machine> {
 
-        private Builder() {}
+        Builder() {}
 
         @Override
         public Machine build() {


### PR DESCRIPTION
### Description of changes:

Being able to extend Machine.Builder is useful when adding an adapter layer around Ruler.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
