### PR TITLE
Introduce option to detect and fail on path overriding in rule definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -798,7 +798,7 @@ public class GenericMachine<T> {
             return this;
         }
 
-        public Builder<M, T> withRuleOverriding(boolean ruleOverriding) {
+        public Builder<M, T> withOverridesForDuplicateRules(boolean ruleOverriding) {
             this.ruleOverriding = ruleOverriding;
             return this;
         }

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -764,10 +764,42 @@ public class GenericMachine<T> {
          */
         private boolean additionalNameStateReuse = false;
 
+        /**
+         * If true, when encountering the same name path in a rule, the compiler will accept the rule and
+         * override previously encountered patterns with the latest patterns from the compilation of the
+         * last-most occurrence of the name path. For example:
+         * <pre>
+         * {@code
+         *   {
+         *     "a": [1, 2]
+         *     "a": [3, 4]
+         *   }
+         * }
+         * </pre>
+         * Will have the same effect as:
+         * <pre>
+         *   {@code
+         *   {
+         *    "a": [3, 4]
+         *    }
+         * }
+         * </pre>
+         *
+         * When set to false, all rules where paths are overlapping are considered invalid and rejected by the compiler.
+         * For retro-compatibility, rule overriding is by default true.
+         * @see <a href="https://github.com/aws/event-ruler/issues/22">Undocumented duplicate key behaviour for events and rules</a>
+         */
+        private boolean ruleOverriding = true;
+
         Builder() {}
 
         public Builder<M,T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
             this.additionalNameStateReuse = additionalNameStateReuse;
+            return this;
+        }
+
+        public Builder<M, T> withRuleOverriding(boolean ruleOverriding) {
+            this.ruleOverriding = ruleOverriding;
             return this;
         }
 
@@ -776,7 +808,7 @@ public class GenericMachine<T> {
         }
 
         protected GenericMachineConfiguration buildConfig() {
-            return new GenericMachineConfiguration(additionalNameStateReuse);
+            return new GenericMachineConfiguration(additionalNameStateReuse, ruleOverriding);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -412,7 +412,7 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final String json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
             addPatternRule(name, RuleCompiler.compile(json));
         }
@@ -427,7 +427,7 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final Reader json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
             addPatternRule(name, RuleCompiler.compile(json));
         }
@@ -442,7 +442,7 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final InputStream json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
             addPatternRule(name, RuleCompiler.compile(json));
         }
@@ -457,7 +457,7 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final byte[] json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
             addPatternRule(name, RuleCompiler.compile(json));
         }
@@ -472,7 +472,7 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final String json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
             deletePatternRule(name, RuleCompiler.compile(json));
         }
@@ -487,7 +487,7 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final Reader json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
             deletePatternRule(name, RuleCompiler.compile(json));
         }
@@ -502,7 +502,7 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final InputStream json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
             deletePatternRule(name, RuleCompiler.compile(json));
         }

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -414,7 +414,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -429,7 +429,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -444,7 +444,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -459,7 +459,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -474,7 +474,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -489,7 +489,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 
@@ -504,7 +504,7 @@ public class GenericMachine<T> {
         try {
             JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
         }
     }
 

--- a/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
+++ b/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
@@ -6,13 +6,19 @@ package software.amazon.event.ruler;
 class GenericMachineConfiguration {
 
     private final boolean additionalNameStateReuse;
+    private final boolean ruleOverriding;
 
-    GenericMachineConfiguration(boolean additionalNameStateReuse) {
+    GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding) {
         this.additionalNameStateReuse = additionalNameStateReuse;
+        this.ruleOverriding = ruleOverriding;
     }
 
     boolean isAdditionalNameStateReuse() {
         return additionalNameStateReuse;
+    }
+
+    public boolean isRuleOverriding() {
+        return ruleOverriding;
     }
 }
 

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -380,12 +380,12 @@ public class JsonRuleCompiler {
         if (rules.isEmpty()) {
             rules.add(new HashMap<>());
         }
-        rules.forEach(rule -> {
+        for (Map<String, List<Patterns>> rule : rules) {
             if (!withOverriding && rule.containsKey(name)) {
-                throw new IllegalArgumentException("Overriding path '" + name + "' is already defined. Please check that the rule does not list the same path multiple times.");
+                barf(parser, String.format("Path `%s` cannot be allowed multiple times", name));
             }
             rule.put(name, values);
-        });
+        }
     }
 
     // Used to be, the format was

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import static software.amazon.event.ruler.input.DefaultParser.getParser;
 
 /**
- * Represents a updated compiler comparing to RuleCompiler class, it parses a rule described by a JSON string into
+ * Represents an updated compiler comparing to RuleCompiler class, it parses a rule described by a JSON string into
  * a list of Map which is composed of field Patterns, each Map represents one dedicated match branch in the rule.
  * By default, fields in the rule will be interpreted as "And" relationship implicitly and will result into one Map with
  * fields of Patterns, but once it comes across the "$or" relationship which is explicitly decorated by "$or" primitive
@@ -62,9 +62,22 @@ public class JsonRuleCompiler {
      * @param source rule, as a String
      * @return null if the rule is valid, otherwise an error message
      */
-    public static String check(final Reader source) {
+    public static String check(final Reader source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
+            return null;
+        } catch (Exception e) {
+            return e.getLocalizedMessage();
+        }
+    }
+
+    public static String check(final Reader source) {
+        return check(source, true);
+    }
+
+    public static String check(final String source, final boolean withOverriding) {
+        try {
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
@@ -72,8 +85,12 @@ public class JsonRuleCompiler {
     }
 
     public static String check(final String source) {
+        return check(source, true);
+    }
+
+    public static String check(final byte[] source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
@@ -81,8 +98,12 @@ public class JsonRuleCompiler {
     }
 
     public static String check(final byte[] source) {
+        return check(source, true);
+    }
+
+    public static String check(final InputStream source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
@@ -90,12 +111,7 @@ public class JsonRuleCompiler {
     }
 
     public static String check(final InputStream source) {
-        try {
-            doCompile(JSON_FACTORY.createParser(source));
-            return null;
-        } catch (Exception e) {
-            return e.getLocalizedMessage();
-        }
+        return check(source, true);
     }
 
     /**
@@ -105,33 +121,50 @@ public class JsonRuleCompiler {
      * @return List of Sub rule which represented as Map
      * @throws IOException if the rule isn't syntactically valid
      */
-    public static List<Map<String, List<Patterns>>> compile(final Reader source)
+    public static List<Map<String, List<Patterns>>> compile(final Reader source, boolean withOverriding)
             throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
     }
 
-    public static List<Map<String, List<Patterns>>> compile(final String source)
-            throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+    public static List<Map<String, List<Patterns>>> compile(final Reader source) throws IOException {
+        return compile(source, true);
     }
 
-    public static List<Map<String, List<Patterns>>> compile(final byte[] source)
+
+    public static List<Map<String, List<Patterns>>> compile(final String source, boolean withOverriding)
             throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
     }
 
-    public static List<Map<String, List<Patterns>>> compile(final InputStream source)
-            throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+    public static List<Map<String, List<Patterns>>> compile(final String source) throws IOException {
+        return compile(source, true);
     }
 
-    private static List<Map<String, List<Patterns>>> doCompile(final JsonParser parser) throws IOException {
+    public static List<Map<String, List<Patterns>>> compile(final byte[] source, boolean withOverriding)
+            throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
+    }
+
+    public static List<Map<String, List<Patterns>>> compile(final byte[] source) throws IOException {
+        return compile(source, true);
+    }
+
+    public static List<Map<String, List<Patterns>>> compile(final InputStream source, final boolean withOverriding)
+            throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
+    }
+
+    public static List<Map<String, List<Patterns>>> compile(final InputStream source) throws IOException {
+        return compile(source, true);
+    }
+
+    private static List<Map<String, List<Patterns>>> doCompile(final JsonParser parser, boolean withOverriding) throws IOException {
         final Path path = new Path();
         final List<Map<String, List<Patterns>>> rules = new ArrayList<>();
         if (parser.nextToken() != JsonToken.START_OBJECT) {
             barf(parser, "Filter is not an object");
         }
-        parseObject(rules, path, parser, true);
+        parseObject(rules, path, parser, true, withOverriding);
         parser.close();
         return rules;
     }
@@ -139,7 +172,8 @@ public class JsonRuleCompiler {
     private static void parseObject(final List<Map<String, List<Patterns>>> rules,
                                     final Path path,
                                     final JsonParser parser,
-                                    final boolean withQuotes) throws IOException {
+                                    final boolean withQuotes,
+                                    final boolean withOverriding) throws IOException {
 
         boolean fieldsPresent = false;
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -151,7 +185,7 @@ public class JsonRuleCompiler {
             // If it is "$or" primitive, we should bypass that primitive itself in the path as it is not
             // a real field name, it is just used to describe the "$or" relationship among object in the followed array.
             if (stepName.equals(Constants.OR_RELATIONSHIP_KEYWORD)) {
-                parseIntoOrRelationship(rules, path, parser, withQuotes);
+                parseIntoOrRelationship(rules, path, parser, withQuotes, withOverriding);
                 // all Objects in $or array have been handled in above function, just bypass below logic.
                 continue;
             }
@@ -159,12 +193,12 @@ public class JsonRuleCompiler {
             switch (parser.nextToken()) {
             case START_OBJECT:
                 path.push(stepName);
-                parseObject(rules, path, parser, withQuotes);
+                parseObject(rules, path, parser, withQuotes, withOverriding);
                 path.pop();
                 break;
 
             case START_ARRAY:
-                writeRules(rules, path.extendedName(stepName), parser, withQuotes);
+                writeRules(rules, path.extendedName(stepName), parser, withQuotes, withOverriding);
                 break;
 
             default:
@@ -179,7 +213,8 @@ public class JsonRuleCompiler {
     private static void parseObjectInsideOrRelationship(final List<Map<String, List<Patterns>>> rules,
                                                         final Path path,
                                                         final JsonParser parser,
-                                                        final boolean withQuotes) throws IOException {
+                                                        final boolean withQuotes,
+                                                        final boolean withOverriding) throws IOException {
 
         boolean fieldsPresent = false;
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -191,7 +226,7 @@ public class JsonRuleCompiler {
             // If it is "$or" primitive, we should bypass the "$or" primitive itself in the path as it is not
             // a real step name, it is just used to describe the "$or" relationship among object in the followed Array.
             if (stepName.equals(Constants.OR_RELATIONSHIP_KEYWORD)) {
-                parseIntoOrRelationship(rules, path, parser, withQuotes);
+                parseIntoOrRelationship(rules, path, parser, withQuotes, withOverriding);
                 continue;
             }
 
@@ -204,12 +239,12 @@ public class JsonRuleCompiler {
             switch (parser.nextToken()) {
                 case START_OBJECT:
                     path.push(stepName);
-                    parseObjectInsideOrRelationship(rules, path, parser, withQuotes);
+                    parseObjectInsideOrRelationship(rules, path, parser, withQuotes, withOverriding);
                     path.pop();
                     break;
 
                 case START_ARRAY:
-                    writeRules(rules, path.extendedName(stepName), parser, withQuotes);
+                    writeRules(rules, path.extendedName(stepName), parser, withQuotes, withOverriding);
                     break;
 
                 default:
@@ -247,7 +282,8 @@ public class JsonRuleCompiler {
     private static void parseIntoOrRelationship(final List<Map<String, List<Patterns>>> rules,
                                                 final Path path,
                                                 final JsonParser parser,
-                                                final boolean withQuotes) throws IOException {
+                                                final boolean withQuotes,
+                                                final boolean withOverriding) throws IOException {
 
         final List<Map<String, List<Patterns>>> currentRules = deepCopyRules(rules);
         rules.clear();
@@ -265,7 +301,7 @@ public class JsonRuleCompiler {
                 if (newRules.isEmpty()) {
                     newRules.add(new HashMap<>());
                 }
-                parseObjectInsideOrRelationship(newRules, path, parser, withQuotes);
+                parseObjectInsideOrRelationship(newRules, path, parser, withQuotes, withOverriding);
                 rules.addAll(newRules);
             } else {
                 barf(parser,
@@ -285,7 +321,8 @@ public class JsonRuleCompiler {
     private static void writeRules(final List<Map<String, List<Patterns>>> rules,
                                    final String name,
                                    final JsonParser parser,
-                                   final boolean withQuotes) throws IOException {
+                                   final boolean withQuotes,
+                                   final boolean withOverriding) throws IOException {
 
         JsonToken token;
         final List<Patterns> values = new ArrayList<>();
@@ -343,7 +380,12 @@ public class JsonRuleCompiler {
         if (rules.isEmpty()) {
             rules.add(new HashMap<>());
         }
-        rules.forEach(rule -> rule.put(name, values));
+        rules.forEach(rule -> {
+            if (!withOverriding && rule.containsKey(name)) {
+                throw new IllegalArgumentException("Overriding path '" + name + "' is already defined. Please check that the rule does not list the same path multiple times.");
+            }
+            rule.put(name, values);
+        });
     }
 
     // Used to be, the format was

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -47,13 +47,17 @@ public final class RuleCompiler {
      * @param source rule, as a Reader
      * @return null if the rule is valid, otherwise an error message
      */
-    public static String check(final Reader source) {
+    public static String check(final Reader source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
         }
+    }
+
+    public static String check(final Reader source) {
+        return check(source, true);
     }
 
     /**
@@ -61,13 +65,17 @@ public final class RuleCompiler {
      * @param source rule, as a String
      * @return null if the rule is valid, otherwise an error message
      */
-    public static String check(final String source) {
+    public static String check(final String source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
         }
+    }
+
+    public static String check(final String source) {
+        return check(source, true);
     }
 
     /**
@@ -75,13 +83,17 @@ public final class RuleCompiler {
      * @param source rule, as a byte array
      * @return null if the rule is valid, otherwise an error message
      */
-    public static String check(final byte[] source) {
+    public static String check(final byte[] source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
         }
+    }
+
+    public static String check(final byte[] source) {
+        return check(source, true);
     }
 
     /**
@@ -89,13 +101,17 @@ public final class RuleCompiler {
      * @param source rule, as an InputStream
      * @return null if the rule is valid, otherwise an error message
      */
-    public static String check(final InputStream source) {
+    public static String check(final InputStream source, final boolean withOverriding) {
         try {
-            doCompile(JSON_FACTORY.createParser(source));
+            doCompile(JSON_FACTORY.createParser(source), withOverriding);
             return null;
         } catch (Exception e) {
             return e.getLocalizedMessage();
         }
+    }
+
+    public static String check(final InputStream source) {
+        return check(source, true);
     }
 
     /**
@@ -105,8 +121,12 @@ public final class RuleCompiler {
      * @return Map form of rule
      * @throws IOException if the rule isn't syntactically valid
      */
+    public static Map<String, List<Patterns>> compile(final Reader source, final boolean withOverriding) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
+    }
+
     public static Map<String, List<Patterns>> compile(final Reader source) throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+        return compile(source, true);
     }
 
     /**
@@ -116,8 +136,12 @@ public final class RuleCompiler {
      * @return Map form of rule
      * @throws IOException if the rule isn't syntactically valid
      */
+    public static Map<String, List<Patterns>> compile(final String source, final boolean withOverriding) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
+    }
+
     public static Map<String, List<Patterns>> compile(final String source) throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+        return compile(source, true);
     }
 
     /**
@@ -127,8 +151,12 @@ public final class RuleCompiler {
      * @return Map form of rule
      * @throws IOException if the rule isn't syntactically valid
      */
+    public static Map<String, List<Patterns>> compile(final byte[] source, final boolean withOverriding) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
+    }
+
     public static Map<String, List<Patterns>> compile(final byte[] source) throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+        return compile(source, true);
     }
 
     /**
@@ -138,17 +166,21 @@ public final class RuleCompiler {
      * @return Map form of rule
      * @throws IOException if the rule isn't syntactically valid
      */
-    public static Map<String, List<Patterns>> compile(final InputStream source) throws IOException {
-        return doCompile(JSON_FACTORY.createParser(source));
+    public static Map<String, List<Patterns>> compile(final InputStream source, final boolean withOverriding) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding);
     }
 
-    private static Map<String, List<Patterns>> doCompile(final JsonParser parser) throws IOException {
+    public static Map<String, List<Patterns>> compile(final InputStream source) throws IOException {
+        return compile(source, true);
+    }
+
+    private static Map<String, List<Patterns>> doCompile(final JsonParser parser, final boolean withOverriding) throws IOException {
         final Path path = new Path();
         final Map<String, List<Patterns>> rule = new HashMap<>();
         if (parser.nextToken() != JsonToken.START_OBJECT) {
             barf(parser, "Filter is not an object");
         }
-        parseObject(rule, path, parser, true);
+        parseObject(rule, path, parser, true, withOverriding);
         parser.close();
         return rule;
     }
@@ -156,7 +188,8 @@ public final class RuleCompiler {
     private static void parseObject(final Map<String, List<Patterns>> rule,
                                     final Path path,
                                     final JsonParser parser,
-                                    final boolean withQuotes) throws IOException {
+                                    final boolean withQuotes,
+                                    final boolean withOverriding) throws IOException {
 
         boolean fieldsPresent = false;
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -168,12 +201,12 @@ public final class RuleCompiler {
             switch (parser.nextToken()) {
             case START_OBJECT:
                 path.push(stepName);
-                parseObject(rule, path, parser, withQuotes);
+                parseObject(rule, path, parser, withQuotes, withOverriding);
                 path.pop();
                 break;
 
             case START_ARRAY:
-                writeRules(rule, path.extendedName(stepName), parser, withQuotes);
+                writeRules(rule, path.extendedName(stepName), parser, withQuotes, withOverriding);
                 break;
 
             default:
@@ -188,7 +221,8 @@ public final class RuleCompiler {
     private static void writeRules(final Map<String, List<Patterns>> rule,
                                    final String name,
                                    final JsonParser parser,
-                                   final boolean withQuotes) throws IOException {
+                                   final boolean withQuotes,
+                                   final boolean withOverriding) throws IOException {
         JsonToken token;
         final List<Patterns> values = new ArrayList<>();
 
@@ -239,6 +273,9 @@ public final class RuleCompiler {
         }
         if (values.isEmpty()) {
             barf(parser, "Empty arrays are not allowed");
+        }
+        if (!withOverriding && rule.containsKey(name)) {
+            throw new IllegalArgumentException("Overriding path '" + name + "' is already defined. Please check that the rule does not list the same path multiple times.");
         }
         rule.put(name, values);
     }

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -275,7 +275,7 @@ public final class RuleCompiler {
             barf(parser, "Empty arrays are not allowed");
         }
         if (!withOverriding && rule.containsKey(name)) {
-            throw new IllegalArgumentException("Overriding path '" + name + "' is already defined. Please check that the rule does not list the same path multiple times.");
+            barf(parser, String.format("Path `%s` cannot be allowed multiple times", name));
         }
         rule.put(name, values);
     }

--- a/src/test/software/amazon/event/ruler/GenericMachineConfigurationTest.java
+++ b/src/test/software/amazon/event/ruler/GenericMachineConfigurationTest.java
@@ -9,11 +9,21 @@ public class GenericMachineConfigurationTest {
 
     @Test
     public void testAdditionalNameStateReuseTrue() {
-        assertTrue(new GenericMachineConfiguration(true).isAdditionalNameStateReuse());
+        assertTrue(new GenericMachineConfiguration(true, true).isAdditionalNameStateReuse());
     }
 
     @Test
     public void testAdditionalNameStateReuseFalse() {
-        assertFalse(new GenericMachineConfiguration(false).isAdditionalNameStateReuse());
+        assertFalse(new GenericMachineConfiguration(false, true).isAdditionalNameStateReuse());
+    }
+
+    @Test
+    public void testWithRuleOverridingTrue() {
+        assertTrue(new GenericMachineConfiguration(true, true).isRuleOverriding());
+    }
+
+    @Test
+    public void testWithRuleOverridingFalse() {
+        assertFalse(new GenericMachineConfiguration(true, false).isRuleOverriding());
     }
 }

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -585,6 +585,21 @@ public class RuleCompilerTest {
         }
     }
 
+    @Test
+    public void testWithRuleOverride() throws Exception {
+        // Example rule taken from: https://github.com/aws/event-ruler/issues/22
+        String jsonSimpleRule2 = "{\n" +
+            "  \"source\": [\"aws.sns\"],\n" +
+            "  \"detail-type\": [\"AWS API Call via CloudTrail\"],\n" +
+            "  \"detail\": {\n" +
+            "    \"eventSource\": [\"s3.amazonaws.com\"],\n" +
+            "    \"eventSource\": [\"sns.amazonaws.com\"]\n" +
+            "  }\n" +
+            "}";
+        assertNull("", RuleCompiler.check(jsonSimpleRule2));
+        assertEquals("Overriding path 'detail.eventSource' is already defined. Please check that the rule does not list the same path multiple times.", JsonRuleCompiler.check(jsonSimpleRule2, false));
+    }
+
     private void multiThreadedTestHelper(List<String> rules,
                                          List<String[]> events, int numMatchesPerEvent) throws Exception {
 

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -597,7 +597,14 @@ public class RuleCompilerTest {
             "  }\n" +
             "}";
         assertNull("", RuleCompiler.check(jsonSimpleRule2));
-        assertEquals("Overriding path 'detail.eventSource' is already defined. Please check that the rule does not list the same path multiple times.", JsonRuleCompiler.check(jsonSimpleRule2, false));
+        assertEquals("Path `detail.eventSource` cannot be allowed multiple times\n at [Source: (String)\"{\n" +
+                "  \"source\": [\"aws.sns\"],\n" +
+                "  \"detail-type\": [\"AWS API Call via CloudTrail\"],\n" +
+                "  \"detail\": {\n" +
+                "    \"eventSource\": [\"s3.amazonaws.com\"],\n" +
+                "    \"eventSource\": [\"sns.amazonaws.com\"]\n" +
+                "  }\n" +
+                "}\"; line: 6, column: 41]", RuleCompiler.check(jsonSimpleRule2, false));
     }
 
     private void multiThreadedTestHelper(List<String> rules,


### PR DESCRIPTION
### Issue #22 

### Description of changes:

Detect and fail in case of path overriding in rule definition which causes the undefined behavior as described in issue #22. 
Note that in case of OR explicit operators we do not need to fail, as the resulting patterns are being copied and therefore not overridden. 

* Tests are added to `JsonRuleCompiler` as well as`RuleCompiler`.
* The `GenericMachine` class and related builder has been modified to be configured. 
   * By default, the previous behavior is maintained, where the override is happening to avoid breaking compatibility.
* No breaking changes are introduced.

#### Benchmark / Performance (for source code changes):

```
<replace this with output from /src/test/software/amazon/event/ruler/Bechmarks.java here.

The benchmark results can be fetched from "Pull request checks -> Java build -> build (ubuntu-X.Y, 8) -> Run benchmarks".>
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
