### PR TITLE
Fix order-dependent deletion for superset value lists (#260)

### DIFF
--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -251,6 +251,8 @@ public class GenericMachine<T> {
      *  The eventual result will be same as one time deleteRule call with r1 {a, [1,2]}.
      *  So, caller is expected to save its rule expression if want to entirely remove the rule unless deliberately
      *  want to remove partial rule from rule name.
+     *  Values within a key are order-independent; values that reach no rule are skipped while later values are
+     *  still considered.
      *
      * @param name ARN of the rule
      * @param namevals names and values which make up the rule
@@ -309,22 +311,13 @@ public class GenericMachine<T> {
                         : byteMachine.findAllPatterns(pattern);
             }
 
-            if (nextNameStates.size() <= 1) {
-                NameState nextNameState = nextNameStates.isEmpty() ? null : nextNameStates.iterator().next();
-                if (nextNameState != null && deleteStepForNameState(state, key, keyIndex, keys, patterns, ruleName,
-                        deletedKeys, candidateSubRuleIds, pattern, nextNameState, deletedSubRuleIds, nextNameStates)) {
-                    return deletedSubRuleIds;
-                }
-            } else {
-                Set<SubRuleContext> survivingCandidates = new HashSet<>();
-                for (NameState nextNameState : nextNameStates) {
-                    Set<SubRuleContext> incoming = new HashSet<>(candidateSubRuleIds);
-                    deleteStepForNameState(state, key, keyIndex, keys, patterns, ruleName,
-                            deletedKeys, incoming, pattern, nextNameState, deletedSubRuleIds, nextNameStates);
-                    survivingCandidates.addAll(incoming);
-                }
-                candidateSubRuleIds.clear();
-                candidateSubRuleIds.addAll(survivingCandidates);
+            // Values within a key have OR semantics. Each value/NameState branch starts with the same candidates
+            // inherited from the preceding keys.
+            for (NameState nextNameState : nextNameStates) {
+                final Set<SubRuleContext> branchCandidateSubRuleIds = new HashSet<>(candidateSubRuleIds);
+                deleteStepForNameState(state, key, keyIndex, keys, patterns, ruleName,
+                        deletedKeys, branchCandidateSubRuleIds, pattern, nextNameState, deletedSubRuleIds,
+                        nextNameStates);
             }
         }
 
@@ -333,18 +326,18 @@ public class GenericMachine<T> {
 
     // Deletes a single pattern via a single NameState. The teardown guard considers all NameStates the pattern can
     // lead to (nextNameStates), so shared wildcard transitions survive while any other NameState still uses them.
-    private boolean deleteStepForNameState(final NameState state,
-                                           final String key,
-                                           final int keyIndex,
-                                           final List<String> keys,
-                                           final Map<String, List<Patterns>> patterns,
-                                           final T ruleName,
-                                           final List<String> deletedKeys,
-                                           final Set<SubRuleContext> candidateSubRuleIds,
-                                           final Patterns pattern,
-                                           final NameState nextNameState,
-                                           final Set<SubRuleContext> deletedSubRuleIds,
-                                           final Set<NameState> nextNameStates) {
+    private void deleteStepForNameState(final NameState state,
+                                        final String key,
+                                        final int keyIndex,
+                                        final List<String> keys,
+                                        final Map<String, List<Patterns>> patterns,
+                                        final T ruleName,
+                                        final List<String> deletedKeys,
+                                        final Set<SubRuleContext> candidateSubRuleIds,
+                                        final Patterns pattern,
+                                        final NameState nextNameState,
+                                        final Set<SubRuleContext> deletedSubRuleIds,
+                                        final Set<NameState> nextNameStates) {
         // If this was the last step, then reaching the last state means the rule matched, and we should delete
         // the rule from the next NameState.
         final int nextKeyIndex = keyIndex + 1;
@@ -354,13 +347,12 @@ public class GenericMachine<T> {
         Set<SubRuleContext> nextNameStateSubRuleIds = isTerminal ?
                 nextNameState.getTerminalSubRuleIdsForPattern(pattern) :
                 nextNameState.getNonTerminalSubRuleIdsForPattern(pattern);
-        // If no sub-rule IDs are found for next NameState, then we have no candidates, and will return below
-        // without further recursion through the keys.
         if (nextNameStateSubRuleIds == null) {
-            candidateSubRuleIds.clear();
-            // If candidate set is empty, we are at first NameState, so initialize to next NameState's sub-rule IDs.
-            // When initializing, ensure that sub-rule IDs match the provided rule name for deletion.
-        } else if (candidateSubRuleIds.isEmpty()) {
+            return;
+        }
+        // Only the first key initializes candidates. An empty set at a later key means the preceding key
+        // constraints found no matching sub-rule and must not be reset.
+        if (keyIndex == 0) {
             for (SubRuleContext nextNameStateSubRuleId : nextNameStateSubRuleIds) {
                 if (Objects.equals(ruleName,
                         nextNameStateSubRuleId.getRuleName())) {
@@ -370,6 +362,10 @@ public class GenericMachine<T> {
             // Have already initialized candidate set. Just retain the candidates present in the next NameState.
         } else {
             candidateSubRuleIds.retainAll(nextNameStateSubRuleIds);
+        }
+
+        if (candidateSubRuleIds.isEmpty()) {
+            return;
         }
 
         if (isTerminal) {
@@ -387,11 +383,8 @@ public class GenericMachine<T> {
                 }
             }
         } else {
-            if (candidateSubRuleIds.isEmpty()) {
-                return true;
-            }
             deletedSubRuleIds.addAll(deleteStep(nextNameState, keys, nextKeyIndex, patterns, ruleName,
-                    deletedKeys, new HashSet<>(candidateSubRuleIds)));
+                    deletedKeys, candidateSubRuleIds));
 
             for (SubRuleContext deletedSubRuleId : deletedSubRuleIds) {
                 nextNameState.deleteSubRule(deletedSubRuleId.getRuleName(),
@@ -405,8 +398,6 @@ public class GenericMachine<T> {
                 state.removeNextNameState(key);
             }
         }
-
-        return false;
     }
 
     private boolean noNameStateContainsPattern(final Set<NameState> nameStates, final Patterns pattern) {

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -548,6 +548,116 @@ public class MachineTest {
     }
 
     @Test
+    public void testIssue260SupersetExactDeleteIsOrderIndependent() throws Exception {
+        for (String deleteRule : asList(
+                "{\"x\":[\"a\",\"b\"],\"y\":[\"e\"]}",
+                "{\"x\":[\"b\",\"a\"],\"y\":[\"e\"]}")) {
+            Machine machine = Machine.builder().build();
+            machine.addRule("r1", "{\"x\":[\"b\"],\"y\":[\"e\"]}");
+            machine.addRule("r3", "{\"x\":[\"a\"],\"y\":[\"e\"]}");
+
+            machine.deleteRule("r1", deleteRule);
+
+            assertFalse(machine.rulesForJSONEvent("{\"x\":\"b\",\"y\":\"e\"}").contains("r1"));
+            assertEquals(Collections.singletonList("r3"),
+                    machine.rulesForJSONEvent("{\"x\":\"a\",\"y\":\"e\"}"));
+        }
+    }
+
+    @Test
+    public void testIssue260SupersetWildcardDeleteIsOrderIndependent() throws Exception {
+        for (String deleteRule : asList(
+                "{\"x\":[{\"wildcard\":\"*foo*\"},{\"wildcard\":\"*bar*\"}],\"y\":[\"e\"]}",
+                "{\"x\":[{\"wildcard\":\"*bar*\"},{\"wildcard\":\"*foo*\"}],\"y\":[\"e\"]}")) {
+            Machine machine = Machine.builder().build();
+            String barRule = "{\"x\":[{\"wildcard\":\"*bar*\"}],\"y\":[\"e\"]}";
+            String fooRule = "{\"x\":[{\"wildcard\":\"*foo*\"}],\"y\":[\"e\"]}";
+            machine.addRule("r1", barRule);
+            machine.addRule("r2", barRule);
+            machine.addRule("r3", fooRule);
+
+            machine.deleteRule("r1", deleteRule);
+
+            assertEquals(Collections.singleton("r2"),
+                    new HashSet<>(machine.rulesForJSONEvent("{\"x\":\"a-bar-b\",\"y\":\"e\"}")));
+            assertEquals(Collections.singletonList("r3"),
+                    machine.rulesForJSONEvent("{\"x\":\"a-foo-b\",\"y\":\"e\"}"));
+        }
+    }
+
+    @Test
+    public void testIssue260SupersetDeletePreservesPriorKeyCandidates() throws Exception {
+        // Reuse funnels later-key values into one shared NameState, making foreign patterns findable there.
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        String firstRule = "{\"a\":[\"one\"],\"b\":[\"left\"],\"c\":[\"left-end\"]}";
+        String secondRule = "{\"a\":[\"two\"],\"b\":[\"right\"],\"c\":[\"right-end\"]}";
+        String otherRule = "{\"a\":[\"one\"],\"b\":[\"missing\"],\"c\":[\"other-end\"]}";
+        machine.addRule("r1", firstRule);
+        machine.addRule("r1", secondRule);
+        machine.addRule("other", otherRule);
+
+        machine.deleteRule("r1",
+                "{\"a\":[\"one\"],\"b\":[\"missing\",\"right\"],\"c\":[\"right-end\"]}");
+
+        assertTrue(machine.rulesForJSONEvent(
+                "{\"a\":\"one\",\"b\":\"left\",\"c\":\"left-end\"}").contains("r1"));
+        assertTrue(machine.rulesForJSONEvent(
+                "{\"a\":\"two\",\"b\":\"right\",\"c\":\"right-end\"}").contains("r1"));
+        assertTrue(machine.rulesForJSONEvent(
+                "{\"a\":\"one\",\"b\":\"missing\",\"c\":\"other-end\"}").contains("other"));
+    }
+
+    @Test
+    public void testIssue260TerminalSupersetDoesNotResetPriorKeyCandidates() throws Exception {
+        // Reuse funnels later-key values into one shared NameState, making foreign patterns findable there.
+        Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+        machine.addRule("r1", "{\"a\":[\"one\"],\"b\":[\"left\"]}");
+        machine.addRule("r1", "{\"a\":[\"two\"],\"b\":[\"right\"]}");
+        machine.addRule("other", "{\"a\":[\"one\"],\"b\":[\"missing\"]}");
+
+        machine.deleteRule("r1", "{\"a\":[\"one\"],\"b\":[\"missing\",\"right\"]}");
+
+        assertTrue(machine.rulesForJSONEvent("{\"a\":\"one\",\"b\":\"left\"}").contains("r1"));
+        assertTrue(machine.rulesForJSONEvent("{\"a\":\"two\",\"b\":\"right\"}").contains("r1"));
+        assertTrue(machine.rulesForJSONEvent("{\"a\":\"one\",\"b\":\"missing\"}").contains("other"));
+    }
+
+    @Test
+    public void testIssue260LaterKeySupersetDeleteContinuesPastEmptyBranch() throws Exception {
+        for (String deleteRule : asList(
+                "{\"a\":[\"one\"],\"b\":[\"missing\",\"right\"]}",
+                "{\"a\":[\"one\"],\"b\":[\"right\",\"missing\"]}")) {
+            // Reuse funnels later-key values into one NameState, exposing the branch-sharing edge case.
+            Machine machine = Machine.builder().withAdditionalNameStateReuse(true).build();
+            String targetRule = "{\"a\":[\"one\"],\"b\":[\"right\"]}";
+            String otherRule = "{\"a\":[\"one\"],\"b\":[\"missing\"]}";
+            machine.addRule("r1", targetRule);
+            machine.addRule("other", otherRule);
+
+            machine.deleteRule("r1", deleteRule);
+
+            assertTrue(machine.rulesForJSONEvent("{\"a\":\"one\",\"b\":\"right\"}").isEmpty());
+            assertEquals(Collections.singletonList("other"),
+                    machine.rulesForJSONEvent("{\"a\":\"one\",\"b\":\"missing\"}"));
+            machine.deleteRule("other", otherRule);
+            assertTrue(machine.isEmpty());
+        }
+    }
+
+    @Test
+    public void testIssue260SupersetDeletesIndependentSameNameSubRules() throws Exception {
+        Machine machine = Machine.builder().build();
+        machine.addRule("r1", "{\"x\":[\"a\"]}");
+        machine.addRule("r1", "{\"x\":[\"b\"]}");
+
+        machine.deleteRule("r1", "{\"x\":[\"a\",\"b\"]}");
+
+        assertTrue(machine.rulesForJSONEvent("{\"x\":\"a\"}").isEmpty());
+        assertTrue(machine.rulesForJSONEvent("{\"x\":\"b\"}").isEmpty());
+        assertTrue(machine.isEmpty());
+    }
+
+    @Test
     public void testCityLotsProblemLines() throws Exception {
 
         String[] e = {


### PR DESCRIPTION
### Issue #, if available:

Closes #260

### Description of changes:

`Machine.deleteRule` could silently fail when the supplied rule contained a
superset of the stored values. Values within a field have OR semantics, but
the delete path reused a mutable candidate set across those alternatives and
also used an empty set to mean both "not initialized yet" and "no candidates
matched the preceding keys." The result depended on value order.

This change:

- tracks candidate-set initialization explicitly;
- evaluates every value/NameState alternative from the same candidates inherited
  from preceding keys;
- prevents an empty candidate set at a later key from being reinitialized; and
- limits an empty branch to that branch instead of skipping the remaining
  alternatives for the field.

The existing multi-NameState wildcard teardown guard remains unchanged.

Testing:

- Added order-independent reproductions for exact and wildcard value lists.
- Added prior-key and terminal boundary tests to prevent candidate reinitialization.
- Added coverage for deleting independent sub-rules with the same rule name.
- The five focused regressions passed in 20 consecutive runs.
- `mvn -Dtest=MachineTest test`: 91 tests passed.
- `mvn verify`: 772 tests passed; Checkstyle and SpotBugs reported no findings.

#### Benchmark / Performance (for source code changes):

Environment:

- Apple Silicon, macOS 26.5.1
- OpenJDK 21.0.12
- Maven 3.9.16

Full comparison command:

```text
./scripts/perf-compare.sh \
  337e8d99026d3f6687f783535f157be8bf4ebbb7 \
  0e0b36545d52b71be24355349a0ce7f314706db0 \
  -- -Dstyle.color=never -Druler.perf.warmup=5 -Druler.perf.measure=10
```

```text
rule_type                     before_eps     after_eps   delta_pct  verdict
---------                     ----------     ---------   ---------  -------
EXACT                             431543        428359       -0.7%  noise (±2.8%)
WILDCARD                          276394        341981      +23.7%  improvement (noise ±3.2%)
PREFIX                            433777        429462       -1.0%  noise (±2.1%)
PREFIX_EIC                        424932        429335       +1.0%  noise (±9.5%)
SUFFIX                            422192        425125       +0.7%  noise (±4.2%)
SUFFIX_EIC                        421414        422822       +0.3%  noise (±2.3%)
EQUALS_IGNORE_CASE                380035        382514       +0.7%  noise (±2.7%)
NUMERIC                           279480        281772       +0.8%  noise (±1.3%)
ANYTHING_BUT                      250883        242854       -3.2%  REGRESSION (noise ±3.0%)
ANYTHING_BUT_IGNORE_CASE          243198        245030       +0.8%  noise (±2.4%)
ANYTHING_BUT_PREFIX               254955        259433       +1.8%  noise (±2.6%)
ANYTHING_BUT_SUFFIX               254234        252456       -0.7%  noise (±2.6%)
ANYTHING_BUT_WILDCARD             231962        282701      +21.9%  improvement (noise ±1.9%)
COMPLEX_ARRAYS                     55038         54984       -0.1%  noise (±1.7%)
```

The only full-run flag was `ANYTHING_BUT`, 0.2 percentage points outside the
script's heuristic noise band. I repeated the whole `ANYTHING_BUT` family with
5 warmup and 15 measurement passes:

```text
rule_type                     before_eps     after_eps   delta_pct  verdict
---------                     ----------     ---------   ---------  -------
ANYTHING_BUT                      254288        235802       -7.3%  noise (±17.4%)
ANYTHING_BUT_IGNORE_CASE          242591        245506       +1.2%  noise (±1.9%)
ANYTHING_BUT_PREFIX               255447        258124       +1.0%  noise (±7.0%)
ANYTHING_BUT_SUFFIX               251671        251312       -0.1%  noise (±4.5%)
ANYTHING_BUT_WILDCARD             232983        234265       +0.6%  noise (±3.1%)
```

No matching-throughput regression was reproducible. This change only affects
rule deletion; the benchmark exercises event matching.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
