### PR TITLE
feat(ci): Bump ubuntu runner version to 24.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-24.04 ]
         java: [ "8", "11", "17", "21"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

Bump version of ubuntu runner in CI: https://github.com/actions/runner-images/issues/11101

#### Benchmark / Performance (for source code changes):

```
<replace this with output from /src/test/software/amazon/event/ruler/Bechmarks.java here.

The benchmark results can be fetched from "Pull request checks -> Java build -> build (ubuntu-X.Y, 8) -> Run benchmarks".>
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
