### PR TITLE
test: Add a complexity-evaluator benchmark and regression guard (issue #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,7 @@ Events are processed at over 220K/second except for:
 
 ### Running the benchmarks
 
-Two benchmark harnesses are available; both operate on the same `citylots2` dataset and the same fourteen rule types.
+Two matching-throughput harnesses are available; both operate on the same `citylots2` dataset and the same fourteen rule types. The complexity evaluator has its own pair of classes, described at the end of this section.
 
 **[`Benchmarks.java`](src/test/software/amazon/event/ruler/Benchmarks.java)** — single-shot per rule type. Fast, but JVM warmup cost makes single-pass variance between runs of the same code routinely hit 10-20%. Good for eyeballing a large change; not reliable for detecting small regressions.
 
@@ -1008,6 +1008,24 @@ mvn test -Dtest=StableBenchmarks -Druler.perf.run=true \
 ```
 
 `StableBenchmarks` is gated off by default (`-Druler.perf.run=true` required) so it doesn't run in CI. For publication-grade numbers, use the [JMH benchmarks in `src/test/.../jmh/`](src/test/software/amazon/event/ruler/jmh) — those measure steady-state throughput under a full JMH harness.
+
+#### Complexity evaluation
+
+`MachineComplexityEvaluator` has its own pair of test classes, over a shared corpus of machines whose evaluation cost is known ([`MachineComplexityEvaluatorCorpus.java`](src/test/software/amazon/event/ruler/MachineComplexityEvaluatorCorpus.java): the Quamina exploder set, leading-star anything-but sets, exact-match value lists ahead of a wildcard key, one multi-star wildcard up to the 4,096-character pattern limit, two machines hidden behind an `{"exists": false}` key, and leading-star pattern sets whose uncapped evaluation is exponential in the pattern count). Every machine is built through `Machine.addRule`, so an evaluation walks the NameState graph and not only one `ByteMachine`.
+
+**[`MachineComplexityEvaluatorRegressionTest.java`](src/test/software/amazon/event/ruler/MachineComplexityEvaluatorRegressionTest.java)** runs in every build, once per machine and cap: it pins the value every machine reports under a cap of 11 and the uncapped complexity of every fast machine, pins the number of `ByteMachine` walks each evaluation makes, and bounds each evaluation's time — the machines whose uncapped walk takes seconds or minutes are evaluated capped only, so a change that defeats the cap fails the build.
+
+**[`MachineComplexityEvaluatorBenchmarks.java`](src/test/software/amazon/event/ruler/MachineComplexityEvaluatorBenchmarks.java)** reports build time, evaluation time and allocation per machine, capped and uncapped, and is gated like `StableBenchmarks`:
+
+```
+# Default: 3 warmup + 10 measured evaluations per row, except the seconds-long machines' uncapped row (once);
+# the minutes-long machine runs capped only. About half a minute, and a 2 GB heap suffices
+mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true
+
+# Same knobs as StableBenchmarks (-Druler.perf.warmup, -Druler.perf.measure, -Druler.perf.only, -Druler.perf.csv), plus:
+#   -Druler.perf.heavy=false   skip the seconds-long uncapped evaluations
+#   -Druler.perf.heavy=all     also run the minutes-long one (about 7 GB of live heap: -DargLine=-Xmx12g)
+```
 
 ### Suggestions for better performance
 

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorBenchmarks.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorBenchmarks.java
@@ -1,0 +1,309 @@
+package software.amazon.event.ruler;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.Entry;
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.Tier;
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.WalkCountingEvaluator;
+
+import com.sun.management.ThreadMXBean;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.PRODUCTION_CAP;
+import static software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.UNCAPPED;
+
+/**
+ * Timings of {@link MachineComplexityEvaluator} over the {@link MachineComplexityEvaluatorCorpus}: for every machine,
+ * build time, then evaluation time, allocation and reported complexity under a production-style cap and uncapped.
+ *
+ * <p>Gated off by default, like {@link StableBenchmarks}. Flip it on with {@code -Druler.perf.run=true}:
+ *
+ * <pre>
+ *   # Default: 3 warmup + 10 measured evaluations per row, except the seconds-long (HEAVY) machines' uncapped row,
+ *   # which runs once (about 20 s of the run); the minutes-long (EXPENSIVE) machine runs capped only. About half a
+ *   # minute in total, and a 2 GB heap suffices.
+ *   mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true
+ *
+ *   # Custom pass counts (the HEAVY and EXPENSIVE uncapped rows stay single-pass)
+ *   mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true \
+ *       -Druler.perf.warmup=5 -Druler.perf.measure=20
+ *
+ *   # Only machines whose name contains one of the given substrings
+ *   mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true \
+ *       -Druler.perf.only=quamina,multi-star
+ *
+ *   # Uncapped evaluation of the heavy machines: false = none, true = HEAVY tier (default), all = EXPENSIVE tier too
+ *   # (the 16-pattern leading-star set: about three minutes and 7 GB of live heap, e.g. -DargLine=-Xmx12g)
+ *   mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true -Druler.perf.heavy=all
+ *
+ *   # Write a CSV for diffing two revisions
+ *   mvn test -Dtest=MachineComplexityEvaluatorBenchmarks -Druler.perf.run=true \
+ *       -Druler.perf.csv=/tmp/evaluator-perf.csv
+ * </pre>
+ *
+ * <p>Reading the table: {@code complexity} and {@code walks} must not change between revisions — this class asserts
+ * both against the corpus on every row, and {@link MachineComplexityEvaluatorRegressionTest} does the same in every
+ * build. {@code median_us} and {@code alloc_kb} are the numbers to compare across revisions on one host. The capped
+ * rows are what a consumer enforcing a maximum of 10 pays at rule-creation time; the uncapped rows are the cost of
+ * reporting the true number, which for the leading-star sets grows exponentially with the pattern count.
+ */
+public class MachineComplexityEvaluatorBenchmarks {
+
+    private static final int DEFAULT_WARMUP_PASSES = 3;
+    private static final int DEFAULT_MEASURE_PASSES = 10;
+    private static final String ROW_FORMAT = "%-36s %-9s %10d %6d %7d %10.1f %11.1f %11.1f %11.1f %10.1f%n";
+
+    /** One row of the report. */
+    private static final class Row {
+        final String machine;
+        final String cap;
+        final int complexity;
+        final int walks;
+        final int passes;
+        final double buildMedianUs;
+        final double medianUs;
+        final double minUs;
+        final double maxUs;
+        final double allocKb;
+
+        Row(String machine, String cap, int complexity, int walks, int passes, double buildMedianUs, double medianUs,
+            double minUs, double maxUs, double allocKb) {
+            this.machine = machine;
+            this.cap = cap;
+            this.complexity = complexity;
+            this.walks = walks;
+            this.passes = passes;
+            this.buildMedianUs = buildMedianUs;
+            this.medianUs = medianUs;
+            this.minUs = minUs;
+            this.maxUs = maxUs;
+            this.allocKb = allocKb;
+        }
+
+        void print() {
+            System.out.printf(Locale.ROOT, ROW_FORMAT, machine, cap, complexity, walks, passes, buildMedianUs, medianUs,
+                    minUs, maxUs, allocKb);
+        }
+    }
+
+    @Test
+    public void evaluatorBenchmarks() throws Exception {
+        Assume.assumeTrue(
+                "Skipped: set -Druler.perf.run=true to run the complexity evaluator benchmarks. "
+                        + "See the class javadoc for options.",
+                Boolean.getBoolean("ruler.perf.run"));
+
+        int warmupPasses = getIntProp("ruler.perf.warmup", DEFAULT_WARMUP_PASSES, 0);
+        int measurePasses = getIntProp("ruler.perf.measure", DEFAULT_MEASURE_PASSES, 1);
+        String heavy = System.getProperty("ruler.perf.heavy", "true").trim().toLowerCase(Locale.ROOT);
+        Tier uncapUpTo;
+        switch (heavy) {
+            case "false":
+                uncapUpTo = Tier.FAST;
+                break;
+            case "true":
+                uncapUpTo = Tier.HEAVY;
+                break;
+            case "all":
+                uncapUpTo = Tier.EXPENSIVE;
+                break;
+            default:
+                throw new IllegalArgumentException("ruler.perf.heavy must be false, true or all, got: " + heavy);
+        }
+        List<String> only = onlyFilter();
+        Path csv = csvPath();
+
+        System.out.printf(Locale.ROOT, "%nMachineComplexityEvaluator benchmarks: %s %s, %s %s %s, %d cpus, %d MB heap%n",
+                System.getProperty("java.vm.name"), System.getProperty("java.version"),
+                System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"),
+                Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().maxMemory() / (1024 * 1024));
+        System.out.printf(Locale.ROOT, "warmup=%d measure=%d heavy=%s only=%s%n%n", warmupPasses, measurePasses, heavy,
+                only.isEmpty() ? "(all)" : only);
+
+        List<Entry> selected = new ArrayList<>();
+        for (Entry entry : MachineComplexityEvaluatorCorpus.entries()) {
+            if (only.isEmpty() || matchesFilter(entry.name, only)) {
+                selected.add(entry);
+            }
+        }
+        if (selected.isEmpty()) {
+            System.out.println("no corpus entry matches -Druler.perf.only=" + only);
+            return;
+        }
+
+        // Compile the evaluator's hot paths before the first measured row: the first machine's few capped passes are
+        // otherwise far too little work for the JIT, and its numbers straddle interpreted and compiled code. Over every
+        // fast entry, whatever the filter selected (about a second).
+        for (Entry entry : MachineComplexityEvaluatorCorpus.entries()) {
+            if (entry.tier == Tier.FAST) {
+                Machine machine = entry.build();
+                machine.evaluateComplexity(new WalkCountingEvaluator(PRODUCTION_CAP));
+                machine.evaluateComplexity(new WalkCountingEvaluator(UNCAPPED));
+            }
+        }
+
+        System.out.printf(Locale.ROOT, "%-36s %-9s %10s %6s %7s %10s %11s %11s %11s %10s%n",
+                "machine", "cap", "complexity", "walks", "passes", "build_us", "median_us", "min_us", "max_us",
+                "alloc_kb");
+        List<Row> rows = new ArrayList<>();
+        for (Entry entry : selected) {
+            double buildMedianUs = measureBuild(entry, warmupPasses, measurePasses);
+            rows.add(measureAndCheck(entry, PRODUCTION_CAP, warmupPasses, measurePasses, buildMedianUs));
+            if (entry.tier.compareTo(uncapUpTo) <= 0) {
+                boolean repeat = entry.tier == Tier.FAST;
+                rows.add(measureAndCheck(entry, UNCAPPED, repeat ? warmupPasses : 0, repeat ? measurePasses : 1,
+                        buildMedianUs));
+            }
+        }
+        System.out.println();
+
+        if (csv != null) {
+            writeCsv(csv, rows);
+            System.out.println("CSV written to " + csv);
+        }
+    }
+
+    /** The {@code ruler.perf.csv} path with its parent directory created, or null when the property is unset. */
+    private static Path csvPath() throws IOException {
+        String csvPath = System.getProperty("ruler.perf.csv");
+        if (csvPath == null || csvPath.trim().isEmpty()) {
+            return null;
+        }
+        Path csv = Paths.get(csvPath.trim());
+        if (csv.getParent() != null) {
+            Files.createDirectories(csv.getParent());
+        }
+        return csv;
+    }
+
+    /** Comma-separated, case-insensitive substrings from {@code ruler.perf.only}; empty parts are dropped. */
+    private static List<String> onlyFilter() {
+        List<String> only = new ArrayList<>();
+        String onlyProp = System.getProperty("ruler.perf.only");
+        if (onlyProp != null) {
+            for (String part : onlyProp.split(",")) {
+                String needle = part.trim().toLowerCase(Locale.ROOT);
+                if (!needle.isEmpty()) {
+                    only.add(needle);
+                }
+            }
+        }
+        return only;
+    }
+
+    private static boolean matchesFilter(String name, List<String> only) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        for (String needle : only) {
+            if (lower.contains(needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Median wall time of {@code new Machine() + addRule}, over the measured passes. */
+    private static double measureBuild(Entry entry, int warmupPasses, int measurePasses) throws Exception {
+        for (int i = 0; i < warmupPasses; i++) {
+            entry.build();
+        }
+        double[] us = new double[measurePasses];
+        for (int i = 0; i < us.length; i++) {
+            long start = System.nanoTime();
+            entry.build();
+            us[i] = (System.nanoTime() - start) / 1000.0;
+        }
+        return median(us);
+    }
+
+    /**
+     * Times {@code measurePasses} evaluations of the entry's machine under the given cap after {@code warmupPasses}
+     * unmeasured ones, asserts the reported complexity and walk count against the corpus, and prints the row.
+     */
+    private static Row measureAndCheck(Entry entry, int maxComplexity, int warmupPasses, int measurePasses,
+                                       double buildMedianUs) throws Exception {
+        Machine machine = entry.build();
+        for (int i = 0; i < warmupPasses; i++) {
+            machine.evaluateComplexity(new WalkCountingEvaluator(maxComplexity));
+        }
+        ThreadMXBean allocation = allocationCounter();
+        long threadId = Thread.currentThread().getId();
+        double[] us = new double[measurePasses];
+        double[] kb = new double[measurePasses];
+        int complexity = -1;
+        int walks = -1;
+        for (int i = 0; i < measurePasses; i++) {
+            WalkCountingEvaluator evaluator = new WalkCountingEvaluator(maxComplexity);
+            long allocatedBefore = allocation == null ? 0 : allocation.getThreadAllocatedBytes(threadId);
+            long start = System.nanoTime();
+            complexity = machine.evaluateComplexity(evaluator);
+            us[i] = (System.nanoTime() - start) / 1000.0;
+            kb[i] = allocation == null ? Double.NaN
+                    : (allocation.getThreadAllocatedBytes(threadId) - allocatedBefore) / 1024.0;
+            walks = evaluator.getWalks();
+        }
+        String capLabel = maxComplexity == UNCAPPED ? "uncapped" : String.valueOf(maxComplexity);
+        Row row = new Row(entry.name, capLabel, complexity, walks, measurePasses, buildMedianUs, median(us),
+                Arrays.stream(us).min().getAsDouble(), Arrays.stream(us).max().getAsDouble(), median(kb));
+        row.print();
+        // The corpus pins what an uncapped evaluation reports; a capped one reports the lesser of the cap and that.
+        assertEquals(entry.name + " complexity under cap " + capLabel,
+                Math.min(maxComplexity, entry.expectedComplexity), complexity);
+        assertEquals(entry.name + " ByteMachine walks under cap " + capLabel, entry.expectedWalks, walks);
+        return row;
+    }
+
+    /** The JVM's per-thread allocation counter, or null when this JVM does not support or has disabled it. */
+    private static ThreadMXBean allocationCounter() {
+        java.lang.management.ThreadMXBean threads = ManagementFactory.getThreadMXBean();
+        if (!(threads instanceof ThreadMXBean)) {
+            return null;
+        }
+        ThreadMXBean allocation = (ThreadMXBean) threads;
+        return allocation.isThreadAllocatedMemorySupported() && allocation.isThreadAllocatedMemoryEnabled()
+                ? allocation : null;
+    }
+
+    private static void writeCsv(Path path, List<Row> rows) throws IOException {
+        try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(path, StandardCharsets.UTF_8))) {
+            out.println("machine,cap,complexity,walks,passes,build_us,median_us,min_us,max_us,alloc_kb");
+            for (Row row : rows) {
+                out.printf(Locale.ROOT, "%s,%s,%d,%d,%d,%.1f,%.1f,%.1f,%.1f,%.1f%n", row.machine, row.cap,
+                        row.complexity, row.walks, row.passes, row.buildMedianUs, row.medianUs, row.minUs, row.maxUs,
+                        row.allocKb);
+            }
+        }
+    }
+
+    private static int getIntProp(String name, int defaultValue, int minimum) {
+        String value = System.getProperty(name);
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        int parsed = Integer.parseInt(value.trim());
+        if (parsed < minimum) {
+            throw new IllegalArgumentException(name + " must be at least " + minimum + ", got: " + parsed);
+        }
+        return parsed;
+    }
+
+    private static double median(double[] values) {
+        double[] sorted = values.clone();
+        Arrays.sort(sorted);
+        int n = sorted.length;
+        return n % 2 == 1 ? sorted[n / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+    }
+
+}

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorCorpus.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorCorpus.java
@@ -1,0 +1,250 @@
+package software.amazon.event.ruler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Machines whose complexity evaluation has a known cost, shared by {@link MachineComplexityEvaluatorRegressionTest}
+ * (deterministic pins plus generous time bounds, runs in every build) and {@link MachineComplexityEvaluatorBenchmarks}
+ * (timings, opt-in).
+ *
+ * <p>Every machine is built through the public {@code Machine.addRule} API rather than a bare {@code ByteMachine}, so an
+ * evaluation walks the NameState graph too — the recursion into next NameStates across exact-match value lists, and the
+ * absent-key ({@code {"exists": false}}) edges — which a benchmark over a single ByteMachine cannot see.
+ */
+final class MachineComplexityEvaluatorCorpus {
+
+    /**
+     * {@code maxComplexity} of a consumer enforcing a per-rule maximum of 10 (README, complexity strategy #2): 10 + 1,
+     * because the README's snippet rejects on {@code complexity > max}, so the evaluator must be able to report max + 1.
+     */
+    static final int PRODUCTION_CAP = 11;
+
+    /** A cap no machine here reaches: the evaluator reports the machine's true complexity. */
+    static final int UNCAPPED = 1_000_000;
+
+    /** The four anything-but wildcard strings of {@link MachineComplexityEvaluatorWalkCountTest}, all leading with a star. */
+    private static final String[] LEADING_STAR_STRINGS = {
+        "*kiwi*", "*BASE_QuxB*", "*Delta*", "*a/example-lake-abc98765432*",
+    };
+
+    /** The wildcard set that "explodes" a naive automaton; also in {@code MachineComplexityEvaluatorTest}. */
+    private static final String[] QUAMINA_EXPLODER = {
+        "aahed*", "aal*ii", "aargh*", "aarti*", "a*baca", "*abaci", "a*back", "ab*acs", "abaf*t", "*abaka", "ab*amp",
+        "a*band", "*abase", "abash*", "abas*k", "ab*ate", "aba*ya", "abbas*", "abbed*", "ab*bes", "abbey*", "*abbot",
+        "ab*cee", "abea*m", "abe*ar", "a*bele", "a*bers", "abet*s", "*abhor", "abi*de", "a*bies", "*abled",
+    };
+
+    private MachineComplexityEvaluatorCorpus() {
+    }
+
+    /**
+     * How expensive an uncapped evaluation of an entry is, which decides where it runs. Declared in ascending cost
+     * order; the benchmark compares on it.
+     */
+    enum Tier {
+        /** Milliseconds: the regression test evaluates it uncapped and pins the result; the benchmark repeats it. */
+        FAST,
+        /**
+         * Seconds and gigabytes of transient allocation: the regression test evaluates it only under
+         * {@link #PRODUCTION_CAP}; the benchmark evaluates it uncapped once ({@code -Druler.perf.heavy=true}, the
+         * default).
+         */
+        HEAVY,
+        /**
+         * Minutes, with several gigabytes of live heap: the regression test evaluates it only under
+         * {@link #PRODUCTION_CAP}, as the guard that the cap bounds the walk; the benchmark evaluates it uncapped once
+         * only with {@code -Druler.perf.heavy=all}.
+         */
+        EXPENSIVE
+    }
+
+    /**
+     * One machine of the corpus.
+     */
+    static final class Entry {
+        /** Short name, used in test names, benchmark output and {@code -Druler.perf.only}. */
+        final String name;
+        /** The rule JSON the machine is built from. */
+        private final String rule;
+        /** The complexity an uncapped evaluation reports. */
+        final int expectedComplexity;
+        /**
+         * How many ByteMachines an evaluation walks: one per key holding value patterns on every NameState the walk
+         * reaches, exact-match keys included; an absent-key pattern adds no ByteMachine. The count is the same capped
+         * and uncapped for every entry here: a capped walk stops recursing into the NameStates behind a ByteMachine
+         * that reaches the cap, and no entry puts a cap-reaching key ahead of another key. An entry that does needs a
+         * capped and an uncapped count.
+         */
+        final int expectedWalks;
+        /** Cost class of the uncapped evaluation. */
+        final Tier tier;
+
+        private Entry(String name, String rule, int expectedComplexity, int expectedWalks, Tier tier) {
+            this.name = name;
+            this.rule = rule;
+            this.expectedComplexity = expectedComplexity;
+            this.expectedWalks = expectedWalks;
+            this.tier = tier;
+        }
+
+        Machine build() throws Exception {
+            Machine machine = new Machine();
+            machine.addRule(name, rule);
+            return machine;
+        }
+
+        /** The name: JUnit's parameterized runner uses it to label each entry's tests. */
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /**
+     * Counts how many ByteMachine walks an evaluation starts: {@code ByteMachine.evaluateComplexity} calls
+     * {@code evaluate(ByteState)} exactly once, so the count is the number of ByteMachine evaluations.
+     */
+    static final class WalkCountingEvaluator extends MachineComplexityEvaluator {
+        private int walks = 0;
+
+        WalkCountingEvaluator(int maxComplexity) {
+            super(maxComplexity);
+        }
+
+        @Override
+        int evaluate(ByteState state) {
+            walks++;
+            return super.evaluate(state);
+        }
+
+        int getWalks() {
+            return walks;
+        }
+    }
+
+    /**
+     * The corpus, in evaluation-cost order. Expected values are the numbers the evaluator reports at the commit that
+     * introduced this class; a change in any of them is a semantic change to the metric and needs a deliberate decision.
+     */
+    static List<Entry> entries() {
+        List<Entry> entries = new ArrayList<>();
+        // 32 wildcards on one key with heavy prefix sharing: the historical stress input.
+        entries.add(new Entry("quamina-exploder", oneKey("key", wildcards(QUAMINA_EXPLODER)), 45, 1, Tier.FAST));
+        // Four leading-star exclusions, as one anything-but set and as four plain wildcards: the same strings score
+        // differently because an anything-but set is one pattern object and plain wildcards are four.
+        entries.add(new Entry("leading-star-anything-but-set", oneKey("key", anythingButWildcards(LEADING_STAR_STRINGS)),
+                7, 1, Tier.FAST));
+        entries.add(new Entry("leading-star-plain-wildcards", oneKey("key", wildcards(LEADING_STAR_STRINGS)), 12, 1,
+                Tier.FAST));
+        // The production shape: exact-match lists of 2 x 50 x 21 values on keys that sort ahead of the anything-but set.
+        // The evaluator walks each key's machine once (4 walks in all), not once per combination of list values
+        // (2,100 walks of the set's machine).
+        entries.add(new Entry("value-lists-then-anything-but", valueListsThenAnythingBut(), 7, 4, Tier.FAST));
+        // One wildcard "*a*a*...*a*" - n repeats of "*a" then "*", so n + 1 stars - whose repeated character keeps
+        // every position live on a run of that character: complexity 2n + 1, the README's warning about repeating
+        // character sequences following a wildcard character.
+        entries.add(new Entry("multi-star-50", oneKey("zzz", wildcards(multiStar(50))), 101, 1, Tier.FAST));
+        entries.add(new Entry("multi-star-100", oneKey("zzz", wildcards(multiStar(100))), 201, 1, Tier.FAST));
+        // The same 100-repeat machine behind an absent-key pattern whose key sorts before it: the evaluator follows the
+        // NameMatcher edge and reports the open machine's 201.
+        entries.add(new Entry("multi-star-100-behind-absent-key", behindAbsentKey("zzz", wildcards(multiStar(100))),
+                201, 1, Tier.FAST));
+        // m patterns "*<token>*" sharing the leading star: complexity 3m. Uncapped evaluation is exponential in m
+        // because the walk visits every reachable subset of the m trailing-star states (about 30 ms at 8 after
+        // warm-up, 6 s at 12, about three minutes and 7 GB of live heap at 16). Capped at 11, the 12- and 16-pattern
+        // sets return at the walk's first step, since the shared leading star alone reaches m >= 11 patterns.
+        entries.add(new Entry("leading-star-set-4", oneKey("zzz", wildcards(leadingStarSet(4))), 12, 1, Tier.FAST));
+        entries.add(new Entry("leading-star-set-8", oneKey("zzz", wildcards(leadingStarSet(8))), 24, 1, Tier.FAST));
+        entries.add(new Entry("leading-star-set-12", oneKey("zzz", wildcards(leadingStarSet(12))), 36, 1, Tier.HEAVY));
+        entries.add(new Entry("leading-star-set-16", oneKey("zzz", wildcards(leadingStarSet(16))), 48, 1,
+                Tier.EXPENSIVE));
+        // A 4,045-character multi-star wildcard (2,022 repeats) behind an absent key - a rule at the scale of
+        // EventBridge's 4,096-character event-pattern limit, with its whole cost behind a NameMatcher edge. Complexity
+        // 4,045; uncapped evaluation about 15 s with about 6 GB of transient allocation.
+        entries.add(new Entry("multi-star-2022-behind-absent-key", behindAbsentKey("zzz", wildcards(multiStar(2022))),
+                4045, 1, Tier.HEAVY));
+        return Collections.unmodifiableList(entries);
+    }
+
+    // ---- rule builders -------------------------------------------------------------------------------------------
+
+    /** {@code {"<key>": <patterns>}} */
+    private static String oneKey(String key, String patterns) {
+        return "{\"" + key + "\": " + patterns + "}";
+    }
+
+    /** {@code {"aaa": [{"exists": false}], "<key>": <patterns>}} — "aaa" sorts before every key used here. */
+    private static String behindAbsentKey(String key, String patterns) {
+        return "{\"aaa\": [{\"exists\": false}], \"" + key + "\": " + patterns + "}";
+    }
+
+    /** A JSON array of {@code {"wildcard": "<s>"}} patterns. */
+    private static String wildcards(String... values) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.length; i++) {
+            sb.append(i > 0 ? ", " : "").append("{\"wildcard\": \"").append(values[i]).append("\"}");
+        }
+        return sb.append(']').toString();
+    }
+
+    /** A JSON array holding one {@code {"anything-but": {"wildcard": [...]}}} pattern over all the values. */
+    private static String anythingButWildcards(String... values) {
+        StringBuilder sb = new StringBuilder("[{\"anything-but\": {\"wildcard\": [");
+        for (int i = 0; i < values.length; i++) {
+            sb.append(i > 0 ? ", " : "").append('"').append(values[i]).append('"');
+        }
+        return sb.append("]}}]").toString();
+    }
+
+    /** A JSON array of quoted exact-match values. */
+    private static String exactValues(List<String> values) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            sb.append(i > 0 ? ", " : "").append('"').append(values.get(i)).append('"');
+        }
+        return sb.append(']').toString();
+    }
+
+    /** {@code "*a"} repeated the given number of times, then {@code "*"}: n + 1 stars, 2n + 1 characters. */
+    private static String[] multiStar(int repeats) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < repeats; i++) {
+            sb.append("*a");
+        }
+        return new String[] {sb.append('*').toString()};
+    }
+
+    /** {@code "*<token>*"} for the given number of distinct two-letter tokens. */
+    private static String[] leadingStarSet(int patterns) {
+        String[] values = new String[patterns];
+        for (int i = 0; i < patterns; i++) {
+            values[i] = "*" + (char) ('a' + i % 26) + (char) ('a' + i / 26) + "*";
+        }
+        return values;
+    }
+
+    /**
+     * Two error codes x 50 event names (two shared-prefix families) x 21 event sources (one shared-suffix family) as
+     * exact-match lists on keys sorting ahead of the anything-but set.
+     */
+    private static String valueListsThenAnythingBut() {
+        List<String> eventNames = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            eventNames.add("MakeThing" + i);
+        }
+        for (int i = 0; i < 25; i++) {
+            eventNames.add("DropThing" + i);
+        }
+        List<String> eventSources = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            eventSources.add(String.format("svc%02d.example.com", i));
+        }
+        return "{\"aaa\": " + exactValues(Arrays.asList("ErrCodeOne", "ErrCodeTwo"))
+                + ", \"bbb\": " + exactValues(eventNames)
+                + ", \"ccc\": " + exactValues(eventSources)
+                + ", \"zzz\": " + anythingButWildcards(LEADING_STAR_STRINGS) + "}";
+    }
+}

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorRegressionTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorRegressionTest.java
@@ -1,0 +1,92 @@
+package software.amazon.event.ruler;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.Entry;
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.Tier;
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.WalkCountingEvaluator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.PRODUCTION_CAP;
+import static software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.UNCAPPED;
+
+/**
+ * Regression guard for {@link MachineComplexityEvaluator} over the {@link MachineComplexityEvaluatorCorpus}, run in
+ * every build. One test per (entry, cap) pair, labelled with both: every entry under a production-style cap of 11, and
+ * every fast entry uncapped as well — the entries whose uncapped walk takes seconds or minutes are evaluated capped
+ * only, because the walk stops the moment a position set reaches the cap. Each test asserts:
+ *
+ * <ul>
+ *   <li>Deterministic pins: the complexity the evaluation reports (the lesser of the cap and the entry's true value)
+ *   and the number of ByteMachines it walks. A change in a reported value changes the meaning of the metric for every
+ *   consumer enforcing a maximum; a walk count above one per ByteMachine means a machine behind a chain of exact-match
+ *   value lists is walked once per combination of list values (the production shape's 4 walks becoming 2,203).</li>
+ *   <li>A time bound: the evaluation completes within {@link #BOUND_MS}. Measured after warm-up on a 2024 workstation:
+ *   0.2-14 ms capped, 2-32 ms uncapped; about 300 ms for the slowest fast entry in a cold JVM, and the uncapped bound
+ *   is taken on a second evaluation, after the first has paid the cold-JIT cost. A change that defeats the cap fails
+ *   the capped bound of the seconds-and-minutes entries, or their {@link #TIMEOUT_MS} JUnit timeout. The timeout fails
+ *   the test but does not stop the evaluation thread, which keeps running because neither the evaluator nor NameState
+ *   checks for interruption; a defeated cap therefore also leaves a multi-gigabyte walk running in the surefire fork
+ *   behind the red test.</li>
+ * </ul>
+ *
+ * {@link MachineComplexityEvaluatorBenchmarks} prints the timings behind the bounds; run it after any change here.
+ */
+@RunWith(Parameterized.class)
+public class MachineComplexityEvaluatorRegressionTest {
+
+    /** Upper bound for one evaluation. */
+    private static final long BOUND_MS = 5_000;
+
+    /** JUnit stops waiting for a test after this long and fails it; the evaluation thread runs on. */
+    private static final long TIMEOUT_MS = 120_000;
+
+    @Parameters(name = "{0}, {2}")
+    public static Collection<Object[]> entriesAndCaps() {
+        List<Object[]> parameters = new ArrayList<>();
+        for (Entry entry : MachineComplexityEvaluatorCorpus.entries()) {
+            parameters.add(new Object[] {entry, PRODUCTION_CAP, "cap " + PRODUCTION_CAP});
+            if (entry.tier == Tier.FAST) {
+                parameters.add(new Object[] {entry, UNCAPPED, "uncapped"});
+            }
+        }
+        return parameters;
+    }
+
+    private final Entry entry;
+    private final int maxComplexity;
+
+    /** {@code capLabel} only labels the test ({@code "cap 11"} or {@code "uncapped"}). */
+    public MachineComplexityEvaluatorRegressionTest(Entry entry, int maxComplexity, String capLabel) {
+        this.entry = entry;
+        this.maxComplexity = maxComplexity;
+    }
+
+    @Test(timeout = TIMEOUT_MS)
+    public void evaluationReportsThePinnedValueAndWalksWithinBound() throws Exception {
+        Machine machine = entry.build();
+        WalkCountingEvaluator evaluator = new WalkCountingEvaluator(maxComplexity);
+        long start = System.nanoTime();
+        int complexity = machine.evaluateComplexity(evaluator);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        assertEquals(entry + " complexity", Math.min(maxComplexity, entry.expectedComplexity), complexity);
+        assertEquals(entry + " ByteMachine walks", entry.expectedWalks, evaluator.getWalks());
+        if (maxComplexity == UNCAPPED) {
+            // The first evaluation paid the cold-JIT cost of the whole walk; the bound is taken on a second one.
+            start = System.nanoTime();
+            machine.evaluateComplexity(new MachineComplexityEvaluator(maxComplexity));
+            elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        }
+        assertTrue(entry + " evaluation took " + elapsedMs + " ms (complexity " + complexity + "), bound " + BOUND_MS
+                + " ms", elapsedMs < BOUND_MS);
+    }
+}

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorWalkCountTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorWalkCountTest.java
@@ -2,6 +2,8 @@ package software.amazon.event.ruler;
 
 import org.junit.Test;
 
+import software.amazon.event.ruler.MachineComplexityEvaluatorCorpus.WalkCountingEvaluator;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,28 +31,6 @@ public class MachineComplexityEvaluatorWalkCountTest {
      */
     private static final String ANYTHING_BUT_WILDCARD_SET = "[{\"anything-but\": {\"wildcard\": " +
             "[\"*kiwi*\", \"*BASE_QuxB*\", \"*Delta*\", \"*a/example-lake-abc98765432*\"]}}]";
-
-    /**
-     * Counts how many times a ByteMachine walk is started. ByteMachine.evaluateComplexity invokes evaluate(ByteState)
-     * exactly once, so this counts ByteMachine evaluations.
-     */
-    private static class WalkCountingEvaluator extends MachineComplexityEvaluator {
-        private int walks = 0;
-
-        WalkCountingEvaluator(int maxComplexity) {
-            super(maxComplexity);
-        }
-
-        @Override
-        int evaluate(ByteState state) {
-            walks++;
-            return super.evaluate(state);
-        }
-
-        int getWalks() {
-            return walks;
-        }
-    }
 
     /**
      * Complexity of a machine holding only exact matches ahead of a wildcard key equals the complexity of the wildcard


### PR DESCRIPTION
### Issue #, if available:

Fixes #26

### Description of changes:

`MachineComplexityEvaluator` had no benchmark and no cost guard: the two defects fixed in #270 — recursing once per
exact-match list value instead of once per next NameState, and never following `{"exists": false}` edges — each got a
value-level test, and the suite's two timed evaluations cover a capped bare `ByteMachine` and a numeric-only rule; nothing
bounded a wildcard machine's walk across next NameStates and absent-key edges or pinned that the cap holds there, which is
how both stayed invisible until a production rule was measured. This adds a shared corpus of machines whose evaluation cost is known, a
regression test that runs in every build, and a gated benchmark. Test scope only; no `src/main` change.

**`MachineComplexityEvaluatorCorpus`** — the machines, each built through `Machine.addRule` so an evaluation walks the
NameState graph (value transitions, exact-match lists ahead of a wildcard key, absent-key edges) and not only one
`ByteMachine`; a benchmark over a bare `ByteMachine` cannot see either #270 defect. Each entry carries the complexity
and the ByteMachine walk count an evaluation reports, and a tier saying how expensive the uncapped evaluation is:

| machine | complexity | uncapped evaluation |
|---|---|---|
| Quamina exploder (32 wildcards; the set already in `MachineComplexityEvaluatorTest`) | 45 | 32 ms |
| four leading-`*` exclusions as one anything-but set / as four plain wildcards | 7 / 12 | 13 ms / 13 ms |
| exact-match lists of 2 x 50 x 21 values ahead of the anything-but set (the production shape behind #269) | 7 | 14 ms, 4 walks |
| one wildcard `*a*a*…*a*`, `*a` repeated 50 / 100 times | 101 / 201 | 5 ms / 20 ms |
| the 100-repeat machine behind an `{"exists": false}` key | 201 | 19 ms |
| leading-`*` pattern sets `*<tok>*` of 4 / 8 / 12 / 16 patterns | 12 / 24 / 36 / 48 | 2 ms / 0.13 s / 5.3 s / ~3 min and ~7 GB live |
| a 4,045-character wildcard (2,022 repeats) behind an absent key — a rule at the scale of the 4,096-character pattern limit | 4,045 | 15 s |

(Timings from the new benchmark on a 16-core Linux host, Corretto 17.) The leading-`*` sets are the case issue #26's
"consumers with a really high max complexity" would hit: with the cap far above the true value, the walk visits every
reachable subset of the trailing-`*` states and grows about 2.5x per added pattern; capped at 11, the 12- and 16-pattern
sets return at the walk's first step (0.2-0.5 ms) because the shared leading star alone reaches every pattern.

The corpus's `WalkCountingEvaluator` replaces the private copy `MachineComplexityEvaluatorWalkCountTest` held (that test
now imports it; nothing else in it changes).

**`MachineComplexityEvaluatorRegressionTest`** runs in every build, one JUnit test per (machine, cap) — every machine
under a cap of 11 and every fast machine uncapped, 21 tests in about a second, each named like
`[leading-star-set-12, cap 11]`. Each asserts the reported complexity (the lesser of the cap and the true value), the
ByteMachine walk count, and a 5 s bound on the evaluation, under a 120 s JUnit timeout. The machines whose uncapped walk
takes seconds or minutes are evaluated capped only — the walk stops the moment a position set reaches the cap — so a
change that defeats the cap fails the build by the bound or the timeout. Measured after warm-up: 0.08-14 ms capped,
2-32 ms uncapped; the slowest fast machine takes about 300 ms in a cold JVM, and the uncapped bound is taken on a second
evaluation after the first has paid the JIT cost.

Red-proofs, each by editing main code, running the test and reverting: skipping the absent-key edge walk fails the 3
tests over the hidden machines (they report 0); restoring the pre-#270 once-per-ByteMatch recursion walks the production
shape 2,203 times instead of 4 (both its tests fail on the walk pin); disabling the `size >= maxComplexity` return fails
the capped bound of the 12-pattern set at 6.0 s and of the 4,045-character machine at 17.2 s.

**`MachineComplexityEvaluatorBenchmarks`** reports build time, evaluation time and allocation per machine, capped and
uncapped, and asserts the same pins on every row. Gated behind `-Druler.perf.run=true` exactly like `StableBenchmarks`,
taking the same `warmup` / `measure` / `only` / `csv` properties plus `-Druler.perf.heavy` (`false` skips the
seconds-long uncapped evaluations, `true` — the default — runs them once, `all` also runs the minutes-long 16-pattern
set, which needs about 7 GB of live heap). The default run takes about half a minute and fits a 2 GB heap. README's
benchmark section documents both classes.

Verification: `mvn verify` green on Java 17 (818 tests, 0 failures; checkstyle and spotbugs clean); the four touched test
files compile with `javac --release 8`. No JMH class is added, so CI's benchmark step is unchanged.

#### Benchmark / Performance (for source code changes):

```
Test-only change; no source-code performance impact. Default benchmark run at this revision (3 warmup, 10 measured):

machine                              cap       complexity  walks  passes   build_us   median_us   alloc_kb
quamina-exploder                     11                11      1      10     1415.8       570.6      143.3
quamina-exploder                     uncapped          45      1      10     1415.8     31707.4    18806.2
leading-star-anything-but-set        11                 7      1      10      202.9     20112.7    13768.1
leading-star-anything-but-set        uncapped           7      1      10      202.9     12905.7    13768.1
leading-star-plain-wildcards         11                11      1      10      138.4      9904.5    10351.9
leading-star-plain-wildcards         uncapped          12      1      10      138.4     13349.2    13971.4
value-lists-then-anything-but        11                 7      4      10      986.7     15005.4    13907.8
value-lists-then-anything-but        uncapped           7      4      10      986.7     13479.5    13907.3
multi-star-50                        11                11      1      10      207.4       319.4      210.0
multi-star-50                        uncapped         101      1      10      207.4      5264.2     4307.3
multi-star-100                       11                11      1      10      311.6       619.5      357.5
multi-star-100                       uncapped         201      1      10      311.6     19955.3    15643.8
multi-star-100-behind-absent-key     11                11      1      10      289.2       595.8      367.1
multi-star-100-behind-absent-key     uncapped         201      1      10      289.2     19009.7    15636.5
leading-star-set-4                   11                11      1      10       99.6      1857.1     2090.9
leading-star-set-4                   uncapped          12      1      10       99.6      2095.1     2269.6
leading-star-set-8                   11                11      1      10      113.3        76.3       71.3
leading-star-set-8                   uncapped          24      1      10      113.3    127426.5   112466.9
leading-star-set-12                  11                11      1      10      172.5       181.0      143.7
leading-star-set-12                  uncapped          36      1       1      172.5   5327849.0  3913383.7
leading-star-set-16                  11                11      1      10      261.6       454.3      247.0
multi-star-2022-behind-absent-key    11                11      1      10     7267.5     13228.7     6000.0
multi-star-2022-behind-absent-key    uncapped        4045      1       1     7267.5  15393435.9  5829498.7
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
