### PR TITLE
Add ByteMatch hashCode() to reduce transitions object count.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -81,8 +81,12 @@ final class ByteMatch extends SingleByteTransition  {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ByteMatch byteMatch = (ByteMatch) o;
         return Objects.equals(pattern, byteMatch.pattern) && Objects.equals(nextNameState, byteMatch.nextNameState);
     }

--- a/src/main/software/amazon/event/ruler/ByteMatch.java
+++ b/src/main/software/amazon/event/ruler/ByteMatch.java
@@ -1,6 +1,7 @@
 package software.amazon.event.ruler;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -76,5 +77,18 @@ final class ByteMatch extends SingleByteTransition  {
     @Override
     public String toString() {
         return "BM: HC=" + hashCode() + " P=" + pattern  + "(" + pattern.pattern() + ") NNS=" + nextNameState;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ByteMatch byteMatch = (ByteMatch) o;
+        return Objects.equals(pattern, byteMatch.pattern) && Objects.equals(nextNameState, byteMatch.nextNameState);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pattern, nextNameState);
     }
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -2418,7 +2418,7 @@ public class MachineTest {
         assertEquals(1, matchRules.size());
     }
 
-    @Test(timeout = 500)
+    @Test(timeout = 250)
     public void testApproximateSizeDoNotTakeForeverForRulesWithNumericMatchers() throws Exception {
         Machine machine = new Machine();
         machine.addRule("rule",
@@ -2428,7 +2428,7 @@ public class MachineTest {
                         "    \"c\": [{ \"numeric\": [\">\", 50] }]\n" +
                         "}");
 
-        assertEquals(3299, machine.approximateObjectCount(10000));
+        assertEquals(52, machine.approximateObjectCount(10000));
     }
 
     @Test


### PR DESCRIPTION
### Description of changes:
It takes many hours to compute the machine complexity of this rule on a laptop:

```
{
    "field1": [{
        "numeric": ["<=", 120.0]
    }],
    "field2": [{
        "numeric": [">", 300.0]
    }],
    "field3": [{
        "numeric": ["=", 60.0]
    }],
    "field4": [{
        "numeric": ["<", 60.0]
    }],
    "field5": [{
        "numeric": ["<=", 60.0]
    }]
}
```

This is because numeric matchers are compiles as ranges for comparison. The ranges create a sequence of numbers that then get added into the byte machine however most of these transition to a small number of state. See `ByteMachine.addRangePattern` for more details.

Given that the numbers are only transition to handful of end states, we should have been merging the transtion within `ByteMap.updateTransitions`. However the merge relies on transitions being comparable which isn't the case for ByteMap.

After adding hashcode() and equals(), we are not able to dedupe and avoid creating duplicates. This offers nominal benefit in rule matching latency but has notable improvement for (1) rule addition / removal time, and (2) when comparing the machine size / complexity.

#### Benchmark / Performance (for source code changes):

```
Running software.amazon.event.ruler.Benchmarks
Reading citylots2
Read 213068 events
Finding Rules...
Lots: 10000
Lots: 20000
Lots: 30000
Lots: 40000
Lots: 50000
Lots: 60000
Lots: 70000
Lots: 80000
Lots: 90000
Lots: 100000
Lots: 110000
Lots: 120000
Lots: 130000
Lots: 140000
Lots: 150000
Lots: 160000
Lots: 170000
Lots: 180000
Lots: 190000
Lots: 200000
Lots: 210000
Lines: 213068, Msec: 12131
Events/sec: 17563.9
 Rules/sec: 122947.5
Reading citylots2
Read 213068 events
EXACT events/sec: 236742.2
WILDCARD events/sec: 167112.2
PREFIX events/sec: 239402.2
PREFIX_EQUALS_IGNORE_CASE_RULES events/sec: 244344.0
SUFFIX events/sec: 238598.0
SUFFIX_EQUALS_IGNORE_CASE_RULES events/sec: 236742.2
EQUALS_IGNORE_CASE events/sec: 209506.4
NUMERIC events/sec: 126075.7
ANYTHING-BUT events/sec: 127128.9
ANYTHING-BUT-IGNORE-CASE events/sec: 131442.3
ANYTHING-BUT-PREFIX events/sec: 140361.0
ANYTHING-BUT-SUFFIX events/sec: 137908.1
ANYTHING-BUT-WILDCARD events/sec: 144355.0
COMPLEX_ARRAYS events/sec: 27149.3
PARTIAL_COMBO events/sec: 42922.6
COMBO events/sec: 17683.5
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 56.057 sec
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
