### PR TITLE
Improve GenericMachine.Builder Generics

### DIFF
--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -1,9 +1,9 @@
 package software.amazon.event.ruler;
 
-import static software.amazon.event.ruler.SetOperations.intersection;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
+
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -18,7 +18,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+
+import static software.amazon.event.ruler.SetOperations.intersection;
 
 /**
  *  Represents a state machine used to match name/value patterns to rules.

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -1,9 +1,9 @@
 package software.amazon.event.ruler;
 
+import static software.amazon.event.ruler.SetOperations.intersection;
+
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -18,8 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import static software.amazon.event.ruler.SetOperations.intersection;
+import javax.annotation.Nonnull;
 
 /**
  *  Represents a state machine used to match name/value patterns to rules.
@@ -747,11 +746,11 @@ public class GenericMachine<T> {
                 '}';
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static <T> Builder<GenericMachine<T>, T> builder() {
+        return new Builder<>();
     }
 
-    public static class Builder<T extends GenericMachine> {
+    public static class Builder<M extends GenericMachine<T>, T> {
 
         /**
          * Normally, NameStates are re-used for a given key subsequence and pattern if this key subsequence and pattern have
@@ -766,13 +765,13 @@ public class GenericMachine<T> {
 
         Builder() {}
 
-        public Builder<T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
+        public Builder<M,T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
             this.additionalNameStateReuse = additionalNameStateReuse;
             return this;
         }
 
-        public T build() {
-            return (T) new GenericMachine(buildConfig());
+        public M build() {
+            return (M) new GenericMachine<T>(buildConfig());
         }
 
         protected GenericMachineConfiguration buildConfig() {

--- a/src/main/software/amazon/event/ruler/Machine.java
+++ b/src/main/software/amazon/event/ruler/Machine.java
@@ -26,7 +26,7 @@ public class Machine extends GenericMachine<String> {
         return new Builder();
     }
 
-    public static class Builder extends GenericMachine.Builder<Machine> {
+    public static class Builder extends GenericMachine.Builder<Machine, String> {
 
         Builder() {}
 

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -201,11 +201,11 @@ public class GenericMachineTest {
     }
 
     @Test
-    public void testBuilder() throws Exception {
+    public void testBuilderNonString() throws Exception {
       GenericMachine<Integer> machine = GenericMachine.<Integer>builder().build();
-      machine.addRule(1, "{ \"key\" : [ 1 ] }");
-      List<Integer> result = machine.rulesForEvent(new String[]{"key", "1"});
-      assertEquals(result.get(0), (Integer)1);
+      machine.addRule(100, "{ \"key\" : [ 5 ] }");
+      List<Integer> result = machine.rulesForEvent(new String[]{"key", "5"});
+      assertEquals(result.get(0), (Integer)100);
     }
 
     // create a customized class as T

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -200,6 +200,14 @@ public class GenericMachineTest {
         assertEquals(r4, r4AC);
     }
 
+    @Test
+    public void testBuilder() throws Exception {
+      GenericMachine<Integer> machine = GenericMachine.<Integer>builder().build();
+      machine.addRule(1, "{ \"key\" : [ 1 ] }");
+      List<Integer> result = machine.rulesForEvent(new String[]{"key", "1"});
+      assertEquals(result.get(0), (Integer)1);
+    }
+
     // create a customized class as T
     // TODO: Figure out what these unused fields are for and either finish what was started here, or discard it
     public static final class SimpleFilter {

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -1,9 +1,11 @@
 package software.amazon.event.ruler;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,10 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 /**
  * Unit testing a state GenericMachine is hard.  Tried hand-computing a few GenericMachines
@@ -346,5 +345,4 @@ public class GenericMachineTest {
         rules = genericMachine.rulesForEvent(new ArrayList<>());
         assertTrue(rules.contains("rule1"));
     }
-
 }

--- a/src/test/software/amazon/event/ruler/GenericMachineTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineTest.java
@@ -1,11 +1,9 @@
 package software.amazon.event.ruler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,7 +11,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit testing a state GenericMachine is hard.  Tried hand-computing a few GenericMachines
@@ -345,4 +346,5 @@ public class GenericMachineTest {
         rules = genericMachine.rulesForEvent(new ArrayList<>());
         assertTrue(rules.contains("rule1"));
     }
+
 }


### PR DESCRIPTION
### Issue #, if available:
[174](https://github.com/aws/event-ruler/issues/174)

### Description of changes:
I Improved the Builder Generics to allow GenericMachine.Builder to create instances of a type while still allowing Machine.Builder to function.

```
GenericMachine<Integer> machine = GenericMachine.<Integer>builder().build();
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
