### PR TITLE
fix: guard forward multi-byte walker against non-InputByte continuation positions

### DIFF
--- a/src/main/software/amazon/event/ruler/ByteMachine.java
+++ b/src/main/software/amazon/event/ruler/ByteMachine.java
@@ -933,12 +933,31 @@ class ByteMachine {
         if (firstByte >= MIN_FIRST_BYTE_FOR_ONE_BYTE_CHAR && firstByte <= MAX_FIRST_BYTE_FOR_ONE_BYTE_CHAR) {
             return new String(new byte[] { firstByte } , StandardCharsets.UTF_8);
         } else if (firstByte >= MIN_FIRST_BYTE_FOR_TWO_BYTE_CHAR && firstByte <= MAX_FIRST_BYTE_FOR_TWO_BYTE_CHAR) {
+            // A continuation position can hold a non-byte InputCharacter (e.g. an
+            // InputMultiByteSet from an equals-ignore-case value). Stop before
+            // casting to InputByte, as the backward walker does.
+            if (!isByteAtIndex(characters, i + 1)) {
+                return new String(new byte[] { firstByte }, StandardCharsets.UTF_8);
+            }
             return new String(new byte[] { firstByte, InputByte.cast(characters[i + 1]).getByte() },
                     StandardCharsets.UTF_8);
         } else {
+            if (!isByteAtIndex(characters, i + 1)) {
+                return new String(new byte[] { firstByte }, StandardCharsets.UTF_8);
+            }
+            if (!isByteAtIndex(characters, i + 2)) {
+                return new String(new byte[] { firstByte, InputByte.cast(characters[i + 1]).getByte() },
+                        StandardCharsets.UTF_8);
+            }
             return new String(new byte[] { firstByte, InputByte.cast(characters[i + 1]).getByte(),
                     InputByte.cast(characters[i + 2]).getByte() }, StandardCharsets.UTF_8);
         }
+    }
+
+    // Bounds-checked byte test so a non-byte continuation position never reaches
+    // InputByte.cast() in the forward multi-byte walker.
+    private static boolean isByteAtIndex(InputCharacter[] characters, int i) {
+        return i >= 0 && i < characters.length && isByte(characters[i]);
     }
 
     // Like findPattern, but returns all NameStates a pattern leads to. A shared wildcard can produce one NameState per

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -3063,4 +3063,39 @@ public class MachineTest {
         machine.addRule("23", "{\"key1\": [\"a\", \"b\", \"c\"], \"key2\": [\"d\", \"e\", \"f\"], \"key3\": [\"g\", \"h\", \"i\"], \"key4\": [\"j\", \"k\", \"l\"], \"key5\": [\"m\", \"n\", \"o\"], \"key6\": [\"p\", \"q\", \"r\"], \"key7\": [\"s\", \"t\", \"u\"], \"key8\": [\"x\"]}");
         machine.addRule("24", "{\"key1\": [\"a\", \"b\", \"c\"], \"key2\": [\"d\", \"e\", \"f\"], \"key3\": [\"g\", \"h\", \"i\"], \"key4\": [\"j\", \"k\", \"l\"], \"key5\": [\"m\", \"n\", \"o\"], \"key6\": [\"p\", \"q\", \"r\"], \"key7\": [\"s\", \"t\", \"u\"], \"key8\": [\"v\", \"w\", \"x\"], \"key9\": [\"y\"]}");
     }
+
+    // Regression: suffix + equals-ignore-case with a multi-byte (non-ASCII) value must not throw
+    // ClassCastException (InputMultiByteSet cannot be cast to InputByte) during rule-machine build.
+    // The crash surfaces on a second such rule that reuses byte states from the first. Value = "a"+U+30C7 デ +U+00E9 é.
+    @Test
+    public void WHEN_SuffixEqualsIgnoreCaseValueHasMultiByteChar_THEN_RuleCompilesAndMatches() throws Exception {
+        Machine machine = new Machine();
+        // Sibling rule sharing the multi-byte tail seeds reusable InputMultiByteSet states on the
+        // shared multi-byte "デé" tail so adding the offender exercises canReuseNextByteState.
+        machine.addRule("sibling", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"bデé\"}}]}");
+        // Offender: before the fix this threw at extractNextJavaCharacterFromInputCharactersForForwardArrays.
+        machine.addRule("offender", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"aデé\"}}]}");
+
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzaデé\"]}").contains("offender"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzAデé\"]}").contains("offender"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"aデéx\"]}").isEmpty());
+    }
+
+
+    // A caught ClassCastException must not leave the machine wedged: two identical multi-byte rules,
+    // then delete them, then add an innocuous rule. Verifies the forward-walker fix leaves no wedge at
+    // the event-ruler level (the offending rules compile, delete cleanly, and later adds still work).
+    @Test
+    public void WHEN_MultiBytePoisonRulesAddedThenDeleted_THEN_NoStickyWedge() throws Exception {
+        Machine machine = new Machine();
+        String poison = "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"aデé\"}}]}";
+        machine.addRule("p1", poison);   // two IDENTICAL rules on one field
+        machine.addRule("p2", poison);
+        machine.deleteRule("p1", poison);
+        machine.deleteRule("p2", poison);
+        // Innocuous rule after the poison rules are gone must compile and match (no wedge).
+        machine.addRule("ok", "{\"k\": [{\"suffix\": \"ade\"}]}");
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzade\"]}").contains("ok"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzaデé\"]}").isEmpty());
+    }
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -14,7 +14,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -3097,5 +3099,109 @@ public class MachineTest {
         machine.addRule("ok", "{\"k\": [{\"suffix\": \"ade\"}]}");
         assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzade\"]}").contains("ok"));
         assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzaデé\"]}").isEmpty());
+    }
+
+    // Same defect, two-byte branch of the forward walker: a caseless TWO-byte character
+    // (© U+00A9) whose continuation position holds an InputMultiByteSet. Before the fix this
+    // threw from the two-byte cast (the line above the three-byte case in the same method).
+    @Test
+    public void WHEN_SuffixEqualsIgnoreCaseValueHasTwoByteChar_THEN_RuleCompilesAndMatches() throws Exception {
+        Machine machine = new Machine();
+        machine.addRule("sibling", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"b©é\"}}]}");
+        machine.addRule("offender", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"a©é\"}}]}");
+
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zza©é\"]}").contains("offender"));
+        // Non-ASCII case folding: É (U+00C9) must match through the InputMultiByteSet path.
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzA©É\"]}").contains("offender"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzb©é\"]}").contains("sibling"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"a©éx\"]}").isEmpty());
+    }
+
+    // Same defect, second continuation position of the three-byte branch: a caseless
+    // one-byte character ("5") sits at i+1, so the first cast succeeds and the crash
+    // (before the fix) came from the i+2 cast.
+    @Test
+    public void WHEN_SuffixEqualsIgnoreCaseHasByteThenMultiByteSetContinuation_THEN_RuleCompilesAndMatches()
+            throws Exception {
+        Machine machine = new Machine();
+        machine.addRule("sibling", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"a5デé\"}}]}");
+        machine.addRule("offender", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"b5デé\"}}]}");
+
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzb5デé\"]}").contains("offender"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzB5デÉ\"]}").contains("offender"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zza5デé\"]}").contains("sibling"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"b5デéx\"]}").isEmpty());
+    }
+
+    // A family of rules sharing the same multi-byte tail, added one at a time: every add
+    // after the first walks reusable states seeded by its predecessors, so this exercises
+    // the guard repeatedly. Each rule must match exactly its own values afterwards, and
+    // deleting part of the family must not disturb the rest.
+    @Test
+    public void WHEN_ManySuffixEqualsIgnoreCaseRulesShareMultiByteTail_THEN_AllCompileMatchAndDeleteCleanly()
+            throws Exception {
+        Machine machine = new Machine();
+        String[] prefixes = {"a", "b", "c", "d", "e", "f"};
+        for (String prefix : prefixes) {
+            machine.addRule("r-" + prefix,
+                    "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"" + prefix + "デé\"}}]}");
+        }
+
+        for (String prefix : prefixes) {
+            List<String> matches = machine.rulesForJSONEvent("{\"k\": [\"zz" + prefix + "デé\"]}");
+            assertEquals(1, matches.size());
+            assertTrue(matches.contains("r-" + prefix));
+            // Upper-cased prefix and non-ASCII-folded É must reach the same rule.
+            List<String> foldedMatches = machine.rulesForJSONEvent(
+                    "{\"k\": [\"zz" + prefix.toUpperCase(Locale.ROOT) + "デÉ\"]}");
+            assertEquals(1, foldedMatches.size());
+            assertTrue(foldedMatches.contains("r-" + prefix));
+        }
+
+        // Delete half the family; the survivors must be unaffected.
+        for (String prefix : new String[] {"a", "c", "e"}) {
+            machine.deleteRule("r-" + prefix,
+                    "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"" + prefix + "デé\"}}]}");
+        }
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzaデé\"]}").isEmpty());
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzbデé\"]}").contains("r-b"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzdデé\"]}").contains("r-d"));
+        assertTrue(machine.rulesForJSONEvent("{\"k\": [\"zzfデé\"]}").contains("r-f"));
+    }
+
+    // The guard only affects the byte-state-reuse optimization, never matching: a machine
+    // built rule-by-rule (reuse path exercised, guard fires) and a machine built from the
+    // same rules on fresh state each time must produce identical match results.
+    @Test
+    public void WHEN_GuardFires_THEN_MatchResultsEqualSingleRuleMachines() throws Exception {
+        String[][] rules = {
+                {"r0", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"aデé\"}}]}"},
+                {"r1", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"bデé\"}}]}"},
+                {"r2", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"a©é\"}}]}"},
+                {"r3", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"b©é\"}}]}"},
+                {"r4", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"a5デé\"}}]}"},
+                {"r5", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"b5デé\"}}]}"},
+        };
+        String[] events = {
+                "{\"k\": [\"zzaデé\"]}", "{\"k\": [\"zzAデÉ\"]}", "{\"k\": [\"zzbデé\"]}",
+                "{\"k\": [\"zza©é\"]}", "{\"k\": [\"zzA©É\"]}", "{\"k\": [\"zzb©é\"]}",
+                "{\"k\": [\"zza5デé\"]}", "{\"k\": [\"zzB5デÉ\"]}",
+                "{\"k\": [\"aデéx\"]}", "{\"k\": [\"unrelated\"]}",
+        };
+
+        Machine shared = new Machine();
+        for (String[] rule : rules) {
+            shared.addRule(rule[0], rule[1]);
+        }
+
+        for (String event : events) {
+            Set<String> expected = new HashSet<>();
+            for (String[] rule : rules) {
+                Machine single = new Machine();
+                single.addRule(rule[0], rule[1]);
+                expected.addAll(single.rulesForJSONEvent(event));
+            }
+            assertEquals("event: " + event, expected, new HashSet<>(shared.rulesForJSONEvent(event)));
+        }
     }
 }


### PR DESCRIPTION
# Guard the forward multi-byte walker against non-InputByte continuation positions

## Summary
`ByteMachine.extractNextJavaCharacterFromInputCharactersForForwardArrays` reconstructs a multi-byte UTF-8
character by casting the continuation positions (`characters[i + 1]`, `characters[i + 2]`) to `InputByte`
with no type check. When a continuation position holds an `InputMultiByteSet` (which an `equals-ignore-case`
value produces via case folding), the cast throws:

```
java.lang.ClassCastException: class software.amazon.event.ruler.input.InputMultiByteSet
    cannot be cast to class software.amazon.event.ruler.input.InputByte
  at software.amazon.event.ruler.input.InputByte.cast(InputByte.java:19)
  at software.amazon.event.ruler.ByteMachine.extractNextJavaCharacterFromInputCharactersForForwardArrays(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.extractNextJavaCharacterFromInputCharacters(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.doMultipleTransitionsConvergeForInputByte(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.canReuseNextByteState(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.addMatchValue(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.addMatchPattern(ByteMachine.java)
  at software.amazon.event.ruler.ByteMachine.addPattern(ByteMachine.java)
  at software.amazon.event.ruler.GenericMachine.addStep(GenericMachine.java)
  at software.amazon.event.ruler.GenericMachine.addRule(GenericMachine.java)
```

The failure happens at `addRule` time (rule compilation), so a single valid rule can crash the machine build.

## Reproduction
```java
Machine machine = new Machine();
// A sibling rule seeds the reusable InputMultiByteSet states on the shared "デé" tail...
machine.addRule("sibling",  "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"b\u30c7\u00e9\"}}]}");
// ...so adding this second rule exercises canReuseNextByteState and throws.
// value = "a" + U+30C7 (デ, 3-byte) + U+00E9 (é, 2-byte)
machine.addRule("offender", "{\"k\": [{\"suffix\": {\"equals-ignore-case\": \"a\u30c7\u00e9\"}}]}");
```
`suffix` + `equals-ignore-case` is a fully supported, documented combination, and non-ASCII rule values are
legitimate, so any caller with such a family of rules hits this deterministically. NOTE: the crash is in the
byte-state-**reuse** path, so it needs a prior rule that seeds a reusable state on the shared multi-byte tail;
a single such rule on a fresh machine does not trip it.

## Verification
Verified against `aws/event-ruler` @ `main` (Apache Maven 3.9.9, Corretto 17): the added test fails on
unpatched `main` with the exact stack below and passes after the fix; the full existing suite stays green
(768 tests, 0 failures, 0 errors).
```
java.lang.ClassCastException: InputMultiByteSet cannot be cast to InputByte
  at InputByte.cast(InputByte.java:19)
  at ByteMachine.extractNextJavaCharacterFromInputCharactersForForwardArrays(ByteMachine.java:939)
  at ByteMachine.doMultipleTransitionsConvergeForInputByte(ByteMachine.java:857)
  at ByteMachine.canReuseNextByteState(ByteMachine.java:822)
  at ByteMachine.addMatchValue(ByteMachine.java:765)
```

## Relationship to #248
#248 ("Guard backwards-array walker against non-InputByte sentinels") added `isByte` guards to
`isContinuationByte` and to `extractNextJavaCharacterFromInputCharactersForBackwardsArrays` (it stops at the
first non-byte and reconstructs from the bytes gathered). It did **not** guard the *forward* walker, which
still performs the unchecked casts. This PR applies the same guard to the forward walker, mirroring #248's
behavior exactly.

## Fix
In `extractNextJavaCharacterFromInputCharactersForForwardArrays`, check each continuation position with a new
bounds-and-type-checked helper `isByteAtIndex(...)` before casting; if a continuation position is not an
`InputByte`, stop and reconstruct from the bytes gathered so far (identical philosophy to the backward walker).

This method is only reached from `doMultipleTransitionsConvergeForInputByte`, which gates the byte-state-reuse
**optimization**. A truncated reconstruction can only cause the optimization to be skipped (a slightly larger
machine); it cannot change match results. The added regression test asserts matching is preserved.

## Testing
- New regression test builds the offending rule and asserts (a) no `ClassCastException`, (b) case-insensitive
  suffix matching still works (exact-case and ASCII case-folded values match; a non-suffix value does not).
- Existing `ByteMachineTest` / `MachineTest` suites for suffix, equals-ignore-case, wildcard, and multi-byte
  patterns must remain green (behavior-preserving change).

## Notes for downstream consumers
This is a net-new
fix: it is NOT resolved by any released version through v2.0.1 (v2.0.0's #248 only covered the backward
walker). Consumers must take the release that contains this change; a version bump within the 2.0.x line prior
to it will not help.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.