### PR TITLE
Fix exponential complexity evaluation and count machines behind absent-key patterns

### DIFF
--- a/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
+++ b/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
@@ -1,9 +1,11 @@
 package software.amazon.event.ruler;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
@@ -101,19 +103,35 @@ public class MachineComplexityEvaluator {
 
         // Now that we have a maxSize for this ByteMachine, let's recursively get the maxSize for each next NameState
         // accessible via any of this ByteMachine's matches. We will return the maximum maxSize.
-        int maxSizeFromNextNameStates = 0;
-        Set<ByteMatch> uniqueMatches = new HashSet<>();
-        for (Set<ByteMatch> matches : matchesAccessibleFromEachTransition.values()) {
-            uniqueMatches.addAll(matches);
-        }
-        for (ByteMatch match : uniqueMatches) {
-            NameState nextNameState = match.getNextNameState();
-            if (nextNameState != null) {
-                maxSizeFromNextNameStates = Math.max(maxSizeFromNextNameStates, nextNameState.evaluateComplexity(this));
+        return Math.max(maxSize, evaluateNextNameStates(matchesAccessibleFromEachTransition.values()));
+    }
+
+    /**
+     * Returns the maximum complexity of the machines reachable through the next NameStates of the given matches, or
+     * zero when no match leads to a next NameState. Recursion happens once per distinct next NameState, not once per
+     * match: all values of an exact-match list lead to the same next NameState, so recursing per match would walk the
+     * machines behind a chain of value lists once per combination of values (the product of the list sizes). The result
+     * is the same either way, since a recursion's result depends only on the NameState it starts from and a maximum is
+     * insensitive to duplicates.
+     *
+     * @param matchesAccessibleFromEachTransition The sets of matches accessible from each transition of one machine.
+     * @return The lesser of maxComplexity and the maximum complexity of any machine reachable from any next NameState.
+     */
+    int evaluateNextNameStates(Collection<Set<ByteMatch>> matchesAccessibleFromEachTransition) {
+        Set<NameState> nextNameStates = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Set<ByteMatch> matches : matchesAccessibleFromEachTransition) {
+            for (ByteMatch match : matches) {
+                NameState nextNameState = match.getNextNameState();
+                if (nextNameState != null) {
+                    nextNameStates.add(nextNameState);
+                }
             }
         }
-
-        return Math.max(maxSize, maxSizeFromNextNameStates);
+        int maxSizeFromNextNameStates = 0;
+        for (NameState nextNameState : nextNameStates) {
+            maxSizeFromNextNameStates = Math.max(maxSizeFromNextNameStates, nextNameState.evaluateComplexity(this));
+        }
+        return maxSizeFromNextNameStates;
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -306,6 +306,18 @@ class NameState {
                 return maxComplexity;
             }
         }
+        // An absent-key pattern ({"exists": false}) leads to its next NameState through a NameMatcher instead of a
+        // ByteMachine. The machines behind that NameState are traversed by matching just like any other, so they
+        // count toward complexity just like any other.
+        for (NameMatcher<NameState> nameMatcher : mustNotExistMatchers.values()) {
+            NameState nextNameState = nameMatcher.getNextState();
+            if (nextNameState != null) {
+                complexity = Math.max(complexity, nextNameState.evaluateComplexity(evaluator));
+                if (complexity >= maxComplexity) {
+                    return maxComplexity;
+                }
+            }
+        }
         return complexity;
     }
 

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorEquivalenceTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorEquivalenceTest.java
@@ -1,0 +1,303 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Property-style verification that recursing into next NameStates once per distinct NameState returns exactly the
+ * complexity that recursing once per distinct match returns: for a corpus of machines spanning the pattern types, key
+ * shapes, and rule combinations Ruler supports, the two evaluators must agree on every machine.
+ *
+ * <p>The reference arm re-implements per-match recursion on top of the same ByteMachine walk, so the two arms differ
+ * only in their recursion targets. They agree because a recursion's result depends only on the NameState it starts
+ * from and a maximum is insensitive to duplicates; this suite checks that argument against the compiled machines
+ * themselves.
+ */
+public class MachineComplexityEvaluatorEquivalenceTest {
+
+    /**
+     * Recurses once per distinct match (once per exact-match list value), which walks the machines behind a chain of
+     * value lists once per combination of values. Slow, so the corpus keeps its value lists short.
+     */
+    private static class PerMatchRecursionEvaluator extends MachineComplexityEvaluator {
+        PerMatchRecursionEvaluator(int maxComplexity) {
+            super(maxComplexity);
+        }
+
+        @Override
+        int evaluateNextNameStates(Collection<Set<ByteMatch>> matchesAccessibleFromEachTransition) {
+            Set<ByteMatch> uniqueMatches = new HashSet<>();
+            for (Set<ByteMatch> matches : matchesAccessibleFromEachTransition) {
+                uniqueMatches.addAll(matches);
+            }
+            int maxSizeFromNextNameStates = 0;
+            for (ByteMatch match : uniqueMatches) {
+                NameState nextNameState = match.getNextNameState();
+                if (nextNameState != null) {
+                    maxSizeFromNextNameStates = Math.max(maxSizeFromNextNameStates,
+                            nextNameState.evaluateComplexity(this));
+                }
+            }
+            return maxSizeFromNextNameStates;
+        }
+    }
+
+    private static final int[] MAX_COMPLEXITIES = { 1, 3, 100, Integer.MAX_VALUE };
+
+    /**
+     * Value-pattern shapes, each expressed as the pattern array for one key: every MatchType Ruler's JSON syntax can
+     * produce appears at least once, plus the syntax variants that compile onto the same MatchType differently
+     * (numeric, list-valued and single-valued anything-but) and a few mixed arrays.
+     */
+    private static final Map<String, String> PATTERN_SETS = buildPatternSets();
+
+    private static Map<String, String> buildPatternSets() {
+        Map<String, String> sets = new LinkedHashMap<>();
+        sets.put("exactSingle", "[\"pv1\"]");
+        sets.put("exactList", "[\"pv1\", \"pv2\", \"pv3\"]");
+        sets.put("exactDuplicates", "[\"dup\", \"dup\", \"dup2\"]");
+        sets.put("prefix", "[{\"prefix\": \"pre\"}]");
+        sets.put("prefixEqualsIgnoreCase", "[{\"prefix\": {\"equals-ignore-case\": \"PrE\"}}]");
+        sets.put("suffix", "[{\"suffix\": \"fix\"}]");
+        sets.put("suffixEqualsIgnoreCase", "[{\"suffix\": {\"equals-ignore-case\": \"FiX\"}}]");
+        sets.put("equalsIgnoreCase", "[{\"equals-ignore-case\": \"MiXeD\"}]");
+        sets.put("wildcardLeading", "[{\"wildcard\": \"*ab\"}]");
+        sets.put("wildcardMiddle", "[{\"wildcard\": \"a*b\"}]");
+        sets.put("wildcardTrailing", "[{\"wildcard\": \"ab*\"}]");
+        sets.put("wildcardMulti", "[{\"wildcard\": \"*a*a*\"}]");
+        sets.put("wildcardRepeatedTail", "[{\"wildcard\": \"F*eatureFeature\"}]");
+        sets.put("anythingButExactList", "[{\"anything-but\": [\"x1\", \"x2\"]}]");
+        sets.put("anythingButSingleString", "[{\"anything-but\": \"x1\"}]");
+        sets.put("anythingButNumericList", "[{\"anything-but\": [100, 200]}]");
+        sets.put("anythingButSingleNumber", "[{\"anything-but\": 123}]");
+        sets.put("anythingButWildcardSingle", "[{\"anything-but\": {\"wildcard\": \"*ab*\"}}]");
+        sets.put("anythingButWildcardSet", "[{\"anything-but\": {\"wildcard\": [\"*ab*\", \"*cd\", \"e*f\"]}}]");
+        sets.put("anythingButPrefix", "[{\"anything-but\": {\"prefix\": \"pre\"}}]");
+        sets.put("anythingButSuffix", "[{\"anything-but\": {\"suffix\": \"fix\"}}]");
+        sets.put("anythingButEqualsIgnoreCase", "[{\"anything-but\": {\"equals-ignore-case\": [\"dad0\", \"dad1\"]}}]");
+        sets.put("numericRange", "[{\"numeric\": [\">\", 0, \"<=\", 100]}]");
+        sets.put("numericEquals", "[{\"numeric\": [\"=\", 3.5]}]");
+        sets.put("existsTrue", "[{\"exists\": true}]");
+        sets.put("existsFalse", "[{\"exists\": false}]");
+        sets.put("cidr", "[{\"cidr\": \"10.0.0.0/24\"}]");
+        sets.put("mixedExactPrefixWildcard", "[\"ev1\", {\"prefix\": \"px\"}, {\"wildcard\": \"*w\"}]");
+        sets.put("mixedAnythingButWildcardExact", "[{\"anything-but\": {\"wildcard\": \"*q*\"}}, \"plain\"]");
+        return Collections.unmodifiableMap(sets);
+    }
+
+    /**
+     * The subset of pattern sets that interact most with complexity evaluation, used for pairwise combinations.
+     */
+    private static final List<String> PAIRWISE_SET_NAMES = Collections.unmodifiableList(Arrays.asList(
+            "exactList", "wildcardLeading", "wildcardMulti", "anythingButWildcardSet", "prefix",
+            "mixedExactPrefixWildcard", "existsFalse", "numericRange"));
+
+    @Test
+    public void testEverySinglePatternSetEvaluatesEquivalently() throws Exception {
+        for (Map.Entry<String, String> patternSet : PATTERN_SETS.entrySet()) {
+            String rule = "{\"kk\": " + patternSet.getValue() + "}";
+            assertEquivalentInAllConfigurations("single pattern set " + patternSet.getKey(),
+                    Collections.singletonList(rule));
+        }
+    }
+
+    @Test
+    public void testEveryOrderedPatternSetPairEvaluatesEquivalently() throws Exception {
+        for (String firstSetName : PAIRWISE_SET_NAMES) {
+            for (String secondSetName : PAIRWISE_SET_NAMES) {
+                String rule = "{" +
+                        "\"aa\": " + PATTERN_SETS.get(firstSetName) + "," +
+                        "\"bb\": " + PATTERN_SETS.get(secondSetName) +
+                        "}";
+                assertEquivalentInAllConfigurations(
+                        "pattern set pair (" + firstSetName + ", " + secondSetName + ")",
+                        Collections.singletonList(rule));
+            }
+        }
+    }
+
+    @Test
+    public void testKeyChainShapesEvaluateEquivalently() throws Exception {
+        List<String> chainRules = Arrays.asList(
+                // Exact-match lists ahead of a wildcard-bearing key: the reported pathological shape.
+                "{\"aaa\": [\"a1\", \"a2\", \"a3\"], \"bbb\": [\"b1\", \"b2\", \"b3\"]," +
+                        " \"zzz\": [{\"wildcard\": \"*z*\"}]}",
+                // Wildcard-bearing key first, exact-match lists after it.
+                "{\"aaa\": [{\"wildcard\": \"*a*\"}], \"mmm\": [\"m1\", \"m2\", \"m3\"]," +
+                        " \"zzz\": [\"z1\", \"z2\", \"z3\"]}",
+                // Wildcard-bearing key between exact-match lists.
+                "{\"aaa\": [\"a1\", \"a2\"], \"mmm\": [{\"wildcard\": \"*m*\"}], \"zzz\": [\"z1\", \"z2\"]}",
+                // Every key carries a wildcard.
+                "{\"aaa\": [{\"wildcard\": \"*a\"}], \"bbb\": [{\"wildcard\": \"b*b\"}]," +
+                        " \"ccc\": [{\"wildcard\": \"*c*\"}]}",
+                // Two wildcard-bearing keys separated by exact-match lists.
+                "{\"aaa\": [\"a1\", \"a2\"], \"bbb\": [{\"wildcard\": \"*b\"}], \"ccc\": [\"c1\", \"c2\"]," +
+                        " \"ddd\": [{\"anything-but\": {\"wildcard\": \"*d*\"}}]}",
+                // Small-scale production shape: lists then an anything-but-wildcard set of leading-star patterns.
+                "{\"aaa\": [\"e1\", \"e2\"], \"bbb\": [\"n1\", \"n2\", \"n3\"]," +
+                        " \"ccc\": [\"s1\", \"s2\", \"s3\", \"s4\"]," +
+                        " \"zzz\": [{\"anything-but\": {\"wildcard\":" +
+                        " [\"*kiwi*\", \"*BASE_QuxB*\", \"*Delta*\", \"*a/example-lake-abc98765432*\"]}}]}",
+                // Deep chain of exact-match lists.
+                "{\"aaa\": [\"a1\", \"a2\"], \"bbb\": [\"b1\", \"b2\"], \"ccc\": [\"c1\", \"c2\"]," +
+                        " \"ddd\": [\"d1\", \"d2\"], \"eee\": [\"e1\", \"e2\"]," +
+                        " \"zzz\": [{\"wildcard\": \"*z\"}]}");
+        for (String rule : chainRules) {
+            assertEquivalentInAllConfigurations("key chain " + rule, Collections.singletonList(rule));
+        }
+    }
+
+    @Test
+    public void testNestedKeysEvaluateEquivalently() throws Exception {
+        List<String> nestedRules = Arrays.asList(
+                "{\"aaa\": {\"inner\": [\"a1\", \"a2\"]}, \"zzz\": [{\"wildcard\": \"*z\"}]}",
+                "{\"detail\": {\"state\": [{\"anything-but\": {\"wildcard\": \"*/bin/*.jar\"}}]}}",
+                "{\"outer\": {\"middle\": {\"inner\": [{\"wildcard\": \"*i*\"}]}}," +
+                        " \"other\": [\"o1\", \"o2\"]}");
+        for (String rule : nestedRules) {
+            assertEquivalentInAllConfigurations("nested keys " + rule, Collections.singletonList(rule));
+        }
+    }
+
+    @Test
+    public void testOrSubRulesEvaluateEquivalently() throws Exception {
+        List<String> orRules = Arrays.asList(
+                "{\"$or\": [{\"bar\": [\"1\"]}, {\"bar\": [\"2\"]}], \"foo\": [{\"wildcard\": \"*f\"}]}",
+                "{\"$or\": [{\"bar\": [{\"wildcard\": \"*x\"}]}, {\"baz\": [{\"wildcard\": \"y*\"}]}]," +
+                        " \"foo\": [\"fv\"]}",
+                "{\"$or\": [{\"bar\": [\"b1\", \"b2\"]}, {\"baz\": [\"z1\", \"z2\"]}]," +
+                        " \"foo\": [{\"anything-but\": {\"wildcard\": [\"*f*\", \"g*g\"]}}]}");
+        for (String rule : orRules) {
+            assertEquivalentInAllConfigurations("$or rule " + rule, Collections.singletonList(rule));
+        }
+    }
+
+    @Test
+    public void testMultipleRulesPerMachineEvaluateEquivalently() throws Exception {
+        List<List<String>> ruleSets = new ArrayList<>();
+        // Shared first-key chain diverging afterwards, wildcards on the diverging keys.
+        ruleSets.add(Arrays.asList(
+                "{\"aaa\": [\"a1\", \"a2\"], \"zzz\": [{\"wildcard\": \"*x*\"}]}",
+                "{\"aaa\": [\"a1\", \"a3\"], \"zzz\": [{\"wildcard\": \"*y\"}]}"));
+        // Rules of different key sets sharing one key.
+        ruleSets.add(Arrays.asList(
+                "{\"aaa\": [\"a1\"], \"bbb\": [\"b1\"]}",
+                "{\"aaa\": [\"a1\"], \"ccc\": [{\"wildcard\": \"*c\"}]}"));
+        // Wildcard-heavy rules on disjoint keys.
+        ruleSets.add(Arrays.asList(
+                "{\"aaa\": [{\"wildcard\": \"a*aaa\"}]}",
+                "{\"bbb\": [{\"wildcard\": \"aa*aa\"}]}",
+                "{\"ccc\": [{\"anything-but\": {\"wildcard\": \"*c*c*\"}}]}"));
+        for (List<String> ruleSet : ruleSets) {
+            assertEquivalentInAllConfigurations("multi-rule machine " + ruleSet, ruleSet);
+        }
+    }
+
+    @Test
+    public void testSameRuleNameAcrossShapesEvaluatesEquivalently() throws Exception {
+        // Adding several shapes under one rule name exercises sub-rule bookkeeping on shared NameStates.
+        Machine machine = new Machine();
+        machine.addRule("rule", "{\"aaa\": [\"a1\", \"a2\"], \"zzz\": [{\"wildcard\": \"*z\"}]}");
+        machine.addRule("rule", "{\"aaa\": [\"a1\"], \"yyy\": [{\"wildcard\": \"*y*\"}]}");
+        for (int maxComplexity : MAX_COMPLEXITIES) {
+            assertMachineEvaluatesEquivalently("same rule name across shapes", machine, maxComplexity);
+        }
+    }
+
+    /**
+     * Seeded (so deterministic in CI) randomized corpus across pattern sets, key counts, nesting, $or use,
+     * machine configurations, rule counts, and maxComplexity values. On failure the message carries the full
+     * generated rules, so any divergence is directly reproducible.
+     */
+    @Test
+    public void testRandomizedRuleCorpusEvaluatesEquivalently() throws Exception {
+        Random random = new Random(20260831L);
+        String[] keyPool = { "aaa", "bbb", "ccc", "ddd", "eee" };
+        List<String> patternSetValues = new ArrayList<>(PATTERN_SETS.values());
+        int[] maxComplexityPool = { 1, 2, 3, 7, 50, Integer.MAX_VALUE };
+
+        for (int i = 0; i < 250; i++) {
+            int ruleCount = 1 + random.nextInt(2);
+            List<String> rules = new ArrayList<>();
+            for (int j = 0; j < ruleCount; j++) {
+                rules.add(generateRandomRule(random, keyPool, patternSetValues));
+            }
+            boolean additionalNameStateReuse = random.nextBoolean();
+            int maxComplexity = maxComplexityPool[random.nextInt(maxComplexityPool.length)];
+            assertEquivalent("random corpus machine " + i + " (additionalNameStateReuse="
+                            + additionalNameStateReuse + ", maxComplexity=" + maxComplexity + ") rules=" + rules,
+                    rules, additionalNameStateReuse, maxComplexity);
+        }
+    }
+
+    private static String generateRandomRule(Random random, String[] keyPool, List<String> patternSetValues) {
+        int keyCount = 1 + random.nextInt(4);
+        List<String> keys = new ArrayList<>(Arrays.asList(keyPool));
+        Collections.shuffle(keys, random);
+        keys = keys.subList(0, keyCount);
+
+        List<String> members = new ArrayList<>();
+        int keyIndex = 0;
+
+        // A quarter of multi-key rules put their first two keys into single-key $or branches.
+        if (keyCount >= 2 && random.nextInt(4) == 0) {
+            String firstBranch = "{\"" + keys.get(0) + "\": "
+                    + patternSetValues.get(random.nextInt(patternSetValues.size())) + "}";
+            String secondBranch = "{\"" + keys.get(1) + "\": "
+                    + patternSetValues.get(random.nextInt(patternSetValues.size())) + "}";
+            members.add("\"$or\": [" + firstBranch + ", " + secondBranch + "]");
+            keyIndex = 2;
+        }
+
+        for (; keyIndex < keyCount; keyIndex++) {
+            String patternSet = patternSetValues.get(random.nextInt(patternSetValues.size()));
+            // A fifth of keys nest their pattern one level deep.
+            if (random.nextInt(5) == 0) {
+                members.add("\"" + keys.get(keyIndex) + "\": {\"inner\": " + patternSet + "}");
+            } else {
+                members.add("\"" + keys.get(keyIndex) + "\": " + patternSet);
+            }
+        }
+        return "{" + String.join(", ", members) + "}";
+    }
+
+    private void assertEquivalentInAllConfigurations(String description, List<String> rules) throws Exception {
+        for (boolean additionalNameStateReuse : new boolean[] { false, true }) {
+            for (int maxComplexity : MAX_COMPLEXITIES) {
+                assertEquivalent(description + " (additionalNameStateReuse=" + additionalNameStateReuse
+                                + ", maxComplexity=" + maxComplexity + ")",
+                        rules, additionalNameStateReuse, maxComplexity);
+            }
+        }
+    }
+
+    private void assertEquivalent(String description, List<String> rules, boolean additionalNameStateReuse,
+                                  int maxComplexity) throws Exception {
+        Machine machine = additionalNameStateReuse
+                ? new Machine.Builder().withAdditionalNameStateReuse(true).build()
+                : new Machine();
+        int ruleIndex = 0;
+        for (String rule : rules) {
+            machine.addRule("rule" + ruleIndex++, rule);
+        }
+        assertMachineEvaluatesEquivalently(description, machine, maxComplexity);
+    }
+
+    private void assertMachineEvaluatesEquivalently(String description, Machine machine, int maxComplexity) {
+        int perMatchRecursion = machine.evaluateComplexity(new PerMatchRecursionEvaluator(maxComplexity));
+        int perNameStateRecursion = machine.evaluateComplexity(new MachineComplexityEvaluator(maxComplexity));
+        assertEquals("complexity divergence: " + description, perMatchRecursion, perNameStateRecursion);
+    }
+}

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -552,6 +552,43 @@ public class MachineComplexityEvaluatorTest {
         assertEquals(0, machine.evaluateComplexity(evaluator));
     }
 
+    @Test
+    public void testEvaluateWildcardBehindAbsentKey() throws Exception {
+        // Keys sort as aaa, zzz: the wildcard machine on zzz sits behind aaa's absent-key pattern, which is a
+        // NameMatcher edge rather than a ByteMachine. "zz" is matched by 3 wildcard prefixes: "*", "*z", "*z*".
+        String ruleBehindAbsentKey = "{\"aaa\": [{\"exists\": false}], \"zzz\": [{\"wildcard\": \"*z*\"}]}";
+        String ruleBehindPresentKey = "{\"aaa\": [{\"exists\": true}], \"zzz\": [{\"wildcard\": \"*z*\"}]}";
+        String wildcardRule = "{\"zzz\": [{\"wildcard\": \"*z*\"}]}";
+        for (boolean additionalNameStateReuse : new boolean[] { false, true }) {
+            assertEquals(3, complexityOfRule(ruleBehindAbsentKey, additionalNameStateReuse));
+            assertEquals(3, complexityOfRule(ruleBehindPresentKey, additionalNameStateReuse));
+            assertEquals(3, complexityOfRule(wildcardRule, additionalNameStateReuse));
+        }
+    }
+
+    @Test
+    public void testEvaluateWildcardBehindNestedAbsentKey() throws Exception {
+        String rule = "{\"aaa\": {\"inner\": [{\"exists\": false}]}, \"zzz\": [{\"wildcard\": \"*z*\"}]}";
+        // "zz" is matched by 3 wildcard prefixes: "*", "*z", "*z*"
+        assertEquals(3, complexityOfRule(rule, false));
+        assertEquals(3, complexityOfRule(rule, true));
+    }
+
+    @Test
+    public void testEvaluateWildcardBehindAbsentKeyRespectsMaxComplexity() throws Exception {
+        String rule = "{\"aaa\": [{\"exists\": false}], \"zzz\": [{\"wildcard\": \"*z*\"}]}";
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+        assertEquals(1, machine.evaluateComplexity(new MachineComplexityEvaluator(1)));
+        assertEquals(2, machine.evaluateComplexity(new MachineComplexityEvaluator(2)));
+    }
+
+    private int complexityOfRule(String rule, boolean additionalNameStateReuse) throws Exception {
+        Machine machine = new Machine.Builder().withAdditionalNameStateReuse(additionalNameStateReuse).build();
+        machine.addRule("rule", rule);
+        return machine.evaluateComplexity(evaluator);
+    }
+
     private void testPatternPermutations(int expectedComplexity, Patterns ... patterns) {
         ByteMachine machine = new ByteMachine();
         List<Patterns[]> patternPermutations = generateAllPermutations(patterns);

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorWalkCountTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorWalkCountTest.java
@@ -1,0 +1,238 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that complexity evaluation walks each ByteMachine once per evaluation, whatever the sizes of the exact-match
+ * value lists ahead of it. All values of one key's list lead to the same next NameState, so recursing into next
+ * NameStates once per match (once per list value) walks the machines behind a chain of value lists of sizes L1..Lk
+ * L1*...*Lk times; for realistic rules (e.g. 2x50x21 value lists ahead of a wildcard-bearing key) that is thousands of
+ * walks of the most expensive machine and tens of gigabytes of transient allocation, for a machine whose reported
+ * complexity is far below any configured maximum. Recursing once per distinct next NameState walks each machine once.
+ *
+ * <p>The tests pin that behavior with deterministic ByteMachine walk counts, not wall-clock time (which would be flaky
+ * in CI): each distinct ByteMachine must be walked exactly once per evaluation.
+ */
+public class MachineComplexityEvaluatorWalkCountTest {
+
+    private static final int MAX_COMPLEXITY = 100;
+
+    /**
+     * Four anything-but wildcard patterns with leading stars: the pattern set of the reported production rule, with
+     * synthetic values.
+     */
+    private static final String ANYTHING_BUT_WILDCARD_SET = "[{\"anything-but\": {\"wildcard\": " +
+            "[\"*kiwi*\", \"*BASE_QuxB*\", \"*Delta*\", \"*a/example-lake-abc98765432*\"]}}]";
+
+    /**
+     * Counts how many times a ByteMachine walk is started. ByteMachine.evaluateComplexity invokes evaluate(ByteState)
+     * exactly once, so this counts ByteMachine evaluations.
+     */
+    private static class WalkCountingEvaluator extends MachineComplexityEvaluator {
+        private int walks = 0;
+
+        WalkCountingEvaluator(int maxComplexity) {
+            super(maxComplexity);
+        }
+
+        @Override
+        int evaluate(ByteState state) {
+            walks++;
+            return super.evaluate(state);
+        }
+
+        int getWalks() {
+            return walks;
+        }
+    }
+
+    /**
+     * Complexity of a machine holding only exact matches ahead of a wildcard key equals the complexity of the wildcard
+     * key's machine alone; asserting against this reference avoids hand-computed constants.
+     */
+    private static int complexityOfRule(String rule) throws Exception {
+        Machine machine = new Machine();
+        machine.addRule("reference", rule);
+        return machine.evaluateComplexity(new MachineComplexityEvaluator(MAX_COMPLEXITY));
+    }
+
+    @Test
+    public void testExactMatchListChainWalksEachByteMachineOnce() throws Exception {
+        // Keys are added to the machine in lexical order: aaa, bbb, ccc, zzz. The wildcard machine on zzz is
+        // reachable via 2x3x4=24 distinct paths through the exact-match values of the preceding keys.
+        String rule = rule(
+                member("aaa", "a1", "a2"),
+                member("bbb", "b1", "b2", "b3"),
+                member("ccc", "c1", "c2", "c3", "c4"),
+                "\"zzz\": [{\"wildcard\": \"*z\"}]");
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        // 4 keys, 4 ByteMachines, 4 walks. Recursing once per match would take 1 + 2 + 2*3 + 2*3*4 = 33 walks.
+        assertEquals(4, evaluator.getWalks());
+        // Exact-match lists contribute no complexity; the chain evaluates to the wildcard machine's complexity.
+        assertEquals(complexityOfRule("{\"zzz\": [{\"wildcard\": \"*z\"}]}"), complexity);
+    }
+
+    @Test
+    public void testWalkCountIndependentOfExactMatchListSizes() throws Exception {
+        String smallLists = rule(
+                member("aaa", generatedValues("avalue", 2)),
+                member("bbb", generatedValues("bvalue", 2)),
+                member("ccc", generatedValues("cvalue", 2)),
+                "\"zzz\": [{\"wildcard\": \"*z*\"}]");
+        String bigLists = rule(
+                member("aaa", generatedValues("avalue", 5)),
+                member("bbb", generatedValues("bvalue", 5)),
+                member("ccc", generatedValues("cvalue", 5)),
+                "\"zzz\": [{\"wildcard\": \"*z*\"}]");
+        Machine smallMachine = new Machine();
+        smallMachine.addRule("rule", smallLists);
+        Machine bigMachine = new Machine();
+        bigMachine.addRule("rule", bigLists);
+
+        WalkCountingEvaluator smallEvaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        WalkCountingEvaluator bigEvaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int smallComplexity = smallMachine.evaluateComplexity(smallEvaluator);
+        int bigComplexity = bigMachine.evaluateComplexity(bigEvaluator);
+
+        // Walk count depends only on the number of distinct ByteMachines, never on value-list sizes (per-match
+        // recursion would take 15 and 156 walks respectively).
+        assertEquals(4, smallEvaluator.getWalks());
+        assertEquals(4, bigEvaluator.getWalks());
+        assertEquals(smallComplexity, bigComplexity);
+    }
+
+    @Test
+    public void testAnythingButWildcardSetAfterExactMatchListsWalksEachByteMachineOnce() throws Exception {
+        String rule = rule(
+                member("aaa", "ErrCodeOne", "ErrCodeTwo"),
+                member("bbb", "b1", "b2", "b3"),
+                member("ccc", "c1", "c2", "c3", "c4"),
+                "\"zzz\": " + ANYTHING_BUT_WILDCARD_SET);
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        assertEquals(4, evaluator.getWalks());
+        assertEquals(complexityOfRule("{\"zzz\": " + ANYTHING_BUT_WILDCARD_SET + "}"), complexity);
+    }
+
+    /**
+     * The reported production shape: two exact-match value lists of sizes 2 and 50, then a list of size 21, then a key
+     * holding an anything-but-wildcard set of four leading-star patterns. The wildcard machine is reachable via
+     * 2*50*21 = 2100 distinct paths, so recursing once per match walks it 2100 times (2203 walks in total, tens of
+     * seconds and tens of gigabytes of transient allocation); recursing once per next NameState walks it once.
+     */
+    @Test
+    public void testProductionShapedRuleWalksEachByteMachineOnce() throws Exception {
+        // Two shared-prefix families for the event-name list, a shared-suffix family for the event-source list.
+        List<String> eventNames = new ArrayList<>(generatedValues("MakeThing", 25));
+        eventNames.addAll(generatedValues("DropThing", 25));
+        List<String> eventSources = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            eventSources.add(String.format("svc%02d.example.com", i));
+        }
+        String rule = rule(
+                member("aaa", "ErrCodeOne", "ErrCodeTwo"),
+                member("bbb", eventNames),
+                member("ccc", eventSources),
+                "\"zzz\": " + ANYTHING_BUT_WILDCARD_SET);
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        assertEquals(4, evaluator.getWalks());
+        assertEquals(complexityOfRule("{\"zzz\": " + ANYTHING_BUT_WILDCARD_SET + "}"), complexity);
+    }
+
+    @Test
+    public void testDeepExactMatchListChainWalksLinearly() throws Exception {
+        // Ten keys, each with two exact-match values, then a wildcard key. Recursing once per match would take
+        // 1 + 2 + 4 + ... + 2^10 = 2047 walks; recursing once per next NameState takes one walk per ByteMachine.
+        List<String> members = new ArrayList<>();
+        for (char key = 'a'; key <= 'j'; key++) {
+            String keyName = "" + key + key + key;
+            members.add(member(keyName, generatedValues(key + "value", 2)));
+        }
+        members.add("\"zzz\": [{\"wildcard\": \"*z\"}]");
+        Machine machine = new Machine();
+        machine.addRule("rule", rule(members.toArray(new String[0])));
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        assertEquals(11, evaluator.getWalks());
+        assertEquals(complexityOfRule("{\"zzz\": [{\"wildcard\": \"*z\"}]}"), complexity);
+    }
+
+    @Test
+    public void testNestedKeysWalkEachByteMachineOnce() throws Exception {
+        String rule = rule(
+                "\"aaa\": {\"inner\": [\"a1\", \"a2\"]}",
+                member("ccc", "c1", "c2"),
+                "\"zzz\": [{\"wildcard\": \"*z\"}]");
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        // Per-match recursion would take 1 + 2 + 4 = 7 walks.
+        assertEquals(3, evaluator.getWalks());
+        assertEquals(complexityOfRule("{\"zzz\": [{\"wildcard\": \"*z\"}]}"), complexity);
+    }
+
+    @Test
+    public void testOrSubRulesWalkEachByteMachineOnce() throws Exception {
+        // The two $or branches create two sub-rules: bar=1 leads to one NameState and bar=2 to another, each
+        // carrying its own ByteMachine for key foo. Expected walks: bar's machine, then foo's machine under
+        // each of the two branch NameStates: 3 total.
+        String rule = "{\"$or\": [{\"bar\": [\"1\"]}, {\"bar\": [\"2\"]}], \"foo\": [{\"wildcard\": \"*f\"}]}";
+        Machine machine = new Machine();
+        machine.addRule("rule", rule);
+
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(MAX_COMPLEXITY);
+        int complexity = machine.evaluateComplexity(evaluator);
+
+        assertEquals(3, evaluator.getWalks());
+        assertEquals(complexityOfRule("{\"foo\": [{\"wildcard\": \"*f\"}]}"), complexity);
+    }
+
+    private static String rule(String... members) {
+        return "{" + String.join(", ", members) + "}";
+    }
+
+    private static String member(String keyName, String... values) {
+        return member(keyName, Arrays.asList(values));
+    }
+
+    private static String member(String keyName, List<String> values) {
+        List<String> quoted = new ArrayList<>();
+        for (String value : values) {
+            quoted.add("\"" + value + "\"");
+        }
+        return "\"" + keyName + "\": [" + String.join(", ", quoted) + "]";
+    }
+
+    private static List<String> generatedValues(String valuePrefix, int count) {
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            values.add(valuePrefix + i);
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
## Issue #, if available

Fixes #269 (MachineComplexityEvaluator re-walks downstream machines once per exact-match
list value).

Also fixes an evaluator blind spot found while validating that fix: machines behind an
`{"exists": false}` key were never counted (change 2 below).

## Description of changes

### 1. Recurse once per next NameState (`MachineComplexityEvaluator`)

`MachineComplexityEvaluator.evaluate(ByteState)` recursed into next NameStates once per
`ByteMatch` — once per exact-match list value. All values of one key's list lead to the same
next NameState, so a rule with exact-match lists of sizes L1..Lk ahead of a wildcard-bearing
key re-walked the wildcard key's ByteMachine L1×...×Lk times. For a CloudTrail-style rule with
2×50×21 lists ahead of four leading-`*` anything-but-wildcard patterns, one `evaluateComplexity`
call walked the wildcard NFA 2,100 times: ~25 s and ~26 GB of transient allocation to report
complexity 7 for a machine whose construction costs ~78 ms / 3.8 MB.

The fix collects the distinct next NameStates of a machine's matches first and recurses once
per NameState. Rule compilation wires every NameState under exactly one ByteMachine, so this
alone walks each ByteMachine once per evaluation. No signature changes at any visibility, and
the evaluator keeps no evaluation state, so reuse across evaluations and sharing between
threads behave exactly as before. The recursion step is a package-private method
(`evaluateNextNameStates`) so tests can substitute the per-match form.

**Why results are unchanged:** a recursion's result depends only on the NameState it starts
from, and `Math.max` is insensitive to duplicates, so recursing once per distinct target returns
exactly what recursing once per distinct match returned. The equivalence suite below checks
that against compiled machines instead of taking the argument on trust.

### 2. Count machines behind absent-key patterns (`NameState`)

`NameState.evaluateComplexity` walked only the ByteMachines in its value transitions. A key
whose pattern is `{"exists": false}` has no ByteMachine — it leads to its next NameState
through a `NameMatcher` — and that edge was never followed, so every machine behind an
absent-key pattern was invisible to the evaluator while matching traverses it normally.
`{"aaa": [{"exists": false}], "zzz": [{"wildcard": "*z*"}]}` matched events at the wildcard
machine's full cost and evaluated to complexity 0; the same rule with `{"exists": true}` on
`aaa`, or with no `aaa` key at all, evaluates to 3. Since key names are the rule author's to
choose, any wildcard set could be placed behind an absent key that sorts before it and pass a
complexity limit unmeasured. The gap predates this PR (the evaluator has never followed these
edges) and is independent of change 1.

The fix follows the `NameMatcher` edges as well, under the same `maxComplexity` cap.
**Deliberate behavior change:** a rule with an absent-key pattern ahead of wildcard-bearing keys
now reports the complexity matching pays for it, so a consumer enforcing a maximum may reject a
rule of that shape it previously accepted. Every other rule evaluates exactly as before.

### Benchmarks (single shot, wall time + thread-allocated bytes, Corretto 17)

| variant | before | after | complexity |
|---|---|---|---|
| full rule (2×50×21 lists + 4 ABW leading-`*` wildcards) | 25,368 ms / 25.6 GB | **87 ms / 15.0 MB** | 7 → 7 |
| lists only | 28 ms / 4.9 MB | 6 ms / 0.2 MB | 0 → 0 |
| wildcard key only | 61 ms / 14.6 MB | 65 ms / 14.6 MB | 7 → 7 |

The "wildcard key only" row is the cost of walking that NFA once; the fix makes the full rule
cost that, instead of 2,100 times that. Complexity values are identical on every variant.

### Test coverage

- `MachineComplexityEvaluatorWalkCountTest` (new, 7 tests): pins the per-ByteMachine walk
  counts of compiled rules with a counting evaluator subclass — deterministic count assertions,
  no wall-clock bounds. Exact-match list chains (4 walks where per-match recursion does 33),
  list-size independence (4 walks for both 2×2×2 and 5×5×5 lists, where per-match recursion
  does 15 and 156), the production-shaped rule (4 vs 2,203), a ten-key chain (11 vs 2,047),
  nested keys (3 vs 7), and `$or` sub-rules (3).
- `MachineComplexityEvaluatorEquivalenceTest` (new, 8 tests): differential check against a
  reference evaluator that re-implements per-match recursion on top of the same ByteMachine
  walk — the pre-change behavior — so the two arms differ only in their recursion targets.
  Covers every `MatchType` at least once plus the `anything-but` syntax variants, ordered
  pairs of the complexity-relevant shapes, chain/nested/`$or`/multi-rule shapes, both
  `additionalNameStateReuse` configurations, capped (1, 3) and uncapped `maxComplexity`, and a
  250-machine seeded random corpus (deterministic in CI; failure messages carry the full
  generated rules).
- `MachineComplexityEvaluatorTest` (+3 tests): the absent-key, nested absent-key, and capped
  cases for change 2, in both `additionalNameStateReuse` configurations.
- Red-proofed: restoring per-match recursion fails 6 of the 7 walk-count tests with exactly the
  predicted counts (33, 15, 33, 2,203, 2,047, 7; the `$or` shape has one machine per branch
  either way); corrupting the recursion result fails all 8 equivalence tests; reverting change 2
  fails exactly its 3 tests (0 where 3, 1, and 2 are expected).
- Full `mvn verify` green (797 tests, 0 failures; checkstyle + spotbugs clean). Complexity
  evaluation is not on the event-matching path, so match throughput is structurally
  unaffected.

### Non-goal noted for maintainer judgment (pre-existing, unchanged)

While validating equivalence we observed that an `anything-but` `wildcard` **set** under-scores
relative to the same patterns as plain wildcards (the four exclusions above score 7 as an ABW
set vs 12 as four plain `wildcard` patterns, measured on this branch), because a values-set
shares one `Patterns` object and complexity counts distinct patterns. That behavior is
pre-existing, is preserved exactly by this PR (the equivalence suite pins it), and is
deliberately not changed here — it deserves its own discussion if it matters.

### Related issues

- #26 (benchmark test for MachineComplexityEvaluator): the walk-count tests added here give
  deterministic regression protection for this defect class; a time-based benchmark as #26
  proposes would complement them and would have surfaced this pathology directly.
- #105 (machine creation latency benchmarks): adjacent test debt — callers typically run
  `evaluateComplexity` at rule-creation time, so evaluator cost is part of effective creation
  latency even though `addRule` itself is fast.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the
Apache-2.0 license.
