### PR TITLE
Fix testPatternPermutations within ByteMachingTest

### DIFF
--- a/src/test/software/amazon/event/ruler/ByteMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ByteMachineTest.java
@@ -3,7 +3,6 @@ package software.amazon.event.ruler;
 import org.junit.Test;
 import software.amazon.event.ruler.input.ParseException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;


### PR DESCRIPTION

### Issue #, if available: 181

### Description of changes:

 For each test within the class we add a list of "noMatches" objects that should never be pattern matches intentinoally or not. However we never check if we ever accidentally register these pattern when adding other patterns. We will fix this by tracking when these patterns get added (probably by error) and then later validate the checks
    
Note, no impact to the correctness of the ByteMachine itself, just that the test scaffolding was broken and needed to be fixed.
    
 See https://github.com/aws/event-ruler/issues/181 for more context.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
