### PR TITLE
Add fastdoubleparser as a dependency instead of using jackson's shaded version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.7.5</version>
+  <version>1.7.6</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't
@@ -32,6 +32,7 @@
   <properties>
     <jdk.version>1.8</jdk.version>
     <jackson.version>2.17.2</jackson.version>
+    <fastdoubleparser.version>1.0.0</fastdoubleparser.version>
     <jsr.version>3.0.2</jsr.version>
     <junit.version>4.13.2</junit.version>
     <compiler.plugin.version>3.13.0</compiler.plugin.version>
@@ -83,6 +84,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.randelshofer</groupId>
+      <artifactId>fastdoubleparser</artifactId>
+      <version>${fastdoubleparser.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/software/amazon/event/ruler/ComparableNumber.java
+++ b/src/main/software/amazon/event/ruler/ComparableNumber.java
@@ -1,6 +1,6 @@
 package software.amazon.event.ruler;
 
-import com.fasterxml.jackson.core.io.doubleparser.JavaBigDecimalParser;
+import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 
 import java.math.BigDecimal;
 


### PR DESCRIPTION

### Description of changes:

Based on following message from Jackson
https://github.com/FasterXML/jackson-core/blob/2.18/src/main/java/com/fasterxml/jackson/core/io/BigDecimalParser.java#L11 to not use their shaded version.

Removing `com.fasterxml.jackson.core.io.doubleparser.JavaBigDecimalParser` also helps folks that are in the middle of migrating from Jackson 2.12.x to more modern versions. There are few breaking changes along the way that requires more careful migration. Folks require the ability to resolve a different version of jackson when noticing a package version conflict.

Usually we'd shy away from adding a new dependency but this one was already being used through Jackson. The dependency itself is pretty stable and tiny (based on browsing the code, commit history, and gathering anecdotes from long-term users of this library). There was no impact on benchmarks either, so I'm comfortable merging this one in. 

#### Benchmark / Performance (for source code changes):

```
Running software.amazon.event.ruler.Benchmarks
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 11368
Events/sec: 18742.8
 Rules/sec: 131199.5
Reading citylots2
Read 213068 events
EXACT events/sec: 269025.3
WILDCARD events/sec: 180413.2
PREFIX events/sec: 268010.1
PREFIX_EQUALS_IGNORE_CASE_RULES events/sec: 271078.9
SUFFIX events/sec: 262399.0
SUFFIX_EQUALS_IGNORE_CASE_RULES events/sec: 264024.8
EQUALS_IGNORE_CASE events/sec: 224755.3
NUMERIC events/sec: 144355.0
ANYTHING-BUT events/sec: 141667.6
ANYTHING-BUT-IGNORE-CASE events/sec: 141856.2
ANYTHING-BUT-PREFIX events/sec: 149311.8
ANYTHING-BUT-SUFFIX events/sec: 148686.7
ANYTHING-BUT-WILDCARD events/sec: 154285.3
COMPLEX_ARRAYS events/sec: 33162.3
PARTIAL_COMBO events/sec: 49332.7
COMBO events/sec: 20201.8
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 54.597 sec
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
