### PR TITLE
feat: Add rulesForJSONEventNonBlocking with linear performance on large arrays

### DIFF
--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -116,7 +116,12 @@ class ACFinder {
                 subRuleContextGenerator);
 
         while (fieldIndex < task.fieldCount) {
-            task.addStep(fieldIndex++, nameState, candidateSubRuleIdsForNextStep, arrayMembership);
+            // Only enqueue a step if the NameState has a value transition for this field's name.
+            final Field field = task.event.fields.get(fieldIndex);
+            if (nameState.getTransitionOn(field.name) != null) {
+                task.addStep(fieldIndex, nameState, candidateSubRuleIdsForNextStep, arrayMembership);
+            }
+            fieldIndex++;
         }
     }
 

--- a/src/main/software/amazon/event/ruler/ACFinder.java
+++ b/src/main/software/amazon/event/ruler/ACFinder.java
@@ -115,13 +115,23 @@ class ACFinder {
         tryMustNotExistMatch(candidateSubRuleIdsForNextStep, nameState, task, fieldIndex, arrayMembership,
                 subRuleContextGenerator);
 
-        while (fieldIndex < task.fieldCount) {
-            // Only enqueue a step if the NameState has a value transition for this field's name.
-            final Field field = task.event.fields.get(fieldIndex);
-            if (nameState.getTransitionOn(field.name) != null) {
-                task.addStep(fieldIndex, nameState, candidateSubRuleIdsForNextStep, arrayMembership);
+        // Use the field name index to jump directly to fields the NameState transitions on,
+        // instead of iterating all remaining fields. For each matching field, pre-check array
+        // consistency before enqueuing. This makes moveFrom() O(T * M) where T = number of
+        // transitions and M = number of array-consistent fields per name, instead of O(F)
+        // where F = total remaining fields.
+        for (final String transitionKey : nameState.getValueTransitionKeys()) {
+            final int[] range = task.event.getFieldRange(transitionKey);
+            if (range == null) {
+                continue;
             }
-            fieldIndex++;
+            final int start = Math.max(range[0], fieldIndex);
+            for (int i = start; i < range[1]; i++) {
+                final Field field = task.event.fields.get(i);
+                if (ArrayMembership.checkArrayConsistency(arrayMembership, field.arrayMembership) != null) {
+                    task.addStep(i, nameState, candidateSubRuleIdsForNextStep, arrayMembership);
+                }
+            }
         }
     }
 

--- a/src/main/software/amazon/event/ruler/Event.java
+++ b/src/main/software/amazon/event/ruler/Event.java
@@ -1,16 +1,8 @@
 package software.amazon.event.ruler;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -19,6 +11,16 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.StringJoiner;
 import java.util.TreeMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Prepares events for Ruler rule matching.
@@ -53,6 +55,11 @@ final class Event {
 
     // the fields of the event
     final List<Field> fields = new ArrayList<>();
+
+    // Index: field name -> [startIndex, endIndex) in the fields list.
+    // Fields are sorted by name (from TreeMap), so same-name fields are contiguous.
+    // Used by ACFinder to jump directly to relevant fields in moveFrom().
+    private final Map<String, int[]> fieldNameRanges = new HashMap<>();
 
     /**
      * represents the current state of an Event-constructor project
@@ -102,6 +109,7 @@ final class Event {
                 fields.add(new Field(entry.getKey(), val.val, val.membership));
             }
         }
+        buildFieldNameRanges();
     }
 
     // as above, only with the JSON already parsed into a ObjectMapper tree
@@ -118,6 +126,33 @@ final class Event {
                 fields.add(new Field(entry.getKey(), val.val, val.membership));
             }
         }
+        buildFieldNameRanges();
+    }
+
+    /**
+     * Build an index from field name to [startIndex, endIndex) in the fields list.
+     * Since fields are sorted by name (from TreeMap), same-name fields are contiguous.
+     */
+    private void buildFieldNameRanges() {
+        if (fields.isEmpty()) return;
+        String currentName = fields.get(0).name;
+        int start = 0;
+        for (int i = 1; i <= fields.size(); i++) {
+            String name = (i < fields.size()) ? fields.get(i).name : null;
+            if (!currentName.equals(name)) {
+                fieldNameRanges.put(currentName, new int[]{start, i});
+                start = i;
+                currentName = name;
+            }
+        }
+    }
+
+    /**
+     * Get the index range [start, end) for fields with the given name.
+     * Returns null if no fields have that name.
+     */
+    int[] getFieldRange(final String fieldName) {
+        return fieldNameRanges.get(fieldName);
     }
 
     private void traverseObject(final JsonParser parser, final TreeMap<String, List<Value>> fieldMap, final Progress progress) throws IOException {

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -1,9 +1,5 @@
 package software.amazon.event.ruler;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -18,6 +14,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import static software.amazon.event.ruler.SetOperations.intersection;
 
@@ -79,16 +80,44 @@ public class GenericMachine<T> {
      *  of different elements of the same JSON array in the event are matched.
      * @param jsonEvent The JSON representation of the event
      * @return list of rule names that match. The list may be empty but never null.
+     * @deprecated Use {@link #rulesForJSONEventNonBlocking(String)} instead, which provides the same array-consistent
+     *  matching semantics with linear performance regardless of array size. This method can exhibit O(N^2) performance
+     *  on events with large arrays matching multi-field rules.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public List<T> rulesForJSONEvent(final String jsonEvent) throws Exception {
         final Event event = new Event(jsonEvent, this);
         return (List<T>) ACFinder.matchRules(event, this, subRuleContextGenerator);
     }
+
+    /**
+     * @deprecated Use {@link #rulesForJSONEventNonBlocking(String)} instead.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public List<T> rulesForJSONEvent(final JsonNode eventRoot) {
         final Event event = new Event(eventRoot, this);
         return (List<T>) ACFinder.matchRules(event, this, subRuleContextGenerator);
+    }
+
+    /**
+     * Return any rules that match the fields in the event, with array-consistent matching
+     * and linear performance regardless of array size.
+     *
+     * <p>This method walks the JSON tree structurally, splitting on object arrays and matching
+     * per-element. It avoids the O(N^2) step queue growth that {@link #rulesForJSONEvent(String)}
+     * can exhibit on events with large arrays matching multi-field rules.</p>
+     *
+     * <p>Semantically equivalent to {@link #rulesForJSONEvent(String)} — same rules match
+     * same events — but with guaranteed linear performance in event size.</p>
+     *
+     * @param jsonEvent The JSON representation of the event
+     * @return list of rule names that match. The list may be empty but never null.
+     */
+    @SuppressWarnings("unchecked")
+    public List<T> rulesForJSONEventNonBlocking(final String jsonEvent) throws Exception {
+        return (List<T>) StructuredFinder.matchRules(jsonEvent, this, subRuleContextGenerator);
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -1,10 +1,11 @@
 package software.amazon.event.ruler;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Represents a state in the machine.
@@ -46,6 +47,14 @@ class NameState {
 
     ByteMachine getTransitionOn(final String token) {
         return valueTransitions.get(token);
+    }
+
+    /**
+     * Get all field names that have value transitions from this state.
+     * Used by ACFinder to iterate only relevant fields in moveFrom().
+     */
+    Set<String> getValueTransitionKeys() {
+        return valueTransitions.keySet();
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/StructuredFinder.java
+++ b/src/main/software/amazon/event/ruler/StructuredFinder.java
@@ -1,0 +1,186 @@
+package software.amazon.event.ruler;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Array-consistent matching without the O(N^2) step queue growth of ACFinder.
+ *
+ * <p>Instead of flattening the entire event into a single field list and tracking
+ * array membership (which causes quadratic blowup when large arrays match
+ * multi-field rules), this class walks the JSON tree structurally:</p>
+ *
+ * <ul>
+ *   <li>Scalar fields and primitive arrays are accumulated into a field context</li>
+ *   <li>Object arrays trigger per-element recursion with inherited context</li>
+ *   <li>At leaf level (no more object arrays), matches using {@link Finder}
+ *       (non-AC, with seenSteps dedup)</li>
+ * </ul>
+ *
+ * <p>Array consistency is correct by construction: each Finder call only sees
+ * fields from one element per array level, so cross-element matching is
+ * impossible.</p>
+ *
+ * <p>For events without object arrays (e.g., primitive arrays + scalars), falls
+ * back to {@link ACFinder} which handles those cases efficiently.</p>
+ */
+class StructuredFinder {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private StructuredFinder() {}
+
+    /**
+     * Match rules against an event using structured tree walking.
+     *
+     * @param json the event as a JSON string
+     * @param machine the compiled rule machine
+     * @param gen sub-rule context generator
+     * @return list of matched rule names (empty if none, never null)
+     */
+    static List<Object> matchRules(final String json, final GenericMachine<?> machine,
+                                   final SubRuleContext.Generator gen) throws Exception {
+        final JsonNode root = MAPPER.readTree(json);
+        if (!root.isObject()) {
+            return new ArrayList<>();
+        }
+
+        // If no object arrays anywhere, use Finder directly.
+        // Without object arrays there is no array-consistency concern,
+        // so the non-AC Finder (with seenSteps dedup) is both correct and fast.
+        // If no object arrays anywhere, use ACFinder directly.
+        // With the step-pruning fix, ACFinder is efficient for primitive arrays
+        // because it skips irrelevant fields during JSON parsing (isFieldStepUsed)
+        // and prunes steps for non-matching field names (getTransitionOn).
+        if (!hasObjectArray(root)) {
+            final Event event = new Event(json, machine);
+            return ACFinder.matchRules(event, machine, gen);
+        }
+
+        final Set<Object> matched = new HashSet<>();
+        walkObject(root, "", new ArrayList<>(), machine, gen, matched);
+        return new ArrayList<>(matched);
+    }
+
+    private static boolean hasObjectArray(final JsonNode node) {
+        final Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        while (fields.hasNext()) {
+            final JsonNode val = fields.next().getValue();
+            if (val.isArray()) {
+                for (final JsonNode elem : val) {
+                    if (elem.isObject()) return true;
+                }
+            }
+            if (val.isObject() && hasObjectArray(val)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Walk a JSON object node. Scalars and primitive array values go into the
+     * field context. Sub-objects are recursed into. Object arrays trigger
+     * per-element recursion.
+     */
+    private static void walkObject(final JsonNode node, final String prefix,
+                                   final List<String> inherited,
+                                   final GenericMachine<?> machine,
+                                   final SubRuleContext.Generator gen,
+                                   final Set<Object> matched) throws Exception {
+        final List<String> ctx = new ArrayList<>(inherited);
+        final List<ObjArray> objArrays = new ArrayList<>();
+
+        final Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        while (fields.hasNext()) {
+            final Map.Entry<String, JsonNode> field = fields.next();
+            final String name = field.getKey();
+            final JsonNode val = field.getValue();
+            final String path = prefix.isEmpty() ? name : prefix + "." + name;
+
+            if (!machine.isFieldStepUsed(name)) continue;
+
+            if (val.isObject()) {
+                walkObject(val, path, ctx, machine, gen, matched);
+            } else if (val.isArray()) {
+                classifyArray(val, path, ctx, objArrays);
+            } else if (val.isTextual()) {
+                ctx.add(path);
+                ctx.add("\"" + val.asText() + "\"");
+            } else if (!val.isNull()) {
+                ctx.add(path);
+                ctx.add(val.asText());
+            }
+        }
+
+        // No object arrays at this level: match with accumulated context
+        if (objArrays.isEmpty()) {
+            if (!ctx.isEmpty()) {
+                matched.addAll(Finder.rulesForEvent(sortPairs(ctx), machine, gen));
+            }
+            return;
+        }
+
+        // Per-element recursion for each object array
+        for (final ObjArray arr : objArrays) {
+            for (final JsonNode elem : arr.elements) {
+                if (elem.isObject()) {
+                    walkObject(elem, arr.path, ctx, machine, gen, matched);
+                }
+            }
+        }
+    }
+
+    /**
+     * Classify array elements as objects (for per-element recursion) or
+     * primitives (added directly to context).
+     */
+    private static void classifyArray(final JsonNode arrayNode, final String path,
+                                      final List<String> ctx,
+                                      final List<ObjArray> objArrays) {
+        final List<JsonNode> objElements = new ArrayList<>();
+        for (final JsonNode elem : arrayNode) {
+            if (elem.isObject()) {
+                objElements.add(elem);
+            } else if (elem.isTextual()) {
+                ctx.add(path);
+                ctx.add("\"" + elem.asText() + "\"");
+            } else if (!elem.isNull()) {
+                ctx.add(path);
+                ctx.add(elem.asText());
+            }
+        }
+        if (!objElements.isEmpty()) {
+            objArrays.add(new ObjArray(path, objElements));
+        }
+    }
+
+    /** Sort name/value pairs by name for Finder (which expects sorted input). */
+    private static String[] sortPairs(final List<String> pairs) {
+        if (pairs.size() <= 2) return pairs.toArray(new String[0]);
+        final TreeMap<String, List<String>> sorted = new TreeMap<>();
+        for (int i = 0; i < pairs.size(); i += 2) {
+            sorted.computeIfAbsent(pairs.get(i), k -> new ArrayList<>()).add(pairs.get(i + 1));
+        }
+        final List<String> result = new ArrayList<>();
+        for (final Map.Entry<String, List<String>> e : sorted.entrySet()) {
+            for (final String v : e.getValue()) {
+                result.add(e.getKey());
+                result.add(v);
+            }
+        }
+        return result.toArray(new String[0]);
+    }
+
+    private static class ObjArray {
+        final String path;
+        final List<JsonNode> elements;
+        ObjArray(final String p, final List<JsonNode> e) { path = p; elements = e; }
+    }
+}

--- a/src/test/resources/correctness-cases.json
+++ b/src/test/resources/correctness-cases.json
@@ -1,0 +1,1288 @@
+[
+  {
+    "name": "flat: 2-field exists, both present",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": 1,
+        "b": 2
+      }
+    }
+  },
+  {
+    "name": "flat: 2-field exists, one missing",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": 1
+      }
+    }
+  },
+  {
+    "name": "flat: exact match",
+    "rule": {
+      "d": {
+        "a": [
+          "hello"
+        ],
+        "b": [
+          "world"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello",
+        "b": "world"
+      }
+    }
+  },
+  {
+    "name": "flat: exact mismatch",
+    "rule": {
+      "d": {
+        "a": [
+          "hello"
+        ],
+        "b": [
+          "world"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello",
+        "b": "nope"
+      }
+    }
+  },
+  {
+    "name": "flat: prefix",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "prefix": "hel"
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello"
+      }
+    }
+  },
+  {
+    "name": "flat: numeric range",
+    "rule": {
+      "d": {
+        "x": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              100
+            ]
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "x": 50
+      }
+    }
+  },
+  {
+    "name": "flat: anything-but",
+    "rule": {
+      "d": {
+        "s": [
+          {
+            "anything-but": "banned"
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "s": "active"
+      }
+    }
+  },
+  {
+    "name": "objarray: same element",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: split",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3 elem, last valid",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 3,
+          "b": 4
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3-field, all in one",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ],
+        "c": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2,
+          "c": 3
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3-field, split 3 ways",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ],
+        "c": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: exact same elem",
+    "rule": {
+      "d": {
+        "name": [
+          "alice"
+        ],
+        "status": [
+          "active"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "status": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: exact split",
+    "rule": {
+      "d": {
+        "name": [
+          "alice"
+        ],
+        "status": [
+          "active"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "status": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: prefix same",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "prefix": "al"
+          }
+        ],
+        "status": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "status": "ok"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: prefix split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "prefix": "al"
+          }
+        ],
+        "status": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "status": "ok"
+        }
+      ]
+    }
+  },
+  {
+    "name": "primarray: exists",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ],
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "a",
+          "b"
+        ],
+        "name": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: exact match",
+    "rule": {
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "tags": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "primarray: no match",
+    "rule": {
+      "tags": [
+        "superadmin"
+      ]
+    },
+    "event": {
+      "tags": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "nested: inner same",
+    "rule": {
+      "u": {
+        "t": {
+          "k": [
+            "color"
+          ],
+          "v": [
+            "blue"
+          ]
+        }
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "t": [
+            {
+              "k": "color",
+              "v": "blue"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: inner split",
+    "rule": {
+      "u": {
+        "t": {
+          "k": [
+            "color"
+          ],
+          "v": [
+            "blue"
+          ]
+        }
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "t": [
+            {
+              "k": "color"
+            },
+            {
+              "v": "blue"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: outer split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "info": {
+          "x": [
+            "1"
+          ]
+        }
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "info": {
+            "x": "1"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: outer same",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "info": {
+          "x": [
+            "1"
+          ]
+        }
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "info": {
+            "x": "1"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested2: same leaf",
+    "rule": {
+      "a": {
+        "b": {
+          "x": [
+            {
+              "exists": true
+            }
+          ],
+          "y": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "a": [
+        {
+          "b": [
+            {
+              "x": 1,
+              "y": 2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested2: split leaf",
+    "rule": {
+      "a": {
+        "b": {
+          "x": [
+            {
+              "exists": true
+            }
+          ],
+          "y": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "a": [
+        {
+          "b": [
+            {
+              "x": 1
+            },
+            {
+              "y": 2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "mixed: array+scalar match",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "version": [
+        "1"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "name": "mixed: array+scalar fail",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "version": [
+        "2"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "name": "exists-false: absent",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": false
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        }
+      ]
+    }
+  },
+  {
+    "name": "exists-false: present",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": false
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "empty object",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {}
+  },
+  {
+    "name": "empty array",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": []
+    }
+  },
+  {
+    "name": "single-field rule",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "a": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "many elem one valid",
+    "rule": {
+      "d": {
+        "a": [
+          "target"
+        ],
+        "b": [
+          "found"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": "x"
+        },
+        {
+          "a": "y"
+        },
+        {
+          "a": "target",
+          "b": "found"
+        },
+        {
+          "a": "z"
+        }
+      ]
+    }
+  },
+  {
+    "name": "numeric+exists array",
+    "rule": {
+      "i": {
+        "p": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              100
+            ]
+          }
+        ],
+        "n": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "i": [
+        {
+          "n": "w",
+          "p": 50
+        },
+        {
+          "n": "g",
+          "p": 200
+        }
+      ]
+    }
+  },
+  {
+    "name": "anything-but array",
+    "rule": {
+      "u": {
+        "s": [
+          {
+            "anything-but": "banned"
+          }
+        ],
+        "n": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "n": "alice",
+          "s": "banned"
+        },
+        {
+          "n": "bob",
+          "s": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "primarray: large + scalar, exists",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: large + scalar, prefix",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "prefix": "ad"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "admin",
+          "user",
+          "dev"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: large + scalar, no match",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "prefix": "super"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "admin",
+          "user",
+          "dev"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: nested under object",
+    "rule": {
+      "detail": {
+        "data": {
+          "name": [
+            {
+              "exists": true
+            }
+          ],
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "detail": {
+        "data": {
+          "name": [
+            "alice",
+            "bob"
+          ],
+          "type": "GROUP"
+        }
+      }
+    }
+  },
+  {
+    "name": "primarray: two prim arrays + scalar",
+    "rule": {
+      "tags": [
+        {
+          "exists": true
+        }
+      ],
+      "cats": [
+        {
+          "exists": true
+        }
+      ],
+      "v": [
+        "1"
+      ]
+    },
+    "event": {
+      "tags": [
+        "a",
+        "b"
+      ],
+      "cats": [
+        "x",
+        "y"
+      ],
+      "v": "1"
+    }
+  },
+  {
+    "name": "primarray: exact match among many",
+    "rule": {
+      "d": {
+        "name": [
+          "target"
+        ],
+        "type": [
+          "GROUP"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [
+          "a",
+          "b",
+          "target",
+          "c"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: numeric in array",
+    "rule": {
+      "d": {
+        "vals": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              10
+            ]
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "vals": [
+          100,
+          5,
+          200
+        ],
+        "type": "ok"
+      }
+    }
+  },
+  {
+    "name": "primarray: anything-but in array",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "anything-but": "banned"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "banned",
+          "ok"
+        ],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: single value array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [
+          "only"
+        ],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: empty prim array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "mixed: obj-array + prim-array",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "tags": [
+        "admin",
+        "user"
+      ]
+    }
+  },
+  {
+    "name": "mixed: obj-array split + prim-array",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "email": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        },
+        {
+          "email": "b@x"
+        }
+      ],
+      "tags": [
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "deep prim: nested 3 levels",
+    "rule": {
+      "a": {
+        "b": {
+          "c": {
+            "vals": [
+              {
+                "exists": true
+              }
+            ],
+            "type": [
+              {
+                "exists": true
+              }
+            ]
+          }
+        }
+      }
+    },
+    "event": {
+      "a": {
+        "b": {
+          "c": {
+            "vals": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "ok"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "suffix match in array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "suffix": "ice"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "type": "user"
+        }
+      ]
+    }
+  },
+  {
+    "name": "N emails, only last element has name — dedup loses the only valid match",
+    "rule": {
+      "detail": {
+        "email": [{ "exists": true }],
+        "name":  [{ "exists": true }]
+      }
+    },
+    "event": {
+      "detail": [
+        { "email": "a@x" },
+        { "email": "b@x" },
+        { "email": "c@x" },
+        { "email": "d@x" },
+        { "email": "e@x", "name": "eve" }
+      ]
+    }
+  },
+  {
+    "name": "suffix match split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "suffix": "ice"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "type": "user"
+        }
+      ]
+    }
+  }
+]

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -2756,6 +2756,34 @@ public class ACMachineTest {
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
     }
+    
+    @Test
+    public void testLargeArrayCompletesInReasonableTime() throws Exception {
+        // exists:true so every array element triggers a value match.
+        String rule = "{\"source\":[\"myapp\"],\"items\":[{\"exists\":true}]}";
+        Machine machine = new Machine();
+        machine.addRule("rule1", rule);
+
+        StringBuilder sb = new StringBuilder("{\"source\":\"myapp\",\"items\":[");
+        for (int i = 0; i < 10000; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("\"val").append(i).append("\"");
+        }
+        sb.append("]}");
+        String event = sb.toString();
+
+        // Warmup
+        machine.rulesForJSONEvent(event);
+
+        long start = System.currentTimeMillis();
+        List<String> matches = machine.rulesForJSONEvent(event);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(1, matches.size());
+        assertTrue("Took " + elapsed + "ms, expected < 500ms", elapsed < 500);
+    }
 
     private static Set<String> set(String ... strings) {
         return set(Arrays.asList(strings));

--- a/src/test/software/amazon/event/ruler/StructuredFinderTest.java
+++ b/src/test/software/amazon/event/ruler/StructuredFinderTest.java
@@ -1,0 +1,171 @@
+package software.amazon.event.ruler;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for {@link StructuredFinder} via {@link GenericMachine#rulesForJSONEventNonBlocking(String)}.
+ *
+ * Validates that the new method produces identical results to the deprecated
+ * {@link GenericMachine#rulesForJSONEvent(String)} on all correctness cases,
+ * then benchmarks both on large events.
+ */
+public class StructuredFinderTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * The new method must produce identical results to the old method on every
+     * correctness case. This is the primary correctness gate.
+     */
+    @Test
+    public void nonBlockingMatchesACOnAllCases() throws Exception {
+        InputStream is = getClass().getResourceAsStream("/correctness-cases.json");
+        JsonNode cases = MAPPER.readTree(is);
+        int pass = 0, fail = 0;
+
+        System.out.printf("%n%-55s %-8s %-8s %-6s%n", "Case", "AC", "New", "OK?");
+
+        for (JsonNode tc : cases) {
+            String name = tc.get("name").asText();
+            String rule = MAPPER.writeValueAsString(tc.get("rule"));
+            String event = MAPPER.writeValueAsString(tc.get("event"));
+
+            Machine m = new Machine();
+            m.addRule("r1", rule);
+
+            List<String> acResult = m.rulesForJSONEvent(event);
+            List<String> newResult = m.rulesForJSONEventNonBlocking(event);
+
+            Collections.sort(acResult);
+            Collections.sort(newResult);
+
+            boolean ok = acResult.equals(newResult);
+            if (ok) pass++; else fail++;
+
+            System.out.printf("%-55s %-8s %-8s %-6s%n", name,
+                    acResult.isEmpty() ? "no" : "MATCH",
+                    newResult.isEmpty() ? "no" : "MATCH",
+                    ok ? "OK" : "FAIL");
+
+            assertEquals(name + ": new method must match old", acResult, newResult);
+        }
+
+        System.out.printf("Passed: %d, Failed: %d%n", pass, fail);
+        assertEquals(0, fail);
+    }
+
+    /** Performance comparison on events up to ~500KB. */
+    @Test(timeout = 300000) // 5 minute timeout for the whole perf test
+    public void perfComparison() throws Exception {
+        System.out.printf("%n%-12s %-10s %-10s %-12s %-12s%n",
+                "Scenario", "N", "KB", "Old(ms)", "New(ms)");
+
+        perfRun("prim+scl",
+                "{\"d\":{\"tags\":[{\"exists\":true}],\"type\":[{\"exists\":true}]}}",
+                new int[]{1000, 5000, 10000, 50000, 100000},
+                StructuredFinderTest::buildPrimArray, 1);
+
+        perfRun("obj-both",
+                "{\"d\":{\"a\":[{\"exists\":true}],\"b\":[{\"exists\":true}]}}",
+                new int[]{1000, 2000, 5000, 10000, 20000},
+                StructuredFinderTest::buildObjArray, 1);
+
+        perfRun("nested2",
+                "{\"a\":{\"b\":{\"x\":[{\"exists\":true}],\"y\":[{\"exists\":true}]}}}",
+                new int[]{100, 200, 500, 1000, 2000},
+                StructuredFinderTest::buildNested2, 1);
+
+        perfRun("customer",
+                "{\"detail\":{\"data\":{\"name\":[{\"exists\":true}],\"domains\":{\"email\":[{\"exists\":true},{\"exists\":false}]},\"type\":[{\"exists\":true}]},\"context\":{\"companyId\":[{\"exists\":true}],\"userId\":[{\"exists\":true}],\"email\":[{\"exists\":true}]}}}",
+                new int[]{1000, 5000, 10000, 50000},
+                StructuredFinderTest::buildCustomerLike, 1);
+    }
+
+    // ==================== Event builders ====================
+
+    static String buildPrimArray(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":{\"tags\":[");
+        for (int i = 0; i < n; i++) { if (i > 0) s.append(","); s.append("\"t").append(i).append("\""); }
+        s.append("],\"type\":\"G\"}}"); return s.toString();
+    }
+
+    static String buildObjArray(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":[");
+        for (int i = 0; i < n; i++) { if (i > 0) s.append(","); s.append("{\"a\":\"").append(i).append("\",\"b\":\"").append(i).append("\"}"); }
+        s.append("]}"); return s.toString();
+    }
+
+    static String buildNested2(int n) {
+        StringBuilder s = new StringBuilder("{\"a\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) s.append(",");
+            s.append("{\"b\":[");
+            for (int j = 0; j < 10; j++) {
+                if (j > 0) s.append(",");
+                s.append("{\"x\":\"").append(i).append("_").append(j)
+                  .append("\",\"y\":\"").append(i).append("_").append(j).append("\"}");
+            }
+            s.append("]}");
+        }
+        s.append("]}"); return s.toString();
+    }
+
+    static String buildCustomerLike(int n) {
+        StringBuilder s = new StringBuilder("{\"detail\":{\"data\":{\"name\":[");
+        for (int i = 0; i < n; i++) { if (i > 0) s.append(","); s.append("\"u").append(i).append("\""); }
+        s.append("],\"type\":\"G\",\"domains\":{\"email\":\"t@x\"}},\"context\":{\"companyId\":\"c\",\"userId\":\"u\",\"email\":\"a@b\"}}}");
+        return s.toString();
+    }
+
+    // ==================== Perf runner ====================
+
+    interface EventGen { String build(int n); }
+
+    private void perfRun(String label, String rule, int[] sizes, EventGen gen, int expected) throws Exception {
+        Machine m = new Machine();
+        m.addRule("r1", rule);
+        boolean oldTimedOut = false;
+
+        for (int n : sizes) {
+            String event = gen.build(n);
+            double kb = event.length() / 1024.0;
+            if (kb > 1100) break;
+
+            // New method: must always complete, assert correctness + perf up to 1MB
+            m.rulesForJSONEventNonBlocking(event); // warmup
+            long t1 = System.nanoTime();
+            assertEquals(expected, m.rulesForJSONEventNonBlocking(event).size());
+            long newMs = (System.nanoTime() - t1) / 1000000;
+            assertTrue(label + " N=" + n + " new method took " + newMs + "ms (limit 10s)",
+                    newMs < 10000);
+
+            // Old method: run with 10s timeout, mark as TIMEOUT if exceeded
+            String oldStr;
+            if (oldTimedOut) {
+                oldStr = "TIMEOUT";
+            } else {
+                m.rulesForJSONEvent(event); // warmup
+                long t0 = System.nanoTime();
+                assertEquals(expected, m.rulesForJSONEvent(event).size());
+                long oldMs = (System.nanoTime() - t0) / 1000000;
+                if (oldMs > 10000) {
+                    oldStr = "TIMEOUT";
+                    oldTimedOut = true;
+                } else {
+                    oldStr = oldMs + "ms";
+                }
+            }
+
+            System.out.printf("%-12s %-10d %-10.1f %-12s %-12s%n", label, n, kb, oldStr, newMs + "ms");
+        }
+    }
+}


### PR DESCRIPTION
### Issue #, if available:

Performance improvement for matching events with large arrays.

### Description of changes:

Adds a new method `rulesForJSONEventNonBlocking()` on `GenericMachine` that provides array-consistent matching with guaranteed linear performance regardless of array size.

The existing `rulesForJSONEvent()` can exhibit O(N^2) performance when events contain large arrays at paths matching multi-field rules. For example, an event with a 10,000-element array matching a 2-field rule can take several seconds, while the new method completes in ~40ms.

**What changed:**

- `ACFinder.moveFrom()`: Instead of iterating all remaining fields, uses a field name index to jump directly to relevant fields, and pre-checks array membership consistency before enqueuing steps.
- `Event.java`: Builds a field name to index range map during construction (fields are already sorted by name, so same-name fields are contiguous).
- `NameState.java`: Adds `getValueTransitionKeys()` to expose which field names a state transitions on.
- `StructuredFinder.java` (new): For events with object arrays, walks the JSON tree structurally and matches per-element. Array consistency is correct by construction since each match call only sees one element's fields.
- `GenericMachine.java`: Adds `rulesForJSONEventNonBlocking()` and deprecates `rulesForJSONEvent()`.

**Semantics:** The new method is equivalent to `rulesForJSONEvent()` — same rules match same events. Validated against all 679 existing tests plus 51 new correctness cases.

#### Benchmark / Performance (for source code changes):

| Scenario | N | KB | Old (ms) | New (ms) |
|---|---|---|---|---|
| prim+scalar | 1,000 | 6.8 | 5 | 5 |
| prim+scalar | 100,000 | 868 | 95 | 115 |
| obj-array both fields | 5,000 | 115 | 664 | 22 |
| obj-array both fields | 20,000 | 486 | TIMEOUT | 77 |
| nested 2-level | 500 | 129 | 551 | 12 |
| nested 2-level | 2,000 | 541 | TIMEOUT | 50 |
| customer-like 6-field | 50,000 | 429 | 43 | 46 |

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
