### PR TITLE
Optimization: removed level of indirection for SubRuleContext.

### DIFF
--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -78,7 +78,7 @@ class ACFinder {
         }
     }
 
-    private static void tryMustNotExistMatch(final Set<Double> candidateSubRuleIds, final NameState nameState,
+    private static void tryMustNotExistMatch(final Set<SubRuleContext> candidateSubRuleIds, final NameState nameState,
                                              final ACTask task, int nextKeyIndex, final ArrayMembership arrayMembership,
                                              final SubRuleContext.Generator subRuleContextGenerator) {
         if (!nameState.hasKeyTransitions()) {
@@ -94,7 +94,7 @@ class ACFinder {
     }
 
     // Move from a state. Give all the remaining event fields a chance to transition from it.
-    private static void moveFrom(final Set<Double> candidateSubRuleIdsForNextStep, final NameState nameState,
+    private static void moveFrom(final Set<SubRuleContext> candidateSubRuleIdsForNextStep, final NameState nameState,
                                  int fieldIndex, final ACTask task, final ArrayMembership arrayMembership,
                                  final SubRuleContext.Generator subRuleContextGenerator) {
         /*
@@ -120,12 +120,12 @@ class ACFinder {
         }
     }
 
-    private static void moveFromWithPriorCandidates(final Set<Double> candidateSubRuleIds,
+    private static void moveFromWithPriorCandidates(final Set<SubRuleContext> candidateSubRuleIds,
                                                     final NameState fromState, final Patterns fromPattern,
                                                     final int fieldIndex, final ACTask task,
                                                     final ArrayMembership arrayMembership,
                                                     final SubRuleContext.Generator subRuleContextGenerator) {
-        Set<Double> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(candidateSubRuleIds,
+        Set<SubRuleContext> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(candidateSubRuleIds,
                 fromState, fromPattern);
 
         // If there are no more candidate sub-rules, there is no need to proceed further.
@@ -145,12 +145,12 @@ class ACFinder {
      * @return The set of candidate sub-rule IDs for the next step. Null means there are no candidates and thus, there
      *         is no point to evaluating subsequent steps.
      */
-    private static Set<Double> calculateCandidateSubRuleIdsForNextStep(final Set<Double> currentCandidateSubRuleIds,
+    private static Set<SubRuleContext> calculateCandidateSubRuleIdsForNextStep(final Set<SubRuleContext> currentCandidateSubRuleIds,
                                                                        final NameState fromState,
                                                                        final Patterns fromPattern) {
         // These are all the sub-rules that use the matched pattern to transition to the next NameState. Note that they
         // are not all candidates as they may have required different values for previously evaluated fields.
-        Set<Double> subRuleIds = fromState.getNonTerminalSubRuleIdsForPattern(fromPattern);
+        Set<SubRuleContext> subRuleIds = fromState.getNonTerminalSubRuleIdsForPattern(fromPattern);
 
         // If no sub-rules used the matched pattern to transition to the next NameState, then there are no matches to be
         // found by going further.
@@ -166,12 +166,12 @@ class ACFinder {
 
         // There are candidate sub-rules, so retain only those that used the matched pattern to transition to the next
         // NameState.
-        Set<Double> candidateSubRuleIdsForNextStep = new HashSet<>();
+        Set<SubRuleContext> candidateSubRuleIdsForNextStep = new HashSet<>();
         intersection(subRuleIds, currentCandidateSubRuleIds, candidateSubRuleIdsForNextStep);
         return candidateSubRuleIdsForNextStep;
     }
 
-    private static void addNameState(Set<Double> candidateSubRuleIds, NameState nameState, Patterns pattern,
+    private static void addNameState(Set<SubRuleContext> candidateSubRuleIds, NameState nameState, Patterns pattern,
                                      ACTask task, int nextKeyIndex, final ArrayMembership arrayMembership,
                                      final SubRuleContext.Generator subRuleContextGenerator) {
         // one of the matches might imply a rule match

--- a/src/main/software/amazon/event/ruler/ACStep.java
+++ b/src/main/software/amazon/event/ruler/ACStep.java
@@ -8,10 +8,10 @@ import java.util.Set;
 class ACStep {
     final int fieldIndex;
     final NameState nameState;
-    final Set<Double> candidateSubRuleIds;
+    final Set<SubRuleContext> candidateSubRuleIds;
     final ArrayMembership membershipSoFar;
 
-    ACStep(final int fieldIndex, final NameState nameState, final Set<Double> candidateSubRuleIds,
+    ACStep(final int fieldIndex, final NameState nameState, final Set<SubRuleContext> candidateSubRuleIds,
            final ArrayMembership arrayMembership) {
         this.fieldIndex = fieldIndex;
         this.nameState = nameState;

--- a/src/main/software/amazon/event/ruler/ACTask.java
+++ b/src/main/software/amazon/event/ruler/ACTask.java
@@ -44,7 +44,7 @@ class ACTask {
     /*
      *  Add a step to the queue for later consideration
      */
-    void addStep(final int fieldIndex, final NameState nameState, final Set<Double> candidateSubRuleIds,
+    void addStep(final int fieldIndex, final NameState nameState, final Set<SubRuleContext> candidateSubRuleIds,
                  final ArrayMembership membershipSoFar) {
         stepQueue.add(new ACStep(fieldIndex, nameState, candidateSubRuleIds, membershipSoFar));
     }
@@ -57,21 +57,21 @@ class ACTask {
         return new ArrayList<>(matchingRules);
     }
 
-    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
+    void collectRules(final Set<SubRuleContext> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
                       final SubRuleContext.Generator subRuleContextGenerator) {
-        Set<Double> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
+        Set<SubRuleContext> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
         if (terminalSubRuleIds == null) {
             return;
         }
 
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
         if (candidateSubRuleIds == null || candidateSubRuleIds.isEmpty()) {
-            for (Double terminalSubRuleId : terminalSubRuleIds) {
-                matchingRules.add(subRuleContextGenerator.getNameForGeneratedId(terminalSubRuleId));
+            for (SubRuleContext terminalSubRuleId : terminalSubRuleIds) {
+                matchingRules.add(terminalSubRuleId.getRuleName());
             }
         } else {
             intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules,
-                    id -> subRuleContextGenerator.getNameForGeneratedId(id));
+                    SubRuleContext::getRuleName);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/Finder.java
+++ b/src/main/software/amazon/event/ruler/Finder.java
@@ -83,7 +83,7 @@ class Finder {
     }
 
     // Move from a state.  Give all the remaining tokens a chance to transition from it
-    private static void moveFrom(final Set<Double> candidateSubRuleIdsForNextStep, final NameState nameState,
+    private static void moveFrom(final Set<SubRuleContext> candidateSubRuleIdsForNextStep, final NameState nameState,
                                  final int tokenIndex, final Task task,
                                  final SubRuleContext.Generator subRuleContextGenerator) {
         /*
@@ -111,11 +111,11 @@ class Finder {
         }
     }
 
-    private static void moveFromWithPriorCandidates(final Set<Double> candidateSubRuleIds,
+    private static void moveFromWithPriorCandidates(final Set<SubRuleContext> candidateSubRuleIds,
                                                     final NameState fromState, final Patterns fromPattern,
                                                     final int tokenIndex, final Task task,
                                                     final SubRuleContext.Generator subRuleContextGenerator) {
-        Set<Double> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(candidateSubRuleIds,
+        Set<SubRuleContext> candidateSubRuleIdsForNextStep = calculateCandidateSubRuleIdsForNextStep(candidateSubRuleIds,
                 fromState, fromPattern);
 
         // If there are no more candidate sub-rules, there is no need to proceed further.
@@ -135,12 +135,12 @@ class Finder {
      * @return The set of candidate sub-rule IDs for the next step. Null means there are no candidates and thus, there
      *         is no point to evaluating subsequent steps.
      */
-    private static Set<Double> calculateCandidateSubRuleIdsForNextStep(final Set<Double> currentCandidateSubRuleIds,
+    private static Set<SubRuleContext> calculateCandidateSubRuleIdsForNextStep(final Set<SubRuleContext> currentCandidateSubRuleIds,
                                                                        final NameState fromState,
                                                                        final Patterns fromPattern) {
         // These are all the sub-rules that use the matched pattern to transition to the next NameState. Note that they
         // are not all candidates as they may have required different values for previously evaluated fields.
-        Set<Double> subRuleIds = fromState.getNonTerminalSubRuleIdsForPattern(fromPattern);
+        Set<SubRuleContext> subRuleIds = fromState.getNonTerminalSubRuleIdsForPattern(fromPattern);
 
         // If no sub-rules used the matched pattern to transition to the next NameState, then there are no matches to be
         // found by going further.
@@ -156,7 +156,7 @@ class Finder {
 
         // There are candidate sub-rules, so retain only those that used the matched pattern to transition to the next
         // NameState.
-        Set<Double> candidateSubRuleIdsForNextStep = new HashSet<>();
+        Set<SubRuleContext> candidateSubRuleIdsForNextStep = new HashSet<>();
         intersection(subRuleIds, currentCandidateSubRuleIds, candidateSubRuleIdsForNextStep);
         return candidateSubRuleIdsForNextStep;
     }
@@ -193,7 +193,7 @@ class Finder {
         }
     }
 
-    private static void tryNameMatching(final Set<Double> candidateSubRuleIds, final NameState nameState,
+    private static void tryNameMatching(final Set<SubRuleContext> candidateSubRuleIds, final NameState nameState,
                                         final Task task, final int keyIndex,
                                         final SubRuleContext.Generator subRuleContextGenerator) {
         if (!nameState.hasKeyTransitions()) {
@@ -208,7 +208,7 @@ class Finder {
         }
     }
 
-    private static void addNameState(Set<Double> candidateSubRuleIds, NameState nameState, Patterns pattern, Task task,
+    private static void addNameState(Set<SubRuleContext> candidateSubRuleIds, NameState nameState, Patterns pattern, Task task,
                                      int nextKeyIndex, final SubRuleContext.Generator subRuleContextGenerator) {
         // one of the matches might imply a rule match
         task.collectRules(candidateSubRuleIds, nameState, pattern, subRuleContextGenerator);

--- a/src/main/software/amazon/event/ruler/Step.java
+++ b/src/main/software/amazon/event/ruler/Step.java
@@ -14,9 +14,9 @@ import java.util.Set;
 class Step {
     final int keyIndex;
     final NameState nameState;
-    final Set<Double> candidateSubRuleIds;
+    final Set<SubRuleContext> candidateSubRuleIds;
 
-    Step(final int keyIndex, final NameState nameState, final Set<Double> candidateSubRuleIds) {
+    Step(final int keyIndex, final NameState nameState, final Set<SubRuleContext> candidateSubRuleIds) {
         this.keyIndex = keyIndex;
         this.nameState = nameState;
         this.candidateSubRuleIds = candidateSubRuleIds;

--- a/src/main/software/amazon/event/ruler/SubRuleContext.java
+++ b/src/main/software/amazon/event/ruler/SubRuleContext.java
@@ -11,30 +11,34 @@ import java.util.concurrent.ConcurrentHashMap;
  * A sub-rule refers to name/value pairs, usually represented by Map of String to List of Patterns, that compose a rule.
  * In the case of $or, one rule will have multiple name/value pairs, and this is why we use the "sub-rule" terminology.
  */
-public class SubRuleContext {
+public final class SubRuleContext {
 
-    private final double id;
+    private final long id;
+    private final Object ruleName;
 
-    private SubRuleContext(double id) {
+    SubRuleContext(long id, Object ruleName) {
         this.id = id;
+        this.ruleName = ruleName;
     }
 
-    public double getId() {
-        return id;
+    public Object getRuleName() {
+        return ruleName;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (o == null || !(o instanceof SubRuleContext)) {
-            return false;
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
         }
-        SubRuleContext otherContext = (SubRuleContext) o;
-        return id == otherContext.id;
+        if (obj instanceof SubRuleContext) {
+            return id == ((SubRuleContext) obj).id;
+        }
+        return false;
     }
 
     @Override
     public int hashCode() {
-        return Double.hashCode(id);
+        return Long.hashCode(id);
     }
 
     /**
@@ -42,32 +46,17 @@ public class SubRuleContext {
      */
     static final class Generator {
 
-        private double nextId = -Double.MAX_VALUE;
-
-        private final Map<Object, Set<Double>> nameToIds = new ConcurrentHashMap<>();
-        private final Map<Double, Object> idToName = new ConcurrentHashMap<>();
+        private final Map<Object, Set<SubRuleContext>> nameToContext = new ConcurrentHashMap<>();
+        private long nextId;
 
         public SubRuleContext generate(Object ruleName) {
-            assert nextId < Double.MAX_VALUE : "SubRuleContext.Generator's nextId reached Double.MAX_VALUE - " +
-                    "this required the equivalent of calling generate() at 6 billion TPS for 100 years";
-
-            SubRuleContext subRuleContext = new SubRuleContext(nextId);
-            if (!nameToIds.containsKey(ruleName)) {
-                nameToIds.put(ruleName, new HashSet<>());
-            }
-            nameToIds.get(ruleName).add(nextId);
-            idToName.put(nextId, ruleName);
-
-            nextId = Math.nextUp(nextId);
+            SubRuleContext subRuleContext = new SubRuleContext(nextId++, ruleName);
+            nameToContext.computeIfAbsent(ruleName, k -> new HashSet<>()).add(subRuleContext);
             return subRuleContext;
         }
 
-        public Set<Double> getIdsGeneratedForName(Object ruleName) {
-            return nameToIds.get(ruleName);
-        }
-
-        public Object getNameForGeneratedId(Double id) {
-            return idToName.get(id);
+        public Set<SubRuleContext> getIdsGeneratedForName(Object ruleName) {
+            return nameToContext.get(ruleName);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/Task.java
+++ b/src/main/software/amazon/event/ruler/Task.java
@@ -80,21 +80,21 @@ class Task {
         return new ArrayList<>(matchingRules);
     }
 
-    void collectRules(final Set<Double> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
+    void collectRules(final Set<SubRuleContext> candidateSubRuleIds, final NameState nameState, final Patterns pattern,
                       final SubRuleContext.Generator subRuleContextGenerator) {
-        Set<Double> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
+        Set<SubRuleContext> terminalSubRuleIds = nameState.getTerminalSubRuleIdsForPattern(pattern);
         if (terminalSubRuleIds == null) {
             return;
         }
 
         // If no candidates, that means we're on the first step, so all sub-rules are candidates.
         if (candidateSubRuleIds == null || candidateSubRuleIds.isEmpty()) {
-            for (Double terminalSubRuleId : terminalSubRuleIds) {
-                matchingRules.add(subRuleContextGenerator.getNameForGeneratedId(terminalSubRuleId));
+            for (SubRuleContext terminalSubRuleId : terminalSubRuleIds) {
+                matchingRules.add(terminalSubRuleId.getRuleName());
             }
         } else {
             intersection(candidateSubRuleIds, terminalSubRuleIds, matchingRules,
-                    id -> subRuleContextGenerator.getNameForGeneratedId(id));
+                    SubRuleContext::getRuleName);
         }
     }
 }

--- a/src/test/software/amazon/event/ruler/NameStateTest.java
+++ b/src/test/software/amazon/event/ruler/NameStateTest.java
@@ -15,40 +15,45 @@ import static org.junit.Assert.assertTrue;
 
 public class NameStateTest {
 
+    final SubRuleContext c1 = new SubRuleContext(1, "c1");
+    final SubRuleContext c2 = new SubRuleContext(2, "c2");
+    final SubRuleContext c3 = new SubRuleContext(3, "c3");
+    final SubRuleContext c4 = new SubRuleContext(4, "c4");
+
     @Test
     public void testAddSubRule() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule2", c3, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(asList(1.0, 3.0)),
+        assertEquals(new HashSet<>(asList(c1, c3)),
                 nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
-        assertEquals(new HashSet<>(Collections.singletonList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
+        assertEquals(new HashSet<>(Collections.singletonList(c2)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
         assertNull(nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
     public void testDeleteSubRule() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule2", 2.0, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", c2, Patterns.exactMatch("b"), true);
 
-        assertEquals(new HashSet<>(Collections.singletonList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
-        assertEquals(new HashSet<>(Collections.singletonList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("b"), true);
-        assertEquals(new HashSet<>(Collections.singletonList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
-        assertEquals(new HashSet<>(Collections.singletonList(2.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule("rule2", 2.0, Patterns.exactMatch("b"), true);
-        assertEquals(new HashSet<>(Collections.singletonList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(Collections.singletonList(c1)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(Collections.singletonList(c2)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
+        nameState.deleteSubRule("rule1", c1, Patterns.exactMatch("b"), true);
+        assertEquals(new HashSet<>(Collections.singletonList(c1)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        assertEquals(new HashSet<>(Collections.singletonList(c2)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
+        nameState.deleteSubRule("rule2", c2, Patterns.exactMatch("b"), true);
+        assertEquals(new HashSet<>(Collections.singletonList(c1)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule("rule2", 2.0, Patterns.exactMatch("a"), true);
-        assertEquals(new HashSet<>(Collections.singletonList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule("rule2", c2, Patterns.exactMatch("a"), true);
+        assertEquals(new HashSet<>(Collections.singletonList(c1)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
-        assertEquals(new HashSet<>(Collections.singletonList(1.0)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
+        nameState.deleteSubRule("rule1", c1, Patterns.exactMatch("a"), false);
+        assertEquals(new HashSet<>(Collections.singletonList(c1)), nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
-        nameState.deleteSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
+        nameState.deleteSubRule("rule1", c1, Patterns.exactMatch("a"), true);
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
         assertNull(nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("b")));
     }
@@ -56,10 +61,10 @@ public class NameStateTest {
     @Test
     public void testGetTerminalPatterns() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), false);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), true);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule2", c3, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule3", c4, Patterns.exactMatch("c"), true);
 
         Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
                 Patterns.exactMatch("a"), Patterns.exactMatch("c")));
@@ -69,10 +74,10 @@ public class NameStateTest {
     @Test
     public void testGetNonTerminalPatterns() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), true);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("c"), false);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("b"), true);
+        nameState.addSubRule("rule2", c3, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule3", c4, Patterns.exactMatch("c"), false);
 
         Set<Patterns> expectedPatterns = new HashSet<>(Arrays.asList(
                 Patterns.exactMatch("a"), Patterns.exactMatch("c")));
@@ -82,33 +87,33 @@ public class NameStateTest {
     @Test
     public void testGetTerminalSubRuleIdsForPattern() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("b"), false);
-        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", c3, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule3", c4, Patterns.exactMatch("a"), true);
 
-        assertEquals(new HashSet<>(Arrays.asList(2.0, 4.0)),
+        assertEquals(new HashSet<>(Arrays.asList(c2, c4)),
                 nameState.getTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
     public void testGetNonTerminalSubRuleIdsForPattern() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule2", 3.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule3", 4.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule2", c3, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule3", c4, Patterns.exactMatch("b"), false);
 
-        assertEquals(new HashSet<>(Arrays.asList(2.0, 3.0)),
+        assertEquals(new HashSet<>(Arrays.asList(c2, c3)),
                 nameState.getNonTerminalSubRuleIdsForPattern(Patterns.exactMatch("a")));
     }
 
     @Test
     public void testContainsRule() {
         NameState nameState = new NameState();
-        nameState.addSubRule("rule1", 1.0, Patterns.exactMatch("a"), true);
-        nameState.addSubRule("rule2", 2.0, Patterns.exactMatch("a"), false);
-        nameState.addSubRule("rule1", 2.0, Patterns.exactMatch("b"), false);
+        nameState.addSubRule("rule1", c1, Patterns.exactMatch("a"), true);
+        nameState.addSubRule("rule2", c2, Patterns.exactMatch("a"), false);
+        nameState.addSubRule("rule1", c2, Patterns.exactMatch("b"), false);
 
         assertTrue(nameState.containsRule("rule1", Patterns.exactMatch("a")));
         assertTrue(nameState.containsRule("rule2", Patterns.exactMatch("a")));

--- a/src/test/software/amazon/event/ruler/SubRuleContextTest.java
+++ b/src/test/software/amazon/event/ruler/SubRuleContextTest.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class SubRuleContextTest {
 

--- a/src/test/software/amazon/event/ruler/SubRuleContextTest.java
+++ b/src/test/software/amazon/event/ruler/SubRuleContextTest.java
@@ -14,38 +14,12 @@ public class SubRuleContextTest {
     private static final String NAME = "name";
 
     @Test
-    public void testGenerate() {
-        SubRuleContext.Generator generatorA = new SubRuleContext.Generator();
-        SubRuleContext contextA1 = generatorA.generate(NAME);
-        SubRuleContext contextA2 = generatorA.generate(NAME);
-
-        SubRuleContext.Generator generatorB = new SubRuleContext.Generator();
-        SubRuleContext contextB1 = generatorB.generate(NAME);
-        SubRuleContext contextB2 = generatorB.generate(NAME);
-        SubRuleContext contextB3 = generatorB.generate(NAME);
-
-        SubRuleContext contextA3 = generatorA.generate(NAME);
-
-        double expected1 = -Double.MAX_VALUE;
-        double expected2 = Math.nextUp(expected1);
-        double expected3 = Math.nextUp(expected2);
-        assertTrue(expected1 < expected2);
-        assertTrue(expected2 < expected3);
-        assertEquals(expected1, contextA1.getId(), 0.0);
-        assertEquals(expected1, contextB1.getId(), 0.0);
-        assertEquals(expected2, contextA2.getId(), 0.0);
-        assertEquals(expected2, contextB2.getId(), 0.0);
-        assertEquals(expected3, contextA3.getId(), 0.0);
-        assertEquals(expected3, contextB3.getId(), 0.0);
-    }
-
-    @Test
     public void testGetters() {
         SubRuleContext.Generator generator = new SubRuleContext.Generator();
         SubRuleContext context = generator.generate(NAME);
-        assertEquals(NAME, generator.getNameForGeneratedId(context.getId()));
-        Set<Double> expectedIds = new HashSet<>();
-        expectedIds.add(context.getId());
+        assertEquals(NAME, context.getRuleName());
+        Set<SubRuleContext> expectedIds = new HashSet<>();
+        expectedIds.add(context);
         assertEquals(expectedIds, generator.getIdsGeneratedForName(NAME));
     }
 

--- a/src/test/software/amazon/event/ruler/SubRuleContextTest.java
+++ b/src/test/software/amazon/event/ruler/SubRuleContextTest.java
@@ -13,6 +13,19 @@ public class SubRuleContextTest {
     private static final String NAME = "name";
 
     @Test
+    public void testPerformance() {
+        long start = System.nanoTime();
+
+        for (int i = 0; i < 10_000_000; i++) {
+            SubRuleContext.Generator generator = new SubRuleContext.Generator();
+            SubRuleContext c = generator.generate(NAME);
+//            assertEquals(NAME, generator.getNameForGeneratedId(c.getId()));
+            assertEquals(NAME, c.getRuleName());
+        }
+        System.out.println( (System.nanoTime() - start) / 1000_000 + "ms");
+    }
+
+    @Test
     public void testGetters() {
         SubRuleContext.Generator generator = new SubRuleContext.Generator();
         SubRuleContext context = generator.generate(NAME);


### PR DESCRIPTION
### Description of changes:

Instead of `Double` id use `SubRuleContext` directly everywhere. `SubRuleContext` id is only used internally for backward compatibility in `equals` and `hashCode` (not sure if this is actually needed, but tests check that). The benchmarks are not stable (need JMH with forking, proper warmup and multiple longer iterations for individual benchmarks), but overall can see 3-8% in throughput improvement on some benchmarks with this easy fix.

Using `long` as id instead of `double` because `long` is typically faster and actually can produce more unique 64-bit patterns than `double` because for `long` every 64-bit pattern is valid while for `double` it is not true (NaN).

Changed only types but did not rename variables all over the place because it would be harder to review, can be done later as needed.

#### Benchmark / Performance (for source code changes):

```Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 11459
Events/sec: 18593.9
 Rules/sec: 130157.6
Reading citylots2
Read 213068 events
EXACT events/sec: 274218.8
WILDCARD events/sec: 176526.9
PREFIX events/sec: 271078.9
PREFIX_EQUALS_IGNORE_CASE_RULES events/sec: 272465.5
SUFFIX events/sec: 260474.3
SUFFIX_EQUALS_IGNORE_CASE_RULES events/sec: 266002.5
EQUALS_IGNORE_CASE events/sec: 233883.6
NUMERIC events/sec: 145937.0
ANYTHING-BUT events/sec: 129919.5
ANYTHING-BUT-IGNORE-CASE events/sec: 142902.7
ANYTHING-BUT-PREFIX events/sec: 153507.2
ANYTHING-BUT-SUFFIX events/sec: 150365.6
ANYTHING-BUT-WILDCARD events/sec: 160322.0
COMPLEX_ARRAYS events/sec: 32078.9
PARTIAL_COMBO events/sec: 49037.5
COMBO events/sec: 20434.3
```

Overall the becnhmark results are not conclusive across diffrent jvm versions: the same benchmark can be noticeably better or worse, from what I see from main branch history they are quite flaky. Will try to improve benhcmarks in a separate PR. 
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
