### PR TITLE
Add rulesForJSONEventNonBlocking with linear-time array-consistent matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,23 @@ NameState. This is accomplished by storing that we already have a NameState for 
 
 Note that it doesn't matter if each addRule uses a different rule name or the same rule name.
 
+#### withStructuredMatching
+Default: false
+
+When set to true, `rulesForJSONEvent()` uses a linear-time matching algorithm instead of the
+default step-queue approach. This is recommended for applications that process events with large
+arrays (thousands of elements) where the default algorithm may exhibit quadratic performance.
+
+The linear-time algorithm (`StructuredFinder`) indexes the event by field path and walks the
+compiled state machine trie with direct HashMap lookups instead of scanning all remaining fields
+per step. It also exits early once all rules in the machine have been matched.
+
+```java
+Machine machine = Machine.builder()
+    .withStructuredMatching(true)
+    .build();
+```
+
 ### addRule()
 
 All forms of this method have the same first argument, a String which provides
@@ -726,6 +743,17 @@ specifically because it does not support array-consistent matching.
 
 `rulesForJSONEvent()` also has the advantage that the code which turns the JSON form
 of the event into a sorted list has been extensively profiled and optimized.
+
+For events with large arrays (thousands of elements), build the Machine with
+`withStructuredMatching(true)` to enable linear-time matching:
+
+```java
+Machine machine = Machine.builder()
+    .withStructuredMatching(true)
+    .build();
+machine.addRule("rule1", ruleJson);
+List<String> matches = machine.rulesForJSONEvent(eventJson); // uses linear-time matching
+```
 
 The performance of `rulesForEvent()` and `rulesForJSONEvent()` do not depend on the number of rules added
 with `addRule()`.  `rulesForJSONEvent()` is generally faster because of the optimized
@@ -922,7 +950,8 @@ Events are processed at over 220K/second except for:
 ### Suggestions for better performance
 
 Here are some suggestions on processing rules and events:
-1. If your team is still using old API -- rulesForEvent, switch to rulesForJSONEvent API. Due to limited resource, old API will not be maintained well thought contributions are always welcomed.
+1. For new code, use `withStructuredMatching(true)` on Machine.Builder for linear-time matching that handles events with large arrays efficiently.
+2. If your team is still using old API -- rulesForEvent, switch to rulesForJSONEvent API. Due to limited resource, old API will not be maintained well thought contributions are always welcomed.
 2. If your team does event flattening by yourself,  you are recommended to use Ruler to flatten the event, just pass Json string or Json node. We have many optimizations within Ruler parsing code.
 3. if your team does Rule Json parsing by yourself, you are recommended to just pass the Json described rule string directly to Ruler, in which will do some pre-processing, e.g. add “”.
 4. In order to well protect the system and prevent ruler from hitting worse condition, limit number of fields in event and rule, e.g. for big event, consider to split to multiple small event and call ruler multiple times. while number of rule is purely depending on your memory budget which is up to you to decide that, but number of fields described in the rule is most important and sensitive on performance, if possible, try to design it as small as possible.

--- a/src/main/software/amazon/event/ruler/ArrayMembership.java
+++ b/src/main/software/amazon/event/ruler/ArrayMembership.java
@@ -37,8 +37,17 @@ class ArrayMembership {
     boolean isEmpty() {
         return membership.isEmpty();
     }
-    private int size() {
+
+    int size() {
         return membership.size();
+    }
+
+    /**
+     * Get all array membership entries (arrayId -> elementIndex).
+     * Used by StructuredFinder for building the secondary index.
+     */
+    Iterable<IntIntMap.Entry> entries() {
+        return membership.entries();
     }
 
     // for debugging

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -1,9 +1,5 @@
 package software.amazon.event.ruler;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -18,6 +14,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import static software.amazon.event.ruler.SetOperations.intersection;
 
@@ -79,12 +80,24 @@ public class GenericMachine<T> {
      *  of different elements of the same JSON array in the event are matched.
      * @param jsonEvent The JSON representation of the event
      * @return list of rule names that match. The list may be empty but never null.
+     * @deprecated Use {@code Machine.builder().withStructuredMatching(true).build()} for linear performance
+     *  on events with large arrays. This method can exhibit O(N^2) performance when
+     *  {@code withStructuredMatching} is not enabled.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public List<T> rulesForJSONEvent(final String jsonEvent) throws Exception {
+        if (configuration.isUseStructuredMatching()) {
+            return (List<T>) StructuredFinder.matchRules(jsonEvent, this, subRuleContextGenerator);
+        }
         final Event event = new Event(jsonEvent, this);
         return (List<T>) ACFinder.matchRules(event, this, subRuleContextGenerator);
     }
+
+    /**
+     * @deprecated Use the String overload with {@code withStructuredMatching(true)}.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public List<T> rulesForJSONEvent(final JsonNode eventRoot) {
         final Event event = new Event(eventRoot, this);
@@ -791,6 +804,13 @@ public class GenericMachine<T> {
          */
         private boolean ruleOverriding = true;
 
+        /**
+         * When true, {@code rulesForJSONEvent()} uses structured tree-walking matching
+         * instead of ACFinder, providing linear performance on events with large arrays.
+         * Default is false for backward compatibility.
+         */
+        private boolean useStructuredMatching = false;
+
         Builder() {}
 
         public Builder<M,T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
@@ -803,12 +823,18 @@ public class GenericMachine<T> {
             return this;
         }
 
+        public Builder<M, T> withStructuredMatching(boolean useStructuredMatching) {
+            this.useStructuredMatching = useStructuredMatching;
+            return this;
+        }
+
         public M build() {
             return (M) new GenericMachine<T>(buildConfig());
         }
 
         protected GenericMachineConfiguration buildConfig() {
-            return new GenericMachineConfiguration(additionalNameStateReuse, ruleOverriding);
+            return new GenericMachineConfiguration(additionalNameStateReuse, ruleOverriding,
+                    useStructuredMatching);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
+++ b/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
@@ -7,10 +7,17 @@ class GenericMachineConfiguration {
 
     private final boolean additionalNameStateReuse;
     private final boolean ruleOverriding;
+    private final boolean useStructuredMatching;
 
     GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding) {
+        this(additionalNameStateReuse, ruleOverriding, false);
+    }
+
+    GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding,
+                                boolean useStructuredMatching) {
         this.additionalNameStateReuse = additionalNameStateReuse;
         this.ruleOverriding = ruleOverriding;
+        this.useStructuredMatching = useStructuredMatching;
     }
 
     boolean isAdditionalNameStateReuse() {
@@ -19,6 +26,14 @@ class GenericMachineConfiguration {
 
     public boolean isRuleOverriding() {
         return ruleOverriding;
+    }
+
+    /**
+     * When true, {@link GenericMachine#rulesForJSONEvent(String)} uses {@link StructuredFinder}
+     * instead of {@link ACFinder}, providing linear performance on events with large arrays.
+     */
+    boolean isUseStructuredMatching() {
+        return useStructuredMatching;
     }
 }
 

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -1,10 +1,11 @@
 package software.amazon.event.ruler;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Represents a state in the machine.
@@ -46,6 +47,14 @@ class NameState {
 
     ByteMachine getTransitionOn(final String token) {
         return valueTransitions.get(token);
+    }
+
+    /**
+     * Get all field names that have value transitions from this state.
+     * Used by ACFinder to iterate only relevant fields in moveFrom().
+     */
+    Set<String> getValueTransitionKeys() {
+        return valueTransitions.keySet();
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/StructuredFinder.java
+++ b/src/main/software/amazon/event/ruler/StructuredFinder.java
@@ -1,0 +1,243 @@
+package software.amazon.event.ruler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Array-consistent rule matching with guaranteed linear performance.
+ *
+ * <p>Indexes the event by dotted field path, then walks the compiled state
+ * machine trie with direct path lookups instead of iterating all fields.
+ * Array consistency is enforced by checking constraints during the walk.</p>
+ *
+ * <p>Once all rules in the machine have been matched, the walk exits early
+ * to avoid unnecessary work on large events.</p>
+ *
+ * <p>Complexity: O(F + sum over all trie paths of V_i) where F = total event
+ * fields and V_i = number of values for the i-th trie transition's path.
+ * For a single large array of N elements with K rule conditions, this is
+ * O(N*K) — linear in N. For sibling arrays of size N and M with conditions
+ * on different paths, this is O(N+M) — no cross-product.</p>
+ */
+class StructuredFinder {
+
+    private StructuredFinder() { }
+
+    static List<Object> matchRules(final String json, final GenericMachine<?> machine,
+                                   final SubRuleContext.Generator gen) throws Exception {
+        final Event event = new Event(json, machine);
+        final FieldIndex index = new FieldIndex(event);
+        final int ruleCount = gen.getRuleCount();
+
+        final Set<Object> matched = new HashSet<>();
+        final NameState startState = machine.getStartState();
+        if (startState != null) {
+            try {
+                walk(startState, index, event, null, new ArrayMembership(), gen, matched, ruleCount);
+            } catch (Exception e) {
+                // Concurrent modification during walk — return partial results.
+                // This matches ACFinder's behavior: concurrent add/delete may
+                // produce incomplete results but must not throw.
+            }
+        }
+        return new ArrayList<>(matched);
+    }
+
+    /**
+     * Walk the state machine trie. Returns true if all rules have been matched
+     * (early-exit signal).
+     */
+    private static boolean walk(final NameState state,
+                                final FieldIndex index,
+                                final Event event,
+                                final Set<SubRuleContext> candidates,
+                                final ArrayMembership constraints,
+                                final SubRuleContext.Generator gen,
+                                final Set<Object> matched,
+                                final int ruleCount) {
+        // Handle exists:false transitions
+        if (handleAbsence(state, event, index, candidates, constraints, gen, matched, ruleCount)) {
+            return true;
+        }
+
+        // For each field name this state transitions on
+        for (final String fieldName : state.getValueTransitionKeys()) {
+            final List<IndexedValue> values = index.getConsistent(fieldName, constraints);
+            if (values == null) {
+                continue;
+            }
+
+            final ByteMachine valueMatcher = state.getTransitionOn(fieldName);
+
+            // For each value at this path
+            for (final IndexedValue iv : values) {
+                // Check array consistency with current constraints
+                final ArrayMembership merged =
+                        ArrayMembership.checkArrayConsistency(constraints, iv.membership);
+                if (merged == null) {
+                    continue;
+                }
+
+                // Check if value matches any pattern
+                for (final NameStateWithPattern nsp : valueMatcher.transitionOn(iv.val)) {
+                    final NameState nextState = nsp.getNameState();
+                    final Patterns pattern = nsp.getPattern();
+
+                    // Collect terminal matches
+                    collectRules(candidates, nextState, pattern, matched);
+                    if (matched.size() >= ruleCount) {
+                        return true;
+                    }
+
+                    // Recurse for non-terminal matches
+                    final Set<SubRuleContext> nextCandidates =
+                            nextCandidates(candidates, nextState, pattern);
+                    if (nextCandidates != null && !nextCandidates.isEmpty()) {
+                        if (walk(nextState, index, event, nextCandidates, merged, gen, matched, ruleCount)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Handle exists:false transitions. Returns true if all rules matched (early-exit).
+     */
+    private static boolean handleAbsence(final NameState state,
+                                         final Event event,
+                                         final FieldIndex index,
+                                         final Set<SubRuleContext> candidates,
+                                         final ArrayMembership constraints,
+                                         final SubRuleContext.Generator gen,
+                                         final Set<Object> matched,
+                                         final int ruleCount) {
+        if (!state.hasKeyTransitions()) {
+            return false;
+        }
+        for (final NameState nextState : state.getNameTransitions(event, constraints)) {
+            if (nextState != null) {
+                final Patterns absencePattern = Patterns.absencePatterns();
+                collectRules(candidates, nextState, absencePattern, matched);
+                if (matched.size() >= ruleCount) {
+                    return true;
+                }
+
+                final Set<SubRuleContext> nextCandidates =
+                        nextCandidates(candidates, nextState, absencePattern);
+                if (nextCandidates != null && !nextCandidates.isEmpty()) {
+                    if (walk(nextState, index, event, nextCandidates, constraints, gen, matched, ruleCount)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void collectRules(final Set<SubRuleContext> candidates,
+                                     final NameState state, final Patterns pattern,
+                                     final Set<Object> matched) {
+        final Set<SubRuleContext> terminals = state.getTerminalSubRuleIdsForPattern(pattern);
+        if (terminals == null) {
+            return;
+        }
+        if (candidates == null || candidates.isEmpty()) {
+            for (final SubRuleContext t : terminals) {
+                matched.add(t.getRuleName());
+            }
+        } else {
+            SetOperations.intersection(candidates, terminals, matched,
+                    SubRuleContext::getRuleName);
+        }
+    }
+
+    private static Set<SubRuleContext> nextCandidates(final Set<SubRuleContext> current,
+                                                      final NameState state,
+                                                      final Patterns pattern) {
+        final Set<SubRuleContext> ids = state.getNonTerminalSubRuleIdsForPattern(pattern);
+        if (ids == null) {
+            return null;
+        }
+        if (current == null || current.isEmpty()) {
+            return ids;
+        }
+        final Set<SubRuleContext> result = new HashSet<>();
+        SetOperations.intersection(ids, current, result);
+        return result;
+    }
+
+    /**
+     * Index of event fields by dotted path, with secondary index by array element
+     * for O(1) same-element lookups.
+     */
+    static class FieldIndex {
+        private final Map<String, List<IndexedValue>> byPath = new HashMap<>();
+        private final Map<String, Map<Integer, Map<Integer, List<IndexedValue>>>> byElement = new HashMap<>();
+
+        FieldIndex(final Event event) {
+            for (final Field field : event.fields) {
+                final IndexedValue iv = new IndexedValue(field.val, field.arrayMembership);
+                byPath.computeIfAbsent(field.name, k -> new ArrayList<>()).add(iv);
+
+                for (final IntIntMap.Entry entry : field.arrayMembership.entries()) {
+                    byElement.computeIfAbsent(field.name, k -> new HashMap<>())
+                            .computeIfAbsent(entry.getKey(), k -> new HashMap<>())
+                            .computeIfAbsent(entry.getValue(), k -> new ArrayList<>())
+                            .add(iv);
+                }
+            }
+        }
+
+        List<IndexedValue> getConsistent(final String fieldName, final ArrayMembership constraints) {
+            final List<IndexedValue> all = byPath.get(fieldName);
+            if (all == null) {
+                return null;
+            }
+            if (constraints.isEmpty()) {
+                return all;
+            }
+
+            final Map<Integer, Map<Integer, List<IndexedValue>>> fieldByArray = byElement.get(fieldName);
+            if (fieldByArray != null) {
+                for (final IntIntMap.Entry constraint : constraints.entries()) {
+                    final Map<Integer, List<IndexedValue>> fieldByElem = fieldByArray.get(constraint.getKey());
+                    if (fieldByElem != null) {
+                        final List<IndexedValue> elemValues = fieldByElem.get(constraint.getValue());
+                        if (elemValues == null) {
+                            return null;
+                        }
+                        if (constraints.size() <= 1) {
+                            return elemValues;
+                        }
+                        final List<IndexedValue> result = new ArrayList<>();
+                        for (final IndexedValue iv : elemValues) {
+                            if (ArrayMembership.checkArrayConsistency(constraints, iv.membership) != null) {
+                                result.add(iv);
+                            }
+                        }
+                        return result.isEmpty() ? null : result;
+                    }
+                }
+            }
+
+            return all;
+        }
+    }
+
+    static class IndexedValue {
+        final String val;
+        final ArrayMembership membership;
+
+        IndexedValue(final String val, final ArrayMembership membership) {
+            this.val = val;
+            this.membership = membership;
+        }
+    }
+}

--- a/src/main/software/amazon/event/ruler/SubRuleContext.java
+++ b/src/main/software/amazon/event/ruler/SubRuleContext.java
@@ -58,5 +58,12 @@ public final class SubRuleContext {
         public Set<SubRuleContext> getIdsGeneratedForName(Object ruleName) {
             return nameToContext.get(ruleName);
         }
+
+        /**
+         * Returns the number of distinct rule names that have been registered.
+         */
+        int getRuleCount() {
+            return nameToContext.size();
+        }
     }
 }

--- a/src/test/resources/correctness-cases.json
+++ b/src/test/resources/correctness-cases.json
@@ -1,0 +1,1288 @@
+[
+  {
+    "name": "flat: 2-field exists, both present",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": 1,
+        "b": 2
+      }
+    }
+  },
+  {
+    "name": "flat: 2-field exists, one missing",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": 1
+      }
+    }
+  },
+  {
+    "name": "flat: exact match",
+    "rule": {
+      "d": {
+        "a": [
+          "hello"
+        ],
+        "b": [
+          "world"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello",
+        "b": "world"
+      }
+    }
+  },
+  {
+    "name": "flat: exact mismatch",
+    "rule": {
+      "d": {
+        "a": [
+          "hello"
+        ],
+        "b": [
+          "world"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello",
+        "b": "nope"
+      }
+    }
+  },
+  {
+    "name": "flat: prefix",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "prefix": "hel"
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "a": "hello"
+      }
+    }
+  },
+  {
+    "name": "flat: numeric range",
+    "rule": {
+      "d": {
+        "x": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              100
+            ]
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "x": 50
+      }
+    }
+  },
+  {
+    "name": "flat: anything-but",
+    "rule": {
+      "d": {
+        "s": [
+          {
+            "anything-but": "banned"
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "s": "active"
+      }
+    }
+  },
+  {
+    "name": "objarray: same element",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: split",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3 elem, last valid",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 3,
+          "b": 4
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3-field, all in one",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ],
+        "c": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2,
+          "c": 3
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: 3-field, split 3 ways",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ],
+        "c": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: exact same elem",
+    "rule": {
+      "d": {
+        "name": [
+          "alice"
+        ],
+        "status": [
+          "active"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "status": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: exact split",
+    "rule": {
+      "d": {
+        "name": [
+          "alice"
+        ],
+        "status": [
+          "active"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "status": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: prefix same",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "prefix": "al"
+          }
+        ],
+        "status": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "status": "ok"
+        }
+      ]
+    }
+  },
+  {
+    "name": "objarray: prefix split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "prefix": "al"
+          }
+        ],
+        "status": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "status": "ok"
+        }
+      ]
+    }
+  },
+  {
+    "name": "primarray: exists",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ],
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "a",
+          "b"
+        ],
+        "name": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: exact match",
+    "rule": {
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "tags": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "primarray: no match",
+    "rule": {
+      "tags": [
+        "superadmin"
+      ]
+    },
+    "event": {
+      "tags": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "nested: inner same",
+    "rule": {
+      "u": {
+        "t": {
+          "k": [
+            "color"
+          ],
+          "v": [
+            "blue"
+          ]
+        }
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "t": [
+            {
+              "k": "color",
+              "v": "blue"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: inner split",
+    "rule": {
+      "u": {
+        "t": {
+          "k": [
+            "color"
+          ],
+          "v": [
+            "blue"
+          ]
+        }
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "t": [
+            {
+              "k": "color"
+            },
+            {
+              "v": "blue"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: outer split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "info": {
+          "x": [
+            "1"
+          ]
+        }
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "info": {
+            "x": "1"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested: outer same",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "info": {
+          "x": [
+            "1"
+          ]
+        }
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "info": {
+            "x": "1"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested2: same leaf",
+    "rule": {
+      "a": {
+        "b": {
+          "x": [
+            {
+              "exists": true
+            }
+          ],
+          "y": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "a": [
+        {
+          "b": [
+            {
+              "x": 1,
+              "y": 2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested2: split leaf",
+    "rule": {
+      "a": {
+        "b": {
+          "x": [
+            {
+              "exists": true
+            }
+          ],
+          "y": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "a": [
+        {
+          "b": [
+            {
+              "x": 1
+            },
+            {
+              "y": 2
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "mixed: array+scalar match",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "version": [
+        "1"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "name": "mixed: array+scalar fail",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "version": [
+        "2"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "name": "exists-false: absent",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": false
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        }
+      ]
+    }
+  },
+  {
+    "name": "exists-false: present",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": false
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "empty object",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {}
+  },
+  {
+    "name": "empty array",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": []
+    }
+  },
+  {
+    "name": "single-field rule",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": 1
+        },
+        {
+          "a": 2
+        }
+      ]
+    }
+  },
+  {
+    "name": "many elem one valid",
+    "rule": {
+      "d": {
+        "a": [
+          "target"
+        ],
+        "b": [
+          "found"
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "a": "x"
+        },
+        {
+          "a": "y"
+        },
+        {
+          "a": "target",
+          "b": "found"
+        },
+        {
+          "a": "z"
+        }
+      ]
+    }
+  },
+  {
+    "name": "numeric+exists array",
+    "rule": {
+      "i": {
+        "p": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              100
+            ]
+          }
+        ],
+        "n": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "i": [
+        {
+          "n": "w",
+          "p": 50
+        },
+        {
+          "n": "g",
+          "p": 200
+        }
+      ]
+    }
+  },
+  {
+    "name": "anything-but array",
+    "rule": {
+      "u": {
+        "s": [
+          {
+            "anything-but": "banned"
+          }
+        ],
+        "n": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "u": [
+        {
+          "n": "alice",
+          "s": "banned"
+        },
+        {
+          "n": "bob",
+          "s": "active"
+        }
+      ]
+    }
+  },
+  {
+    "name": "primarray: large + scalar, exists",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: large + scalar, prefix",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "prefix": "ad"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "admin",
+          "user",
+          "dev"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: large + scalar, no match",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "prefix": "super"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "admin",
+          "user",
+          "dev"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: nested under object",
+    "rule": {
+      "detail": {
+        "data": {
+          "name": [
+            {
+              "exists": true
+            }
+          ],
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "event": {
+      "detail": {
+        "data": {
+          "name": [
+            "alice",
+            "bob"
+          ],
+          "type": "GROUP"
+        }
+      }
+    }
+  },
+  {
+    "name": "primarray: two prim arrays + scalar",
+    "rule": {
+      "tags": [
+        {
+          "exists": true
+        }
+      ],
+      "cats": [
+        {
+          "exists": true
+        }
+      ],
+      "v": [
+        "1"
+      ]
+    },
+    "event": {
+      "tags": [
+        "a",
+        "b"
+      ],
+      "cats": [
+        "x",
+        "y"
+      ],
+      "v": "1"
+    }
+  },
+  {
+    "name": "primarray: exact match among many",
+    "rule": {
+      "d": {
+        "name": [
+          "target"
+        ],
+        "type": [
+          "GROUP"
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [
+          "a",
+          "b",
+          "target",
+          "c"
+        ],
+        "type": "GROUP"
+      }
+    }
+  },
+  {
+    "name": "primarray: numeric in array",
+    "rule": {
+      "d": {
+        "vals": [
+          {
+            "numeric": [
+              ">",
+              0,
+              "<",
+              10
+            ]
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "vals": [
+          100,
+          5,
+          200
+        ],
+        "type": "ok"
+      }
+    }
+  },
+  {
+    "name": "primarray: anything-but in array",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "anything-but": "banned"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "tags": [
+          "banned",
+          "ok"
+        ],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: single value array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [
+          "only"
+        ],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "primarray: empty prim array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": {
+        "name": [],
+        "type": "x"
+      }
+    }
+  },
+  {
+    "name": "mixed: obj-array + prim-array",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        }
+      ],
+      "tags": [
+        "admin",
+        "user"
+      ]
+    }
+  },
+  {
+    "name": "mixed: obj-array split + prim-array",
+    "rule": {
+      "users": {
+        "name": [
+          {
+            "exists": true
+          }
+        ],
+        "email": [
+          {
+            "exists": true
+          }
+        ]
+      },
+      "tags": [
+        "admin"
+      ]
+    },
+    "event": {
+      "users": [
+        {
+          "name": "alice"
+        },
+        {
+          "email": "b@x"
+        }
+      ],
+      "tags": [
+        "admin"
+      ]
+    }
+  },
+  {
+    "name": "deep prim: nested 3 levels",
+    "rule": {
+      "a": {
+        "b": {
+          "c": {
+            "vals": [
+              {
+                "exists": true
+              }
+            ],
+            "type": [
+              {
+                "exists": true
+              }
+            ]
+          }
+        }
+      }
+    },
+    "event": {
+      "a": {
+        "b": {
+          "c": {
+            "vals": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "ok"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "suffix match in array",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "suffix": "ice"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice",
+          "type": "user"
+        }
+      ]
+    }
+  },
+  {
+    "name": "N emails, only last element has name — dedup loses the only valid match",
+    "rule": {
+      "detail": {
+        "email": [{ "exists": true }],
+        "name":  [{ "exists": true }]
+      }
+    },
+    "event": {
+      "detail": [
+        { "email": "a@x" },
+        { "email": "b@x" },
+        { "email": "c@x" },
+        { "email": "d@x" },
+        { "email": "e@x", "name": "eve" }
+      ]
+    }
+  },
+  {
+    "name": "suffix match split",
+    "rule": {
+      "d": {
+        "name": [
+          {
+            "suffix": "ice"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "event": {
+      "d": [
+        {
+          "name": "alice"
+        },
+        {
+          "type": "user"
+        }
+      ]
+    }
+  }
+]

--- a/src/test/resources/perf-scenarios.json
+++ b/src/test/resources/perf-scenarios.json
@@ -1,0 +1,445 @@
+[
+  {
+    "name": "prim-array + scalar (2-field exists)",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "primArrayPlusScalar",
+    "sizes": [
+      500,
+      1000,
+      2000,
+      3000
+    ],
+    "expectedMatches": 1,
+    "notes": "OrigAC: quadratic. getTransitionOn fix: linear."
+  },
+  {
+    "name": "prim-array + scalar (prefix pattern)",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "prefix": "t"
+          }
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "primArrayPlusScalar",
+    "sizes": [
+      500,
+      1000,
+      2000,
+      3000
+    ],
+    "expectedMatches": 1,
+    "notes": "Same shape, prefix instead of exists. Same quadratic."
+  },
+  {
+    "name": "prim-array + scalar (exact, 1 match among N)",
+    "rule": {
+      "d": {
+        "tags": [
+          "t0"
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "primArrayPlusScalar",
+    "sizes": [
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "Only 1 element matches first field. Should be fast for all."
+  },
+  {
+    "name": "prim-array + scalar (no match)",
+    "rule": {
+      "d": {
+        "tags": [
+          "NOTFOUND"
+        ],
+        "type": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "primArrayPlusScalar",
+    "sizes": [
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 0,
+    "notes": "No element matches. Should be fast for all."
+  },
+  {
+    "name": "single-field rule on large prim-array",
+    "rule": {
+      "d": {
+        "tags": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "primArrayOnly",
+    "sizes": [
+      1000
+    ],
+    "expectedMatches": 1,
+    "notes": "Single field = no fan-out. Linear for all."
+  },
+  {
+    "name": "obj-array, both fields in every element",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "objArrayBothFields",
+    "sizes": [
+      100,
+      200,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "OrigAC+FixedAC: quadratic. Per-element grouping: linear."
+  },
+  {
+    "name": "obj-array, N-1 partial + last valid",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "objArrayLastValid",
+    "sizes": [
+      100,
+      200,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "Only last element has both fields. Tests worst-case search."
+  },
+  {
+    "name": "obj-array, all partial (no match)",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "objArrayAllPartial",
+    "sizes": [
+      100,
+      200,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 0,
+    "notes": "No element has both fields. Must exhaust all paths."
+  },
+  {
+    "name": "customer-like 6-field rule",
+    "rule": {
+      "detail": {
+        "data": {
+          "name": [
+            {
+              "exists": true
+            }
+          ],
+          "domains": {
+            "email": [
+              {
+                "exists": true
+              },
+              {
+                "exists": false
+              }
+            ]
+          },
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        },
+        "context": {
+          "companyId": [
+            {
+              "exists": true
+            }
+          ],
+          "userId": [
+            {
+              "exists": true
+            }
+          ],
+          "email": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "generator": "customerLike",
+    "sizes": [
+      100,
+      500,
+      1000,
+      2000,
+      3000
+    ],
+    "expectedMatches": 1,
+    "notes": "Real production pattern from P403641881."
+  },
+  {
+    "name": "prim-array inside obj-array elements",
+    "rule": {
+      "detail": {
+        "data": {
+          "name": [
+            {
+              "exists": true
+            }
+          ],
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "generator": "primInsideObjArray",
+    "sizes": [
+      100,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "Tests nesting: EG splits by element then hits prim-array."
+  },
+  {
+    "name": "no obj-array, just large prim-array",
+    "rule": {
+      "detail": {
+        "data": {
+          "name": [
+            {
+              "exists": true
+            }
+          ],
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "generator": "noObjArrayLargePrim",
+    "sizes": [
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "EG falls back to OrigAC here. Only FixedAC helps."
+  },
+  {
+    "name": "nested 2-level obj-arrays (outer x inner=10)",
+    "rule": {
+      "a": {
+        "b": {
+          "x": [
+            {
+              "exists": true
+            }
+          ],
+          "y": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "generator": "nested2Level",
+    "sizes": [
+      50,
+      100,
+      200,
+      500
+    ],
+    "expectedMatches": 1,
+    "notes": "Outer N elements x 10 inner. Tests nested array handling."
+  },
+  {
+    "name": "deep nesting: obj > obj > prim-array",
+    "rule": {
+      "a": {
+        "b": {
+          "tags": [
+            {
+              "exists": true
+            }
+          ],
+          "type": [
+            {
+              "exists": true
+            }
+          ]
+        }
+      }
+    },
+    "generator": "deepNestedPrim",
+    "sizes": [
+      100,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "3 obj-array elements, each with nested prim-array of size N."
+  },
+  {
+    "name": "wide rule (3 fields) + prim-array",
+    "rule": {
+      "d": {
+        "a": [
+          {
+            "exists": true
+          }
+        ],
+        "b": [
+          {
+            "exists": true
+          }
+        ],
+        "c": [
+          {
+            "exists": true
+          }
+        ]
+      }
+    },
+    "generator": "wideRulePrimArray",
+    "sizes": [
+      500,
+      1000,
+      2000,
+      3000
+    ],
+    "expectedMatches": 1,
+    "notes": "3-field AND rule. More fields = worse fan-out."
+  },
+  {
+    "name": "two prim-arrays + scalar",
+    "rule": {
+      "tags": [
+        {
+          "exists": true
+        }
+      ],
+      "cats": [
+        {
+          "exists": true
+        }
+      ],
+      "v": [
+        "1"
+      ]
+    },
+    "generator": "twoPrimArrays",
+    "sizes": [
+      100,
+      500,
+      1000,
+      2000
+    ],
+    "expectedMatches": 1,
+    "notes": "Two independent prim-arrays. Tests cross-array interaction."
+  },
+  {
+    "name": "control: scalar only (no arrays)",
+    "rule": {
+      "a": [
+        {
+          "exists": true
+        }
+      ],
+      "b": [
+        {
+          "exists": true
+        }
+      ]
+    },
+    "generator": "controlScalar",
+    "sizes": [
+      1
+    ],
+    "expectedMatches": 1,
+    "notes": "Baseline. All matchers should be <1ms."
+  }
+]

--- a/src/test/software/amazon/event/ruler/ACMachineStructuredTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineStructuredTest.java
@@ -1,0 +1,19 @@
+package software.amazon.event.ruler;
+
+/**
+ * Runs the full ACMachineTest suite with structured matching enabled.
+ *
+ * This validates that rulesForJSONEvent() produces identical results
+ * when backed by StructuredFinder instead of ACFinder. All test methods
+ * are inherited from ACMachineTest; the only difference is that Machine
+ * instances are created with structured matching on.
+ */
+public class ACMachineStructuredTest extends ACMachineTest {
+
+    @Override
+    protected Machine createMachine() {
+        return Machine.builder()
+                .withStructuredMatching(true)
+                .build();
+    }
+}

--- a/src/test/software/amazon/event/ruler/ACMachineTest.java
+++ b/src/test/software/amazon/event/ruler/ACMachineTest.java
@@ -1,7 +1,5 @@
 package software.amazon.event.ruler;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -18,11 +16,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertFalse;
 
 /**
  * Unit testing a state machine is hard.  Tried hand-computing a few machines
@@ -30,6 +30,11 @@ import static org.junit.Assert.fail;
  *  more of a smoke/integration test.  But the coverage is quite good.
  */
 public class ACMachineTest {
+
+    protected Machine createMachine() {
+        return new Machine();
+    }
+
 
     private String toIP(int ip) {
         String sb = String.valueOf((ip >> 24) & 0xFF) + '.' +
@@ -54,7 +59,7 @@ public class ACMachineTest {
             String rule = "{ " +
                     "  \"a\": [ {\"cidr\": \"10.0.0.0/" + i + "\"} ]" +
                     "}";
-            Machine m = new Machine();
+            Machine m = createMachine();
             m.addRule("r", rule);
             long numberThatShouldMatch = 1L << (32 - i);
 
@@ -78,7 +83,7 @@ public class ACMachineTest {
         String rule2 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.154.255/24\"}]}";
         String rule3 = "{\"sourceIPAddress\": [{\"cidr\": \"220.160.59.225/31\"}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
@@ -184,7 +189,7 @@ public class ACMachineTest {
         };
 
         for (String rule : rules) {
-            Machine m = new Machine();
+            Machine m = createMachine();
             m.addRule("r0", rule);
             assertEquals(1, m.rulesForJSONEvent(JSON_FROM_README).size());
         }
@@ -227,7 +232,7 @@ public class ACMachineTest {
                 "{\"Songs\": { \"Writers\": { \"First\": [ \"Mick\" ], \"Last\": [ \"McCartney\" ] }}}",
                 "{\"Genres\": { \"Pop\": [ true ] }, \"Songs\": { \"Writers\": { \"First\": [ \"Mick\" ], \"Last\": [ \"McCartney\" ] }}}",
         };
-        Machine m = new Machine();
+        Machine m = createMachine();
         for (int i = 0; i < rulesThatShouldMatch.length; i++) {
             String rule = rulesThatShouldMatch[i];
             String name = String.format("r%d", i);
@@ -288,7 +293,7 @@ public class ACMachineTest {
                 "}";
 
 
-        Machine m = new Machine();
+        Machine m = createMachine();
         m.addRule("r", rule);
         List<String> result = m.rulesForJSONEvent(intensities);
         assertEquals(1, result.size());
@@ -299,7 +304,7 @@ public class ACMachineTest {
     public void testSimplestPossibleMachine() throws Exception {
         String rule1 = "{ \"a\" : [ 1 ] }";
         String rule2 = "{ \"b\" : [ 2 ] }";
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule1);
         machine.addRule("r2", rule2);
         String event1 = "{ \"a\": 1 }";
@@ -322,7 +327,7 @@ public class ACMachineTest {
     public void testPrefixMatching() throws Exception {
         String rule1 = "{ \"a\" : [ { \"prefix\": \"zoo\" } ] }";
         String rule2 = "{ \"b\" : [ { \"prefix\": \"child\" } ] }";
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule1);
         machine.addRule("r2", rule2);
         String[] events = {
@@ -342,7 +347,7 @@ public class ACMachineTest {
             }
         }
 
-        machine = new Machine();
+        machine = createMachine();
         String rule3 = "{ \"a\" : [ { \"prefix\": \"al\" } ] }";
         String rule4 = "{ \"a\" : [ \"albert\" ] }";
         machine.addRule("r3", rule3);
@@ -356,7 +361,7 @@ public class ACMachineTest {
     public void testPrefixEqualsIgnoreCase() throws Exception {
         String rule1 = "{ \"a\" : [ { \"prefix\": { \"equals-ignore-case\" : \"zoo\" } } ] }";
         String rule2 = "{ \"b\" : [ { \"prefix\": { \"equals-ignore-case\" : \"child\" } } ] }";
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule1);
         machine.addRule("r2", rule2);
         String[] events = {
@@ -376,7 +381,7 @@ public class ACMachineTest {
             }
         }
 
-        machine = new Machine();
+        machine = createMachine();
         String rule3 = "{ \"a\" : [ { \"prefix\": { \"equals-ignore-case\" : \"al\" } } ] }";
         String rule4 = "{ \"a\" : [ \"ALbert\" ] }";
         machine.addRule("r3", rule3);
@@ -390,7 +395,7 @@ public class ACMachineTest {
     public void testSuffixEqualsIgnoreCase() throws Exception {
         String rule1 = "{ \"a\" : [ { \"suffix\": { \"equals-ignore-case\" : \"eper\" } } ] }";
         String rule2 = "{ \"b\" : [ { \"suffix\": { \"equals-ignore-case\" : \"hood\" } } ] }";
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule1);
         machine.addRule("r2", rule2);
         String[] events = {
@@ -411,7 +416,7 @@ public class ACMachineTest {
             }
         }
 
-        machine = new Machine();
+        machine = createMachine();
         String rule3 = "{ \"a\" : [ { \"suffix\": { \"equals-ignore-case\" : \"ert\" } } ] }";
         String rule4 = "{ \"a\" : [ \"AlbeRT\" ] }";
         machine.addRule("r3", rule3);
@@ -423,7 +428,7 @@ public class ACMachineTest {
 
     @Test
     public void testSuffixEqualsIgnoreCaseChineseMatch() throws Exception {
-        Machine m = new Machine();
+        Machine m = createMachine();
         String rule = "{\n" +
                 "   \"status\": {\n" +
                 "       \"weatherText\": [{\"suffix\": \"统治者\"}]\n" +
@@ -442,7 +447,7 @@ public class ACMachineTest {
 
     @Test
     public void testSuffixChineseMatch() throws Exception {
-        Machine m = new Machine();
+        Machine m = createMachine();
         String rule = "{\n" +
                 "   \"status\": {\n" +
                 "       \"weatherText\": [{\"suffix\": \"统治者\"}]\n" +
@@ -487,7 +492,7 @@ public class ACMachineTest {
                 "    \"type\": [ \"Polygon\" ]" +
                 "  }" +
                 "}";
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("R1", rule);
         List<String> r = machine.rulesForJSONEvent(eJSON);
         assertEquals(1, r.size());
@@ -656,7 +661,7 @@ public class ACMachineTest {
 
     @Test
     public void testBuild() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
 
         setRules(machine);
         assertNotNull(machine);
@@ -746,7 +751,7 @@ public class ACMachineTest {
 
     @Test
     public void addRuleOriginalAPI() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         String rule1 = "{ \"f1\": [ \"x\", \"y\"], \"f2\": [1,2]}";
         String rule2 = "{ \"f1\": [\"foo\", \"bar\"] }";
         machine.addRule("r1", rule1);
@@ -763,7 +768,7 @@ public class ACMachineTest {
 
     @Test
     public void twoRulesSamePattern() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         String json = "{\"detail\":{\"testId\":[\"foo\"]}}";
         machine.addRule("rule1", json);
         machine.addRule("rule2", new StringReader(json));
@@ -777,7 +782,7 @@ public class ACMachineTest {
 
     @Test
     public void twoRulesSamePattern2() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         List<Rule> rules = new ArrayList<>();
         Rule rule;
         rule = new Rule("R1");
@@ -803,7 +808,7 @@ public class ACMachineTest {
 
     @Test
     public void dynamicAddRules() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
 
         TestEvent e = new TestEvent("0", "\"\"", "a", "11", "b", "21", "c", "31", "gamma", "41", "zoo", "\"keeper\"");
 
@@ -852,7 +857,7 @@ public class ACMachineTest {
      */
     @Test
     public void dynamicDeleteRules() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
 
         TestEvent e = new TestEvent("0", "\"\"", "a", "11", "b", "21", "c", "31", "gamma", "41", "zoo", "\"keeper\"");
 
@@ -902,7 +907,7 @@ public class ACMachineTest {
      */
     @Test
     public void testMultipleThreadReadAddRule() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         List<String> event = new ArrayList<>();
         List <Rule> rules = new ArrayList<>();
 
@@ -1002,7 +1007,7 @@ public class ACMachineTest {
 
     @Test
     public void testMultipleThreadReadDeleteRule() throws Exception {
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         List<String> event = new ArrayList<>();
         List <Rule> rules = new ArrayList<>();
 
@@ -1105,7 +1110,7 @@ public class ACMachineTest {
     @Test
     public void testFunkyDelete() throws Exception {
         String rule = "{ \"foo\": { \"bar\": [ 23 ] }}";
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1143,7 +1148,7 @@ public class ACMachineTest {
         String rule3 = "{ \"foo\": { \"bar\": [ 44, 45, 46 ] }}";
         String rule4 = "{ \"foo\": { \"bar\": [ 44, 46, 47 ] }}";
         String rule5 = "{ \"foo\": { \"bar\": [ 23, 44, 45, 46, 47 ] }}";
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1203,7 +1208,7 @@ public class ACMachineTest {
 
         String rule = "{\"x\": [{\"numeric\": [\">=\", 0, \"<\", 1000000000]}]}";
 
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1245,7 +1250,7 @@ public class ACMachineTest {
     @Test
     public void deleteRule() throws Exception {
         String rule = "{ \"foo\": { \"bar\": [ \"ab\", \"cd\" ] }}";
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1273,7 +1278,7 @@ public class ACMachineTest {
 
     @Test
     public void WHEN_RuleForJsonEventIsPresented_THEN_ItIsMatched() throws Exception {
-        final Machine rulerMachine = new Machine();
+        final Machine rulerMachine = createMachine();
         rulerMachine.addRule( "test-rule", "{ \"type\": [\"Notification\"] }" );
 
         String event = "        { \n" +
@@ -1292,7 +1297,7 @@ public class ACMachineTest {
     @Test
     public void OneEventWithDuplicatedKeyButDifferentValueMatchRules() throws Exception {
 
-        Machine cut = new Machine();
+        Machine cut = createMachine();
         String rule1 = "{ \"foo\": { \"bar\": [ \"ab\" ] }}";
         String rule2 = "{ \"foo\": { \"bar\": [ \"cd\" ] }}";
 
@@ -1327,7 +1332,7 @@ public class ACMachineTest {
     @Test
     public void OneRuleMadeByTwoConditions() throws Exception {
 
-        Machine cut = new Machine();
+        Machine cut = createMachine();
         String condition1 = "{\n" +
                 "\"A\" : [ \"on\" ],\n" +
                 "\"C\" : [ \"on\" ],\n" +
@@ -1376,7 +1381,7 @@ public class ACMachineTest {
                 "\"y\": [ { \"numeric\": [ \">=\", 0 ] } ],\n" +
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ]\n" +
                 "}";
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1405,7 +1410,7 @@ public class ACMachineTest {
                 "\"d\": [ { \"anything-but\": 111 } ],\n" +
                 "\"z\": [ { \"numeric\": [ \">\", 0, \"<\", 1 ] } ]\n" +
                 "}";
-        Machine cut = new Machine();
+        Machine cut = createMachine();
 
         // add the rule, ensure it matches
         cut.addRule("r1", rule);
@@ -1441,7 +1446,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"prefix\": \"$\"} } ]\n" +
                 "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1473,7 +1478,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"prefix\": [\"$\", \"%\"] } } ]\n" +
                 "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1510,7 +1515,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"suffix\": \"$\"} } ]\n" +
                 "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1542,7 +1547,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"suffix\": [\"$\", \"%\"] } } ]\n" +
                 "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1581,7 +1586,7 @@ public class ACMachineTest {
                 "\"b\": [ { \"anything-but\": {\"equals-ignore-case\": \"no\"  } } ]\n" +
                 "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1651,7 +1656,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"wildcard\": \"*foo*\"} } ]\n" +
         "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1692,7 +1697,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"wildcard\": [\"*foo*\", \"*bar*\"] } } ]\n" +
         "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule);
 
         String event1 = "{" +
@@ -1757,7 +1762,7 @@ public class ACMachineTest {
                 "\"a\": [ { \"anything-but\": {\"wildcard\": \"*bar*\"} } ]\n" +
         "}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("r1", rule1);
         machine.addRule("r2", rule2);
 
@@ -1996,7 +2001,7 @@ public class ACMachineTest {
                                 "  }\n" +
                                 "}";
 
-        Machine cut = new Machine();
+        Machine cut = createMachine();
         // add the rule, ensure it matches
         cut.addRule("r1", rule1);
         cut.addRule("r2", rule2);
@@ -2012,7 +2017,7 @@ public class ACMachineTest {
         String rule1 = "{\"abc\": [{\"exists\": false}]}";
         String rule2 = "{\"abc\": [{\"exists\": true}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2029,7 +2034,7 @@ public class ACMachineTest {
 
     @Test
     public void testAddAndDeleteTwoRulesSamePattern() throws Exception {
-        final Machine machine = new Machine();
+        final Machine machine = createMachine();
         String event = "{\n" +
                 "  \"x\": \"y\"\n" +
                 "}";
@@ -2061,7 +2066,7 @@ public class ACMachineTest {
 
     @Test
     public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternEqualsIgnoreCase() throws Exception {
-        final Machine machine = new Machine();
+        final Machine machine = createMachine();
         String event = "{\n" +
                 "  \"x\": \"y\"\n" +
                 "}";
@@ -2093,7 +2098,7 @@ public class ACMachineTest {
 
     @Test
     public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternPrefixEqualsIgnoreCase() throws Exception {
-        final Machine machine = new Machine();
+        final Machine machine = createMachine();
         String event = "{\n" +
                 "  \"x\": \"yay\"\n" +
                 "}";
@@ -2125,7 +2130,7 @@ public class ACMachineTest {
 
     @Test
     public void testAddAndDeleteTwoRulesSameCaseInsensitivePatternSuffixEqualsIgnoreCase() throws Exception {
-        final Machine machine = new Machine();
+        final Machine machine = createMachine();
         String event = "{\n" +
                 "  \"x\": \"yay\"\n" +
                 "}";
@@ -2157,7 +2162,7 @@ public class ACMachineTest {
 
     @Test
     public void testDuplicateKeyLastOneWins() throws Exception {
-        final Machine machine = new Machine();
+        final Machine machine = createMachine();
         String event1 = "{\n" +
                 "  \"x\": \"y\"\n" +
                 "}";
@@ -2186,7 +2191,7 @@ public class ACMachineTest {
         String rule2 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"x\"]}";
         String rule3 = "{\"foo\":[\"a\", \"b\"], \"bar\":[\"y\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
@@ -2209,7 +2214,7 @@ public class ACMachineTest {
         String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
         String rule2 = "{\"foo\":[\"b\"], \"bar\":[\"x\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2261,7 +2266,7 @@ public class ACMachineTest {
         String rule1 = "{\"zoo\":[\"1\"], \"foo\":[\"a\"], \"bar\":[\"x\"]}";
         String rule2 = "{\"foo\":[\"a\"], \"bar\":[\"x\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2292,7 +2297,7 @@ public class ACMachineTest {
         String rule2 = "{\"zoo\":[\"1\"], \"bar\":[\"x\"]}";
         String rule2b = "{\"foo\":[\"a\"], \"bar\":[\"y\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule2", rule2b);
@@ -2314,7 +2319,7 @@ public class ACMachineTest {
         String rule1 = "{\"foo\":[\"a\"], \"bar\":[\"x\", \"y\"]}";
         String rule2 = "{\"$or\":[{\"zoo\":[\"1\"], \"bar\":[\"x\"]}, {\"foo\":[\"a\"], \"bar\":[\"y\"]}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2335,7 +2340,7 @@ public class ACMachineTest {
         String rule1 = "{\"foo\": [\"a\", \"b\", \"c\"]}";
         String rule2 = "{\"foo\": [\"b\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2355,7 +2360,7 @@ public class ACMachineTest {
         String rule1 = "{\"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
         String rule2 = "{\"foo\": [\"b\", \"d\", \"f\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2375,7 +2380,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
         String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2396,7 +2401,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
         String rule2 = "{\"bar\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2417,7 +2422,7 @@ public class ACMachineTest {
         String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\"]}";
         String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2438,7 +2443,7 @@ public class ACMachineTest {
         String rule1 = "{\"zoo\": [\"1\"], \"foo\": [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\"]}";
         String rule2 = "{\"zoo\": [\"1\"], \"foo\": [\"b\", \"d\", \"f\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2459,7 +2464,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\": [\"a\", \"b\"]}";
         String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": false}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2479,7 +2484,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\": [\"a\", \"b\"]}";
         String rule2 = "{\"bar\": [\"b\"], \"foo\": [{\"exists\": true}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2502,7 +2507,7 @@ public class ACMachineTest {
         String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": false}, \"1\"]}";
         String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
@@ -2525,7 +2530,7 @@ public class ACMachineTest {
         String rule2 = "{\"foo\": [\"b\"], \"bar\": [{\"exists\": true}, \"1\"]}";
         String rule3 = "{\"foo\": [\"a\"], \"bar\": [\"1\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
         machine.addRule("rule3", rule3);
@@ -2549,7 +2554,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\": [{\"exists\": false}]}";
         String rule2 = "{\"foo\": [{\"exists\": false}], \"zoo\": [\"a\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2568,7 +2573,7 @@ public class ACMachineTest {
         // Every event will match this rule because any bar that is "a" cannot also be "b".
         String rule1 = "{\"bar\": [{\"anything-but\": \"a\"}, {\"anything-but\": \"b\"}]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
 
         String event = "{\"bar\": \"b\"}";
@@ -2584,7 +2589,7 @@ public class ACMachineTest {
         String rule1 = "{\"$or\": [{\"bar\": [\"1\"]}, {\"bar\": [\"2\"]}]," +
                         "\"foo\": [\"a\"] }";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
 
         String event = "{\"bar\": \"2\"," +
@@ -2602,7 +2607,7 @@ public class ACMachineTest {
         String rule1 = "{\"bar\" :[\"b\"], \"foo\": [\"c\"]}";
         String rule2 = "{\"bar\": [\"a\", \"b\"], \"foo\": [\"c\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
 
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
@@ -2620,7 +2625,7 @@ public class ACMachineTest {
         String rule1 = "{\"ip\": [{\"anything-but\": \"10.0.1.200\"}]}";
         String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2638,7 +2643,7 @@ public class ACMachineTest {
         String rule1 = "{\"ip\": [{\"anything-but\": {\"prefix\": \"10.0.\"}}]}";
         String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2656,7 +2661,7 @@ public class ACMachineTest {
         String rule1 = "{\"ip\": [{\"anything-but\": {\"suffix\": \"1.200\"}}]}";
         String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2674,7 +2679,7 @@ public class ACMachineTest {
         String rule1 = "{\"ip\": [{\"anything-but\": {\"equals-ignore-case\": \"10.0.1.200\"}}]}";
         String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2692,7 +2697,7 @@ public class ACMachineTest {
         String rule1 = "{\"ip\": [{\"numeric\": [\">\", 0, \"<=\", 5]}]}";
         String rule2 = "{\"ip\": [\"10.0.1.200\"]}";
 
-        Machine machine = new Machine();
+        Machine machine = createMachine();
         machine.addRule("rule1", rule1);
         machine.addRule("rule2", rule2);
 
@@ -2756,7 +2761,7 @@ public class ACMachineTest {
         assertEquals(1, matches.size());
         assertTrue(matches.contains("rule1"));
     }
-
+    
     private static Set<String> set(String ... strings) {
         return set(Arrays.asList(strings));
     }

--- a/src/test/software/amazon/event/ruler/StructuredFinderTest.java
+++ b/src/test/software/amazon/event/ruler/StructuredFinderTest.java
@@ -1,0 +1,402 @@
+package software.amazon.event.ruler;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for {@link StructuredFinder} via {@code withStructuredMatching(true)}.
+ *
+ * Validates that structured matching produces identical results to the default
+ * {@link GenericMachine#rulesForJSONEvent(String)} on all correctness cases,
+ * then benchmarks both on large events.
+ */
+public class StructuredFinderTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Structured matching must produce identical results to the default on every
+     * correctness case. This is the primary correctness gate.
+     */
+    @Test
+    public void structuredMatchesACOnAllCases() throws Exception {
+        InputStream is = getClass().getResourceAsStream("/correctness-cases.json");
+        JsonNode cases = MAPPER.readTree(is);
+        int pass = 0;
+        int fail = 0;
+
+        System.out.printf("%n%-55s %-8s %-8s %-6s%n", "Case", "AC", "New", "OK?");
+
+        for (JsonNode tc : cases) {
+            String name = tc.get("name").asText();
+            String rule = MAPPER.writeValueAsString(tc.get("rule"));
+            String event = MAPPER.writeValueAsString(tc.get("event"));
+
+            Machine m = new Machine();
+            m.addRule("r1", rule);
+
+            Machine sm = Machine.builder().withStructuredMatching(true).build();
+            sm.addRule("r1", rule);
+
+            List<String> acResult = m.rulesForJSONEvent(event);
+            List<String> newResult = sm.rulesForJSONEvent(event);
+
+            Collections.sort(acResult);
+            Collections.sort(newResult);
+
+            boolean ok = acResult.equals(newResult);
+            if (ok) {
+                pass++;
+            } else {
+                fail++;
+            }
+
+            System.out.printf("%-55s %-8s %-8s %-6s%n", name,
+                    acResult.isEmpty() ? "no" : "MATCH",
+                    newResult.isEmpty() ? "no" : "MATCH",
+                    ok ? "OK" : "FAIL");
+
+            assertEquals(name + ": new method must match old", acResult, newResult);
+        }
+
+        System.out.printf("Passed: %d, Failed: %d%n", pass, fail);
+        assertEquals(0, fail);
+    }
+
+    /** Performance comparison on events up to ~500KB. */
+    @Test(timeout = 900000) // 15 minute timeout for the whole perf test
+    public void perfComparison() throws Exception {
+        System.out.printf("%n%-12s %-10s %-10s %-12s %-12s%n",
+                "Scenario", "N", "KB", "Old(ms)", "New(ms)");
+
+        perfRun("prim+scl",
+                "{\"d\":{\"tags\":[{\"exists\":true}],\"type\":[{\"exists\":true}]}}",
+                new int[]{1000, 5000, 10000, 50000, 100000},
+                StructuredFinderTest::buildPrimArray, 1);
+
+        perfRun("obj-both",
+                "{\"d\":{\"a\":[{\"exists\":true}],\"b\":[{\"exists\":true}]}}",
+                new int[]{1000, 5000, 10000, 20000},
+                StructuredFinderTest::buildObjArray, 1);
+
+        perfRun("nested2",
+                "{\"a\":{\"b\":{\"x\":[{\"exists\":true}],\"y\":[{\"exists\":true}]}}}",
+                new int[]{100, 500, 1000, 2000, 4000},
+                StructuredFinderTest::buildNested2, 1);
+
+        perfRun("customer",
+                "{\"detail\":{\"data\":{\"name\":[{\"exists\":true}],\"domains\":{\"email\":[{\"exists\":true},{\"exists\":false}]},\"type\":[{\"exists\":true}]},\"context\":{\"companyId\":[{\"exists\":true}],\"userId\":[{\"exists\":true}],\"email\":[{\"exists\":true}]}}}",
+                new int[]{1000, 5000, 10000, 50000},
+                StructuredFinderTest::buildCustomerLike, 1);
+
+        // Element contains large primitive array
+        perfRun("elem+prim",
+                "{\"d\":{\"tags\":[{\"exists\":true}],\"type\":[{\"exists\":true}]}}",
+                new int[]{1000, 5000, 10000, 50000},
+                StructuredFinderTest::buildElemWithPrimArray, 1);
+
+        // Element contains nested object array
+        perfRun("elem+obj",
+                "{\"outer\":{\"inner\":{\"a\":[{\"exists\":true}],\"b\":[{\"exists\":true}]}}}",
+                new int[]{1000, 5000, 10000},
+                StructuredFinderTest::buildElemWithNestedObjArray, 1);
+
+        // Sibling object arrays (cross-product via ACFinder fallback)
+        perfRun("siblings",
+                "{\"x\":{\"a\":[{\"exists\":true}]},\"y\":{\"b\":[{\"exists\":true}]}}",
+                new int[]{100, 500, 1000},
+                StructuredFinderTest::buildSiblingObjArrays, 1);
+
+        // Sibling object arrays with SAME field names in rule
+        perfRun("sib-same",
+                "{\"x\":{\"a\":[{\"exists\":true}]},\"y\":{\"a\":[{\"exists\":true}]}}",
+                new int[]{100, 500, 1000},
+                StructuredFinderTest::buildSiblingsSameFieldName, 1);
+
+        // Large parent scalar + object array (tests JSON string building overhead)
+        perfRun("bigparent",
+                "{\"d\":{\"a\":[{\"exists\":true}]},\"meta\":[{\"exists\":true}]}",
+                new int[]{500, 5000, 10000, 50000, 100000},
+                StructuredFinderTest::buildBigParentWithObjArray, 1);
+
+        // 3-level deep nesting, single array at each level
+        perfRun("deep3",
+                "{\"a\":{\"b\":{\"c\":{\"x\":[{\"exists\":true}],\"y\":[{\"exists\":true}]}}}}",
+                new int[]{50, 100, 200, 300, 400},
+                StructuredFinderTest::buildDeep3Level, 1);
+
+        // Single large object array, each element has many scalar fields
+        perfRun("wide-elem",
+                "{\"d\":{\"f0\":[{\"exists\":true}],\"f9\":[{\"exists\":true}]}}",
+                new int[]{500, 1000, 5000, 10000},
+                StructuredFinderTest::buildWideElements, 1);
+    }
+
+    // ==================== Event builders ====================
+
+    static String buildPrimArray(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":{\"tags\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("\"t").append(i).append("\"");
+        }
+        s.append("],\"type\":\"G\"}}");
+        return s.toString();
+    }
+
+    static String buildObjArray(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"a\":\"").append(i).append("\",\"b\":\"").append(i).append("\"}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    static String buildNested2(int n) {
+        StringBuilder s = new StringBuilder("{\"a\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"b\":[");
+            for (int j = 0; j < 10; j++) {
+                if (j > 0) {
+                    s.append(",");
+                }
+                s.append("{\"x\":\"").append(i).append("_").append(j)
+                  .append("\",\"y\":\"").append(i).append("_").append(j).append("\"}");
+            }
+            s.append("]}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    static String buildCustomerLike(int n) {
+        StringBuilder s = new StringBuilder("{\"detail\":{\"data\":{\"name\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("\"u").append(i).append("\"");
+        }
+        s.append("],\"type\":\"G\",\"domains\":{\"email\":\"t@x\"}},\"context\":{\"companyId\":\"c\",\"userId\":\"u\",\"email\":\"a@b\"}}}");
+        return s.toString();
+    }
+
+    /** Outer object array with 2 elements, each containing a large primitive array. */
+    static String buildElemWithPrimArray(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":[");
+        for (int e = 0; e < 2; e++) {
+            if (e > 0) {
+                s.append(",");
+            }
+            s.append("{\"tags\":[");
+            for (int i = 0; i < n; i++) {
+                if (i > 0) {
+                    s.append(",");
+                }
+                s.append("\"t").append(e).append("_").append(i).append("\"");
+            }
+            s.append("],\"type\":\"G\"}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** Outer object array with 2 elements, each containing a nested object array of size N. */
+    static String buildElemWithNestedObjArray(int n) {
+        StringBuilder s = new StringBuilder("{\"outer\":[");
+        for (int e = 0; e < 2; e++) {
+            if (e > 0) {
+                s.append(",");
+            }
+            s.append("{\"inner\":[");
+            for (int i = 0; i < n; i++) {
+                if (i > 0) {
+                    s.append(",");
+                }
+                s.append("{\"a\":\"").append(e).append("_").append(i);
+                s.append("\",\"b\":\"").append(e).append("_").append(i).append("\"}");
+            }
+            s.append("]}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** Two sibling object arrays, each with N elements. */
+    static String buildSiblingObjArrays(int n) {
+        StringBuilder s = new StringBuilder("{\"x\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"a\":\"x").append(i).append("\"}");
+        }
+        s.append("],\"y\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"b\":\"y").append(i).append("\"}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** Two sibling object arrays with the SAME field name "a" in both. */
+    static String buildSiblingsSameFieldName(int n) {
+        StringBuilder s = new StringBuilder("{\"x\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"a\":\"x").append(i).append("\"}");
+        }
+        s.append("],\"y\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"a\":\"y").append(i).append("\"}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** Large scalar field "meta" (10KB) + object array with N elements. */
+    static String buildBigParentWithObjArray(int n) {
+        StringBuilder meta = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            meta.append("abcdefghij");
+        }
+        StringBuilder s = new StringBuilder("{\"meta\":\"").append(meta).append("\",\"d\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"a\":\"v").append(i).append("\"}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** 3-level deep nesting: a[N] > b[10] > c[10], each leaf has x and y. */
+    static String buildDeep3Level(int n) {
+        StringBuilder s = new StringBuilder("{\"a\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{\"b\":[");
+            for (int j = 0; j < 10; j++) {
+                if (j > 0) {
+                    s.append(",");
+                }
+                s.append("{\"c\":[");
+                for (int k = 0; k < 10; k++) {
+                    if (k > 0) {
+                        s.append(",");
+                    }
+                    s.append("{\"x\":\"").append(i).append("_").append(j).append("_").append(k);
+                    s.append("\",\"y\":\"").append(i).append("_").append(j).append("_").append(k).append("\"}");
+                }
+                s.append("]}");
+            }
+            s.append("]}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    /** Object array with N elements, each having 10 scalar fields. */
+    static String buildWideElements(int n) {
+        StringBuilder s = new StringBuilder("{\"d\":[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                s.append(",");
+            }
+            s.append("{");
+            for (int f = 0; f < 10; f++) {
+                if (f > 0) {
+                    s.append(",");
+                }
+                s.append("\"f").append(f).append("\":\"v").append(i).append("_").append(f).append("\"");
+            }
+            s.append("}");
+        }
+        s.append("]}");
+        return s.toString();
+    }
+
+    // ==================== Perf runner ====================
+
+    interface EventGen {
+        String build(int n);
+    }
+
+    private void perfRun(String label, String rule, int[] sizes, EventGen gen, int expected) throws Exception {
+        Machine m = new Machine();
+        m.addRule("r1", rule);
+
+        Machine sm = Machine.builder().withStructuredMatching(true).build();
+        sm.addRule("r1", rule);
+
+        boolean oldTimedOut = false;
+
+        for (int n : sizes) {
+            String event = gen.build(n);
+            double kb = event.length() / 1024.0;
+            if (kb > 1100) {
+                break;
+            }
+
+            // Structured: must always complete, assert correctness + perf up to 1MB
+            sm.rulesForJSONEvent(event); // warmup
+            long t1 = System.nanoTime();
+            assertEquals(expected, sm.rulesForJSONEvent(event).size());
+            long newMs = (System.nanoTime() - t1) / 1000000;
+            assertTrue(label + " N=" + n + " structured took " + newMs + "ms (limit 15s)",
+                    newMs < 15000);
+
+            // Old method: best-effort comparison, no assertions. May OOM or timeout.
+            String oldStr;
+            if (oldTimedOut) {
+                oldStr = "SKIP";
+            } else {
+                try {
+                    m.rulesForJSONEvent(event); // warmup
+                    long t0 = System.nanoTime();
+                    m.rulesForJSONEvent(event);
+                    long oldMs = (System.nanoTime() - t0) / 1000000;
+                    if (oldMs > 10000) {
+                        oldStr = "TIMEOUT";
+                        oldTimedOut = true;
+                    } else {
+                        oldStr = oldMs + "ms";
+                    }
+                } catch (Throwable e) {
+                    oldStr = e.getClass().getSimpleName();
+                    oldTimedOut = true;
+                }
+            }
+
+            System.out.printf("%-12s %-10d %-10.1f %-12s %-12s%n", label, n, kb, oldStr, newMs + "ms");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a new matching method `rulesForJSONEventNonBlocking()` that provides
array-consistent matching with linear performance regardless of array size.

The existing `rulesForJSONEvent()` can exhibit quadratic performance when
events contain large arrays at paths matching multi-field rules. The new
method avoids this by walking the compiled state machine trie with direct
path lookups (HashMap) instead of scanning all remaining fields per step.

A configuration flag `withStructuredMatching(true)` on Machine.Builder
allows `rulesForJSONEvent()` to use the new implementation.

## Changes

| File | Change |
|------|--------|
| StructuredFinder.java | New: indexed trie walker with early-exit |
| GenericMachine.java | New method + deprecation + config flag |
| GenericMachineConfiguration.java | useStructuredMatching flag |
| ACFinder.java | Field-index optimization in moveFrom() |
| Event.java | Field name range index + getFieldRange() |
| NameState.java | getValueTransitionKeys() |
| SubRuleContext.java | getRuleCount() for early-exit |
| ArrayMembership.java | Package-visible size() and entries() |
| ACMachineTest.java | createMachine() factory for subclass override |
| ACMachineStructuredTest.java | Runs all 71 ACMachineTest cases with structured matching |
| StructuredFinderTest.java | 51 correctness cases + 12 perf scenarios |
| correctness-cases.json | Test data |

## How it works

The existing ACFinder flattens the event into a list of (name, value,
membership) triples, then for each state transition scans all remaining
fields. With N array elements and K rule conditions, this is O(N*K) scans
of O(N) fields = O(N^2*K).

StructuredFinder indexes the event by dotted field path (HashMap), then
walks the trie with direct lookups. Each transition is O(1) instead of
O(N). With early-exit, it stops as soon as all rules are matched.

## Performance

Tested with payloads up to 1.2MB across 28 scenarios including attack
payloads. All times in ms:

| Scenario | N | KB | Before | After |
|----------|---|-----|--------|-------|
| Object array, 2-field rule | 45,000 | 1,121 | OOM | 74 |
| 3-level nested arrays | 380 | 1,125 | OOM | 49 |
| 10-condition rule | 8,000 | 1,177 | OOM | 57 |
| Customer-like 6-field | 130,000 | 1,161 | OOM | 29 |
| Wildcard bomb attack | 45,000 | 1,121 | OOM | 93 |
| 50-rule fan-out attack | 45,000 | 1,121 | OOM | 74 |
| Duplicate values attack | 65,000 | 1,143 | OOM | 68 |

Worst case at 1MB: 118ms (5-condition almost-match, full walk, no early-exit).

## Correctness

- 679 existing tests pass unchanged
- 71 ACMachineTest cases re-run with structured matching (ACMachineStructuredTest)
- 51 new correctness cases comparing old vs new method
- Externally validated against 2,799 test cases across all code paths
