### PR TITLE
Fix Machine.deleteRule isolation for shared wildcard sub-patterns (#255)

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -941,6 +941,28 @@ class ByteMachine {
         }
     }
 
+    // Like findPattern, but returns all NameStates a pattern leads to. A shared wildcard can produce one NameState per
+    // rule over the same byte transitions, and the delete path needs all of them.
+    Set<NameState> findAllPatterns(final Patterns pattern) {
+        switch (pattern.type()) {
+        case EXACT:
+        case NUMERIC_EQ:
+        case PREFIX:
+        case PREFIX_EQUALS_IGNORE_CASE:
+        case SUFFIX:
+        case SUFFIX_EQUALS_IGNORE_CASE:
+        case EQUALS_IGNORE_CASE:
+        case WILDCARD:
+            assert pattern instanceof ValuePatterns;
+            return findAllMatchPattern(getParser().parse(pattern.type(), ((ValuePatterns) pattern).pattern()), pattern);
+        case EXISTS:
+            return findAllMatchPattern(getParser().parse(pattern.type(), Patterns.EXISTS_BYTE_STRING), pattern);
+        default:
+            NameState nameState = findPattern(pattern);
+            return nameState == null ? Collections.emptySet() : Collections.singleton(nameState);
+        }
+    }
+
     NameState findPattern(final Patterns pattern) {
         switch (pattern.type()) {
         case NUMERIC_RANGE:
@@ -1009,6 +1031,11 @@ class ByteMachine {
     }
 
     private NameState findMatchPattern(final InputCharacter[] characters, final Patterns pattern) {
+        Set<NameState> nameStates = findAllMatchPattern(characters, pattern);
+        return nameStates.isEmpty() ? null : nameStates.iterator().next();
+    }
+
+    private Set<NameState> findAllMatchPattern(final InputCharacter[] characters, final Patterns pattern) {
         Set<SingleByteTransition> transitionsToProcess = new HashSet<>();
         transitionsToProcess.add(startState);
         ByteTransition shortcutTrans = null;
@@ -1050,15 +1077,15 @@ class ByteMachine {
             }
         }
 
-        // Check matches for all possible final transitions until we find the pattern we are looking for.
+        Set<NameState> nameStates = new HashSet<>();
         for (ByteTransition nextTrans : finalTransitionsToProcess) {
             for (ByteMatch match : nextTrans.getMatches()) {
                 if (match.getPattern().equals(pattern)) {
-                    return match.getNextNameState();
+                    nameStates.add(match.getNextNameState());
                 }
             }
         }
-        return null;
+        return nameStates;
     }
 
     // before we accept the delete range pattern, the input range pattern must exactly match Range ByteMatch

--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -957,41 +957,30 @@ class ByteMachine {
             return findAllMatchPattern(getParser().parse(pattern.type(), ((ValuePatterns) pattern).pattern()), pattern);
         case EXISTS:
             return findAllMatchPattern(getParser().parse(pattern.type(), Patterns.EXISTS_BYTE_STRING), pattern);
-        default:
-            NameState nameState = findPattern(pattern);
-            return nameState == null ? Collections.emptySet() : Collections.singleton(nameState);
-        }
-    }
-
-    NameState findPattern(final Patterns pattern) {
-        switch (pattern.type()) {
         case NUMERIC_RANGE:
             assert pattern instanceof Range;
-            return findRangePattern((Range) pattern);
+            return asSet(findRangePattern((Range) pattern));
         case ANYTHING_BUT:
             assert pattern instanceof AnythingBut;
-            return findAnythingButPattern((AnythingBut) pattern);
+            return asSet(findAnythingButPattern((AnythingBut) pattern));
         case ANYTHING_BUT_IGNORE_CASE:
         case ANYTHING_BUT_SUFFIX:
         case ANYTHING_BUT_PREFIX:
         case ANYTHING_BUT_WILDCARD:
             assert pattern instanceof AnythingButValuesSet;
-            return findAnythingButValuesSetPattern((AnythingButValuesSet) pattern);
-        case EXACT:
-        case NUMERIC_EQ:
-        case PREFIX:
-        case PREFIX_EQUALS_IGNORE_CASE:
-        case SUFFIX:
-        case SUFFIX_EQUALS_IGNORE_CASE:
-        case EQUALS_IGNORE_CASE:
-        case WILDCARD:
-            assert pattern instanceof ValuePatterns;
-            return findMatchPattern((ValuePatterns) pattern);
-        case EXISTS:
-            return findMatchPattern(getParser().parse(pattern.type(), Patterns.EXISTS_BYTE_STRING), pattern);
+            return asSet(findAnythingButValuesSetPattern((AnythingButValuesSet) pattern));
         default:
             throw new AssertionError(pattern + " is not implemented yet");
         }
+    }
+
+    NameState findPattern(final Patterns pattern) {
+        Set<NameState> nameStates = findAllPatterns(pattern);
+        return nameStates.isEmpty() ? null : nameStates.iterator().next();
+    }
+
+    private static Set<NameState> asSet(final NameState nameState) {
+        return nameState == null ? Collections.emptySet() : Collections.singleton(nameState);
     }
 
     private NameState findAnythingButPattern(AnythingBut pattern) {
@@ -1024,10 +1013,6 @@ class ByteMachine {
             return nextNameStates.iterator().next();
         }
         return null;
-    }
-
-    private NameState findMatchPattern(ValuePatterns pattern) {
-        return findMatchPattern(getParser().parse(pattern.type(), pattern.pattern()), pattern);
     }
 
     private NameState findMatchPattern(final InputCharacter[] characters, final Patterns pattern) {

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -299,83 +299,123 @@ public class GenericMachine<T> {
         }
 
         for (Patterns pattern : patterns.get(key)) {
-            NameState nextNameState = null;
+            Set<NameState> nextNameStates;
             if (isNamePattern(pattern)) {
-                if (nameMatcher != null) {
-                    nextNameState = nameMatcher.findPattern(pattern);
-                }
+                NameState nextNameState = nameMatcher == null ? null : nameMatcher.findPattern(pattern);
+                nextNameStates = nextNameState == null ? Collections.emptySet()
+                        : Collections.singleton(nextNameState);
             } else {
-                if (byteMachine != null) {
-                    nextNameState = byteMachine.findPattern(pattern);
-                }
+                nextNameStates = byteMachine == null ? Collections.emptySet()
+                        : byteMachine.findAllPatterns(pattern);
             }
 
-            if (nextNameState != null) {
-                // If this was the last step, then reaching the last state means the rule matched, and we should delete
-                // the rule from the next NameState.
-                final int nextKeyIndex = keyIndex + 1;
-                boolean isTerminal = nextKeyIndex == keys.size();
-
-                // Trim the candidate sub-rule ID set to contain only the sub-rule IDs present in the next NameState.
-                Set<SubRuleContext> nextNameStateSubRuleIds = isTerminal ?
-                        nextNameState.getTerminalSubRuleIdsForPattern(pattern) :
-                        nextNameState.getNonTerminalSubRuleIdsForPattern(pattern);
-                // If no sub-rule IDs are found for next NameState, then we have no candidates, and will return below
-                // without further recursion through the keys.
-                if (nextNameStateSubRuleIds == null) {
-                    candidateSubRuleIds.clear();
-                    // If candidate set is empty, we are at first NameState, so initialize to next NameState's sub-rule IDs.
-                    // When initializing, ensure that sub-rule IDs match the provided rule name for deletion.
-                } else if (candidateSubRuleIds.isEmpty()) {
-                    for (SubRuleContext nextNameStateSubRuleId : nextNameStateSubRuleIds) {
-                        if (Objects.equals(ruleName,
-                                nextNameStateSubRuleId.getRuleName())) {
-                            candidateSubRuleIds.add(nextNameStateSubRuleId);
-                        }
-                    }
-                    // Have already initialized candidate set. Just retain the candidates present in the next NameState.
-                } else {
-                    candidateSubRuleIds.retainAll(nextNameStateSubRuleIds);
+            if (nextNameStates.size() <= 1) {
+                NameState nextNameState = nextNameStates.isEmpty() ? null : nextNameStates.iterator().next();
+                if (nextNameState != null && deleteStepForNameState(state, key, keyIndex, keys, patterns, ruleName,
+                        deletedKeys, candidateSubRuleIds, pattern, nextNameState, deletedSubRuleIds, nextNameStates)) {
+                    return deletedSubRuleIds;
                 }
+            } else {
+                Set<SubRuleContext> survivingCandidates = new HashSet<>();
+                for (NameState nextNameState : nextNameStates) {
+                    Set<SubRuleContext> incoming = new HashSet<>(candidateSubRuleIds);
+                    deleteStepForNameState(state, key, keyIndex, keys, patterns, ruleName,
+                            deletedKeys, incoming, pattern, nextNameState, deletedSubRuleIds, nextNameStates);
+                    survivingCandidates.addAll(incoming);
+                }
+                candidateSubRuleIds.clear();
+                candidateSubRuleIds.addAll(survivingCandidates);
+            }
+        }
 
-                if (isTerminal) {
-                    for (SubRuleContext candidateSubRuleId : candidateSubRuleIds) {
-                        if (nextNameState.deleteSubRule(
-                                candidateSubRuleId.getRuleName(), candidateSubRuleId,
-                                pattern, true)) {
-                            deletedSubRuleIds.add(candidateSubRuleId);
-                            // Only delete the pattern if the pattern does not transition to the next NameState.
-                            if (!doesNameStateContainPattern(nextNameState, pattern) &&
-                                    deletePattern(state, key, pattern)) {
-                                deletedKeys.add(key);
-                                state.removeNextNameState(key);
-                            }
-                        }
-                    }
-                } else {
-                    if (candidateSubRuleIds.isEmpty()) {
-                        return deletedSubRuleIds;
-                    }
-                    deletedSubRuleIds.addAll(deleteStep(nextNameState, keys, nextKeyIndex, patterns, ruleName,
-                            deletedKeys, new HashSet<>(candidateSubRuleIds)));
+        return deletedSubRuleIds;
+    }
 
-                    for (SubRuleContext deletedSubRuleId : deletedSubRuleIds) {
-                        nextNameState.deleteSubRule(deletedSubRuleId.getRuleName(),
-                                deletedSubRuleId, pattern, false);
-                    }
+    // Deletes a single pattern via a single NameState. The teardown guard considers all NameStates the pattern can
+    // lead to (nextNameStates), so shared wildcard transitions survive while any other NameState still uses them.
+    private boolean deleteStepForNameState(final NameState state,
+                                           final String key,
+                                           final int keyIndex,
+                                           final List<String> keys,
+                                           final Map<String, List<Patterns>> patterns,
+                                           final T ruleName,
+                                           final List<String> deletedKeys,
+                                           final Set<SubRuleContext> candidateSubRuleIds,
+                                           final Patterns pattern,
+                                           final NameState nextNameState,
+                                           final Set<SubRuleContext> deletedSubRuleIds,
+                                           final Set<NameState> nextNameStates) {
+        // If this was the last step, then reaching the last state means the rule matched, and we should delete
+        // the rule from the next NameState.
+        final int nextKeyIndex = keyIndex + 1;
+        boolean isTerminal = nextKeyIndex == keys.size();
 
-                    // Unwinding the key recursion, so we aren't on a rule match. Only delete the pattern if the pattern
-                    // does not transition to the next NameState.
-                    if (!doesNameStateContainPattern(nextNameState, pattern) && deletePattern(state, key, pattern)) {
+        // Trim the candidate sub-rule ID set to contain only the sub-rule IDs present in the next NameState.
+        Set<SubRuleContext> nextNameStateSubRuleIds = isTerminal ?
+                nextNameState.getTerminalSubRuleIdsForPattern(pattern) :
+                nextNameState.getNonTerminalSubRuleIdsForPattern(pattern);
+        // If no sub-rule IDs are found for next NameState, then we have no candidates, and will return below
+        // without further recursion through the keys.
+        if (nextNameStateSubRuleIds == null) {
+            candidateSubRuleIds.clear();
+            // If candidate set is empty, we are at first NameState, so initialize to next NameState's sub-rule IDs.
+            // When initializing, ensure that sub-rule IDs match the provided rule name for deletion.
+        } else if (candidateSubRuleIds.isEmpty()) {
+            for (SubRuleContext nextNameStateSubRuleId : nextNameStateSubRuleIds) {
+                if (Objects.equals(ruleName,
+                        nextNameStateSubRuleId.getRuleName())) {
+                    candidateSubRuleIds.add(nextNameStateSubRuleId);
+                }
+            }
+            // Have already initialized candidate set. Just retain the candidates present in the next NameState.
+        } else {
+            candidateSubRuleIds.retainAll(nextNameStateSubRuleIds);
+        }
+
+        if (isTerminal) {
+            for (SubRuleContext candidateSubRuleId : candidateSubRuleIds) {
+                if (nextNameState.deleteSubRule(
+                        candidateSubRuleId.getRuleName(), candidateSubRuleId,
+                        pattern, true)) {
+                    deletedSubRuleIds.add(candidateSubRuleId);
+                    // Only delete the pattern if no NameState the pattern leads to still references it.
+                    if (noNameStateContainsPattern(nextNameStates, pattern) &&
+                            deletePattern(state, key, pattern)) {
                         deletedKeys.add(key);
                         state.removeNextNameState(key);
                     }
                 }
             }
+        } else {
+            if (candidateSubRuleIds.isEmpty()) {
+                return true;
+            }
+            deletedSubRuleIds.addAll(deleteStep(nextNameState, keys, nextKeyIndex, patterns, ruleName,
+                    deletedKeys, new HashSet<>(candidateSubRuleIds)));
 
+            for (SubRuleContext deletedSubRuleId : deletedSubRuleIds) {
+                nextNameState.deleteSubRule(deletedSubRuleId.getRuleName(),
+                        deletedSubRuleId, pattern, false);
+            }
+
+            // Unwinding the key recursion, so we aren't on a rule match. Only delete the pattern if no NameState the
+            // pattern leads to still references it.
+            if (noNameStateContainsPattern(nextNameStates, pattern) && deletePattern(state, key, pattern)) {
+                deletedKeys.add(key);
+                state.removeNextNameState(key);
+            }
         }
 
-        return deletedSubRuleIds;
+        return false;
+    }
+
+    private boolean noNameStateContainsPattern(final Set<NameState> nameStates, final Patterns pattern) {
+        for (NameState nameState : nameStates) {
+            if (doesNameStateContainPattern(nameState, pattern)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean doesNameStateContainPattern(final NameState nameState, final Patterns pattern) {

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -287,6 +287,265 @@ public class MachineTest {
     }
 
     @Test
+    public void testDeletingOneOfTwoIdenticalWildcardRulesLeavesTheOther() throws Exception {
+        // Two distinct rules share the exact same wildcard pattern with a leading wildcard.
+        // Deleting one rule must not delete the other. This exercises the shared self-loop
+        // structure that a leading wildcard creates in the ByteMachine.
+        Machine machine = new Machine();
+        String rule = "{ \"a\" : [ { \"wildcard\": \"*c\" } ] }";
+
+        machine.addRule("r1", rule);
+        machine.addRule("r2", rule);
+
+        assertEquals(new HashSet<>(Arrays.asList("r1", "r2")),
+                new HashSet<>(machine.rulesForJSONEvent("{\"a\" : \"xc\"}")));
+
+        machine.deleteRule("r1", rule);
+
+        // r2 must still match after r1 is deleted.
+        assertEquals(Collections.singletonList("r2"), machine.rulesForJSONEvent("{\"a\" : \"xc\"}"));
+
+        machine.deleteRule("r2", rule);
+        assertTrue(machine.rulesForJSONEvent("{\"a\" : \"xc\"}").isEmpty());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
+    public void testDeleteRuleWithSharedWildcardClauseDifferentShapes() throws Exception {
+        // Case 1: two different-shaped rules that share an identical wildcard clause on field "x".
+        // Deleting one must never strand the other. Run many fresh machines because the defect is
+        // nondeterministic (~50% per trial) due to iteration-order-dependent shared-transition teardown.
+        String A = "{\"x\":[{\"wildcard\":\"*bar*\"}],\"y\":[\"exact1\"]}";
+        String B = "{\"x\":[{\"wildcard\":\"*bar*\"}],\"z\":[\"exact2\"]}";
+        String event = "{\"x\":\"a-bar-b\",\"z\":\"exact2\"}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", B);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i + ": surviving rule 1 was stranded",
+                    Collections.singletonList("1"), m.rulesForJSONEvent(event));
+        }
+    }
+
+    @Test
+    public void testDeleteRuleWithSharedWildcardClauseIdenticalShapes() throws Exception {
+        // Case 2: two identical-shape rules (same JSON, different names) sharing a wildcard clause.
+        // Deleting one must leave exactly the other; never strand it and never ghost the deleted rule.
+        String A = "{\"x\":[{\"wildcard\":\"*bar*\"}],\"y\":[\"exact1\"]}";
+        String event = "{\"x\":\"a-bar-b\",\"y\":\"exact1\"}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", A);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i + ": expected only surviving rule 1",
+                    Collections.singletonList("1"), m.rulesForJSONEvent(event));
+        }
+    }
+
+    @Test
+    public void testDeleteMixedOperatorShapeWithSharedWildcard() throws Exception {
+        // Case 3: a wildcard clause mixed with anything-but, numeric, exists, prefix and exact matches.
+        // Mixed operators build a different trie than a lone wildcard, so this guards the multi-operator shape.
+        // Deleting one must never strand the other. Run many fresh machines because the defect is
+        // nondeterministic (~50% per trial) due to iteration-order-dependent shared-transition teardown.
+        String A = "{\"source\":[\"app.orders\"]," +
+                "\"detail.createdAt\":[{\"exists\":true}]," +
+                "\"detail.tier\":[{\"anything-but\":[\"gold\",\"silver\"]},{\"exists\":false}]," +
+                "\"detail.code\":[{\"prefix\":\"ev_\"}]," +
+                "\"detail.count\":[{\"numeric\":[\"<=\",2]}]," +
+                "\"detail.path\":[{\"wildcard\":\"*checkout*\"}]}";
+        // Different-shaped sibling: SAME wildcard on detail.path, differs by one extra field.
+        String B = "{\"source\":[\"app.orders\"]," +
+                "\"detail.createdAt\":[{\"exists\":true}]," +
+                "\"detail.tier\":[{\"anything-but\":[\"gold\",\"silver\"]},{\"exists\":false}]," +
+                "\"detail.code\":[{\"prefix\":\"ev_\"}]," +
+                "\"detail.count\":[{\"numeric\":[\"<=\",2]}]," +
+                "\"detail.extra\":[\"sibling_only\"]," +
+                "\"detail.path\":[{\"wildcard\":\"*checkout*\"}]}";
+        String eventA = "{\"source\":\"app.orders\",\"detail\":{\"createdAt\":\"2026-01-01\"," +
+                "\"tier\":\"bronze\",\"code\":\"ev_x\",\"count\":1,\"path\":\"/a/checkout/b\"}}";
+        String eventB = "{\"source\":\"app.orders\",\"detail\":{\"createdAt\":\"2026-01-01\"," +
+                "\"tier\":\"bronze\",\"code\":\"ev_x\",\"count\":1,\"extra\":\"sibling_only\"," +
+                "\"path\":\"/a/checkout/b\"}}";
+
+        // Different shapes sharing the wildcard clause: deleting one must never strand the other.
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", B);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i + ": surviving rule 1 was stranded",
+                    Collections.singletonList("1"), m.rulesForJSONEvent(eventB));
+        }
+
+        // Identical shapes (same JSON, different names): delete one and leave exactly the other.
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", A);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i + ": expected only surviving rule 1",
+                    Collections.singletonList("1"), m.rulesForJSONEvent(eventA));
+        }
+    }
+
+    @Test
+    public void testDeleteRuleWithDifferentWildcardsStaysSafe() throws Exception {
+        // Boundary: different wildcard patterns on the same field must remain safe after delete.
+        String A = "{\"x\":[{\"wildcard\":\"*aaa*\"}],\"y\":[\"exact1\"]}";
+        String B = "{\"x\":[{\"wildcard\":\"*bbb*\"}],\"z\":[\"exact2\"]}";
+        String event = "{\"x\":\"z-bbb-z\",\"z\":\"exact2\"}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", B);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i, Collections.singletonList("1"),
+                    m.rulesForJSONEvent(event));
+        }
+    }
+
+    @Test
+    public void testDeleteRuleWithSharedPrefixClauseStaysSafe() throws Exception {
+        // Boundary: a shared NON-wildcard clause (prefix) across different-shaped rules must remain safe after delete.
+        String A = "{\"x\":[{\"prefix\":\"et_\"}],\"y\":[\"exact1\"]}";
+        String B = "{\"x\":[{\"prefix\":\"et_\"}],\"z\":[\"exact2\"]}";
+        String event = "{\"x\":\"et_abc\",\"z\":\"exact2\"}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", B);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i, Collections.singletonList("1"),
+                    m.rulesForJSONEvent(event));
+        }
+    }
+
+    @Test
+    public void testDeleteRuleSharingNothingStaysSafe() throws Exception {
+        // Boundary: deleting a rule that shares nothing with others must stay correct.
+        String A = "{\"x\":[{\"wildcard\":\"*bar*\"}]}";
+        String B = "{\"p\":[{\"wildcard\":\"*qux*\"}]}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", B);
+            m.deleteRule("0", A);
+            assertTrue("iteration " + i, m.rulesForJSONEvent("{\"x\":\"a-bar-b\"}").isEmpty());
+            assertEquals("iteration " + i, Collections.singletonList("1"),
+                    m.rulesForJSONEvent("{\"p\":\"a-qux-b\"}"));
+        }
+    }
+
+    @Test
+    public void testDeleteSharedWildcardThenReAddRecovers() throws Exception {
+        // Deleting one of two rules sharing a wildcard must leave the survivor matching, and re-adding the deleted
+        // rule must restore it - for any add/delete order.
+        String A = "{\"x\":[{\"wildcard\":\"*bar*\"}],\"y\":[\"exact1\"]}";
+        String event = "{\"x\":\"a-bar-b\",\"y\":\"exact1\"}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine m = Machine.builder().build();
+            m.addRule("0", A);
+            m.addRule("1", A);
+            m.deleteRule("0", A);
+            assertEquals("iteration " + i, Collections.singletonList("1"), m.rulesForJSONEvent(event));
+            m.addRule("0", A);
+            assertEquals("iteration " + i, new HashSet<>(Arrays.asList("0", "1")),
+                    new HashSet<>(m.rulesForJSONEvent(event)));
+            m.deleteRule("0", A);
+            m.deleteRule("1", A);
+            assertTrue("iteration " + i, m.rulesForJSONEvent(event).isEmpty());
+            assertTrue("iteration " + i, m.isEmpty());
+        }
+    }
+
+    // Reproductions from GitHub issue #255: deleteRule silently ghosts or corrupts sibling rules that share a wildcard
+    // clause. Each runs over many fresh machines because the failure is non-deterministic (~50% per trial).
+
+    @Test
+    public void testIssue255WildcardDeleteRuleGhost() throws Exception {
+        String ruleJson = "{\"name\":[\"test\"],\"properties.foo\":[{\"wildcard\":\"*bar*\"}]}";
+        String event = "{\"name\":\"test\",\"properties\":{\"foo\":\"foobar\"}}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine machine = Machine.builder().build();
+            machine.addRule("rule1", ruleJson);
+            machine.addRule("rule2", ruleJson);
+            assertEquals("iteration " + i, 2, machine.rulesForJSONEvent(event).size());
+
+            machine.deleteRule("rule1", ruleJson);
+
+            List<String> after = machine.rulesForJSONEvent(event);
+            assertFalse("iteration " + i + ": rule1 should be deleted", after.contains("rule1"));
+            assertTrue("iteration " + i + ": rule2 should still match", after.contains("rule2"));
+        }
+    }
+
+    @Test
+    public void testIssue255WildcardPlusNumericDeleteRuleCorruption() throws Exception {
+        String ruleJson = "{\"name\":[\"test\"]," +
+                "\"properties.foo\":[{\"wildcard\":\"*bar*\"}]," +
+                "\"properties.count\":[{\"numeric\":[\"<=\",2]}]}";
+        String event = "{\"name\":\"test\",\"properties\":{\"foo\":\"foobar\",\"count\":1}}";
+
+        for (int i = 0; i < 200; i++) {
+            Machine machine = Machine.builder().build();
+            machine.addRule("rule1", ruleJson);
+            machine.addRule("rule2", ruleJson);
+            assertEquals("iteration " + i, 2, machine.rulesForJSONEvent(event).size());
+
+            machine.deleteRule("rule1", ruleJson);
+
+            List<String> after = machine.rulesForJSONEvent(event);
+            assertTrue("iteration " + i + ": rule2 should still match", after.contains("rule2"));
+            assertFalse("iteration " + i + ": rule1 should be deleted", after.contains("rule1"));
+        }
+    }
+
+    @Test
+    public void testIssue255WildcardDeleteRuleOrderIndependent() throws Exception {
+        String ruleJson = "{\"type\":[\"track\"],\"name\":[\"event\"]," +
+                "\"properties.foo\":[{\"wildcard\":\"*bar*\"}]," +
+                "\"properties.color\":[{\"anything-but\":[\"purple\",\"pink\"]},{\"exists\":false}]," +
+                "\"properties.count\":[{\"numeric\":[\"<=\",2]}]," +
+                "\"properties.active\":[\"true\"]," +
+                "\"properties.dob\":[{\"exists\":true}]}";
+        String event = "{\"type\":\"track\",\"name\":\"event\"," +
+                "\"properties\":{\"foo\":\"foobar\",\"color\":\"blue\",\"count\":1,\"active\":\"true\"," +
+                "\"dob\":\"1990-01-01\"}}";
+
+        for (int i = 0; i < 200; i++) {
+            // Order A: rule1 added first.
+            Machine machineA = Machine.builder().build();
+            machineA.addRule("rule1", ruleJson);
+            machineA.addRule("rule2", ruleJson);
+            machineA.deleteRule("rule1", ruleJson);
+            List<String> resultA = machineA.rulesForJSONEvent(event);
+
+            // Order B: rule2 added first.
+            Machine machineB = Machine.builder().build();
+            machineB.addRule("rule2", ruleJson);
+            machineB.addRule("rule1", ruleJson);
+            machineB.deleteRule("rule1", ruleJson);
+            List<String> resultB = machineB.rulesForJSONEvent(event);
+
+            assertEquals("iteration " + i + ": order A should return only rule2",
+                    Collections.singletonList("rule2"), resultA);
+            assertEquals("iteration " + i + ": order B should return only rule2",
+                    Collections.singletonList("rule2"), resultB);
+            assertEquals("iteration " + i + ": both orders must produce the same result", resultA, resultB);
+        }
+    }
+
+    @Test
     public void testCityLotsProblemLines() throws Exception {
 
         String[] e = {


### PR DESCRIPTION
### Issue #, if available:
#255

### Description of changes:

We found a bug where cloning a rule (same rule, but different name) and then deleting one of them would cause a couple of non-deterministic behaviors but only when one of the rules had a wildcard.

The two possibilities were:
- a **ghost rule**: a rule that would keep matching even though it was supposed to be deleted, or
- an **orphaned rule*: a rule that would stop matching even though it was still in the Trie and never got deleted.

We reported this in #255, and this PR is one option to fix it.

**What we narrowed it down to:**

When two rules share a wildcard clause (like `*bar*`), Ruler shares the trie transitions between them, but each rule still gets its own match marker at the end of that shared path (its own `ByteMatch` to `NameState`).

The delete path didn't handle that:

1. `ByteMachine.findPattern(...)` only returned **one** `NameState` for the pattern, and which one depended on `HashSet` iteration order (that's the non-determinism). Half the time delete grabbed the *surviving* rule's NameState, didn't find the rule we were deleting, and did nothing so a **ghost**.
2. When it did grab the right NameState, it emptied it and then tore down the shared transitions but the teardown guard (`doesNameStateContainPattern`) only checked that one NameState, never the sibling still using the shared path so an **orphan**.

**The fix (delete/teardown path only, no changes to `addRule` or matching):**

- Added `ByteMachine.findAllPatterns` which returns all NameStates a pattern leads to. Delete now removes the sub-rule from the NameState that actually holds the rule being deleted → kills the ghost.
- Teardown now only removes the shared byte transitions once no NameState references the pattern anymore (`noNameStateContainsPattern`) → kills the orphan.
- The common single-NameState case (exact, prefix, numeric, `$or`, etc.) runs the original logic unchanged (`deleteStepForNameState`), so nothing else moves.

**Testing:**
- Added repro tests for both ghost and orphan, plus the 3 exact reproductions from #255. They're non-deterministic (~50%/trial), so each runs over 200 fresh machines and requires a 100% pass rate — they fail on `main` and pass with the fix.
- Added boundary tests to keep already-safe cases safe: different wildcards on the same field, shared `prefix`, and rules sharing nothing.
- Full suite green (767 tests).

#### Benchmark / Performance (for source code changes):

Perf note (grain of salt): I ran this on my laptop, not a clean/isolated CI box, so please treat these as directional rather than authoritative. This change only touches the add/delete path, the matching path (`rulesForJSONEvent`) is untouched, so I wouldn't expect any real effect on match throughput.

Ran on: Apple M4 Pro (8P + 4E), 48 GB RAM, macOS 26.4.1, OpenJDK 26.0.1. `StableBenchmarks`, warmup=10 / measure=30, `origin/main` vs `fix/wildcard-delete-isolation`. Metric is events/sec, higher is faster.

| rule_type | before eps (±stddev) | after eps (±stddev) | delta % |
|---|--:|--:|--:|
| EXACT | 635,982 (±0.65%) | 616,302 (±0.68%) | -3.09% |
| WILDCARD | 491,418 (±1.61%) | 479,476 (±1.36%) | -2.43% |
| PREFIX | 616,881 (±2.48%) | 630,169 (±0.60%) | +2.15% |
| PREFIX_EQUALS_IGNORE_CASE | 615,477 (±2.70%) | 631,194 (±0.61%) | +2.55% |
| SUFFIX | 611,150 (±1.93%) | 618,821 (±0.67%) | +1.26% |
| SUFFIX_EQUALS_IGNORE_CASE | 606,296 (±1.53%) | 618,413 (±0.82%) | +2.00% |
| EQUALS_IGNORE_CASE | 550,053 (±2.40%) | 566,541 (±0.54%) | +3.00% |
| NUMERIC | 398,969 (±1.27%) | 408,582 (±0.35%) | +2.41% |
| ANYTHING_BUT | 365,110 (±1.74%) | 360,499 (±1.61%) | -1.26% |
| ANYTHING_BUT_IGNORE_CASE | 359,776 (±1.17%) | 355,480 (±1.32%) | -1.19% |
| ANYTHING_BUT_PREFIX | 374,925 (±1.29%) | 374,804 (±1.18%) | -0.03% |
| ANYTHING_BUT_SUFFIX | 365,927 (±1.93%) | 364,181 (±0.58%) | -0.48% |
| ANYTHING_BUT_WILDCARD | 391,149 (±1.02%) | 409,018 (±0.66%) | +4.57% |
| COMPLEX_ARRAYS | 89,871 (±1.37%) | 90,018 (±1.21%) | +0.16% |


> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.