### PR TITLE
feat!: Make StructuredFinder the default for rulesForJSONEvent (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,19 +638,18 @@ NameState. This is accomplished by storing that we already have a NameState for 
 Note that it doesn't matter if each addRule uses a different rule name or the same rule name.
 
 #### withStructuredMatching
-Default: false
+Default: true (since 2.0.0)
 
-When set to true, `rulesForJSONEvent()` uses a linear-time matching algorithm instead of the
-default step-queue approach. This is recommended for applications that process events with large
-arrays (thousands of elements) where the default algorithm may exhibit quadratic performance.
+Controls whether `rulesForJSONEvent()` uses StructuredFinder (indexed trie walker) or
+ACFinder (step-queue iteration) for array-consistent matching. Both produce identical
+results. StructuredFinder provides linear-time performance on events with large arrays,
+where ACFinder may exhibit quadratic step queue growth.
 
-The linear-time algorithm (`StructuredFinder`) indexes the event by field path and walks the
-compiled state machine trie with direct HashMap lookups instead of scanning all remaining fields
-per step. It also exits early once all rules in the machine have been matched.
+To opt out and use the previous ACFinder behavior:
 
 ```java
 Machine machine = Machine.builder()
-    .withStructuredMatching(true)
+    .withStructuredMatching(false)
     .build();
 ```
 
@@ -744,16 +743,8 @@ specifically because it does not support array-consistent matching.
 `rulesForJSONEvent()` also has the advantage that the code which turns the JSON form
 of the event into a sorted list has been extensively profiled and optimized.
 
-For events with large arrays (thousands of elements), build the Machine with
-`withStructuredMatching(true)` to enable linear-time matching:
-
-```java
-Machine machine = Machine.builder()
-    .withStructuredMatching(true)
-    .build();
-machine.addRule("rule1", ruleJson);
-List<String> matches = machine.rulesForJSONEvent(eventJson); // uses linear-time matching
-```
+Since 2.0.0, `rulesForJSONEvent()` uses StructuredFinder by default, which provides
+linear-time matching even on events with large arrays.
 
 The performance of `rulesForEvent()` and `rulesForJSONEvent()` do not depend on the number of rules added
 with `addRule()`.  `rulesForJSONEvent()` is generally faster because of the optimized
@@ -950,7 +941,7 @@ Events are processed at over 220K/second except for:
 ### Suggestions for better performance
 
 Here are some suggestions on processing rules and events:
-1. For new code, use `withStructuredMatching(true)` on Machine.Builder for linear-time matching that handles events with large arrays efficiently.
+1. Since 2.0.0, `rulesForJSONEvent()` uses StructuredFinder by default for linear-time matching. If you need the previous behavior, use `withStructuredMatching(false)` on Machine.Builder.
 2. If your team is still using old API -- rulesForEvent, switch to rulesForJSONEvent API. Due to limited resource, old API will not be maintained well thought contributions are always welcomed.
 2. If your team does event flattening by yourself,  you are recommended to use Ruler to flatten the event, just pass Json string or Json node. We have many optimizations within Ruler parsing code.
 3. if your team does Rule Json parsing by yourself, you are recommended to just pass the Json described rule string directly to Ruler, in which will do some pre-processing, e.g. add “”.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>software.amazon.event.ruler</groupId>
   <artifactId>event-ruler</artifactId>
   <name>Event Ruler</name>
-  <version>1.9.0</version>
+  <version>2.0.0</version>
   <description>Event Ruler is a Java library that allows matching Rules to Events. An event is a list of fields,
     which may be given as name/value pairs or as a JSON object. A rule associates event field names with lists of
     possible values. There are two reasons to use Ruler: 1/ It's fast; the time it takes to match Events doesn't

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -92,6 +92,9 @@ public class GenericMachine<T> {
 
     @SuppressWarnings("unchecked")
     public List<T> rulesForJSONEvent(final JsonNode eventRoot) {
+        if (configuration.isUseStructuredMatching()) {
+            return (List<T>) StructuredFinder.matchRules(eventRoot, this, subRuleContextGenerator);
+        }
         final Event event = new Event(eventRoot, this);
         return (List<T>) ACFinder.matchRules(event, this, subRuleContextGenerator);
     }
@@ -797,11 +800,11 @@ public class GenericMachine<T> {
         private boolean ruleOverriding = true;
 
         /**
-         * When true, {@code rulesForJSONEvent()} uses structured tree-walking matching
-         * instead of ACFinder, providing linear performance on events with large arrays.
-         * Default is false for backward compatibility.
+         * When true, {@code rulesForJSONEvent()} uses {@link StructuredFinder} (indexed trie walker)
+         * instead of {@link ACFinder} (step-queue iteration), providing linear performance on events
+         * with large arrays. Default is true since 2.0.0. Set to false to use the previous ACFinder behavior.
          */
-        private boolean useStructuredMatching = false;
+        private boolean useStructuredMatching = true;
 
         Builder() {}
 

--- a/src/main/software/amazon/event/ruler/StructuredFinder.java
+++ b/src/main/software/amazon/event/ruler/StructuredFinder.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * Array-consistent rule matching with guaranteed linear performance.
  *
@@ -30,6 +32,17 @@ class StructuredFinder {
     static List<Object> matchRules(final String json, final GenericMachine<?> machine,
                                    final SubRuleContext.Generator gen) throws Exception {
         final Event event = new Event(json, machine);
+        return matchRulesFromEvent(event, machine, gen);
+    }
+
+    static List<Object> matchRules(final JsonNode eventRoot, final GenericMachine<?> machine,
+                                   final SubRuleContext.Generator gen) {
+        final Event event = new Event(eventRoot, machine);
+        return matchRulesFromEvent(event, machine, gen);
+    }
+
+    private static List<Object> matchRulesFromEvent(final Event event, final GenericMachine<?> machine,
+                                                    final SubRuleContext.Generator gen) {
         final FieldIndex index = new FieldIndex(event);
         final int ruleCount = gen.getRuleCount();
 


### PR DESCRIPTION
## Breaking Change

`rulesForJSONEvent()` now uses StructuredFinder (indexed trie walker) instead of ACFinder
(step-queue iteration) by default. This changes the default value of `useStructuredMatching`
from `false` to `true` in `GenericMachine.Builder`.

## Why

ACFinder exhibits O(N²) step queue growth when a JSON event contains a large array at a path
matching a multi-field rule. StructuredFinder indexes the event by field path and walks the
trie with direct lookups, providing linear-time matching.

## Changes

- Default `useStructuredMatching` to `true` in `GenericMachine.Builder`
- Add `StructuredFinder.matchRules(JsonNode)` overload so both `rulesForJSONEvent(String)` and
  `rulesForJSONEvent(JsonNode)` use StructuredFinder when enabled
- Update README and javadoc to reflect the new default
- Bump version to 2.0.0

## Validation

- 748 unit tests pass (0 failures)
- 2799 external test harness cases pass (0 wrong)
- Production shadow testing: zero mismatches between ACFinder and StructuredFinder across
  multiple regions under real traffic

## Opt-out

To use the previous ACFinder behavior:
```java
Machine machine = Machine.builder()
    .withStructuredMatching(false)
    .build();
```