### PR TITLE
fix: Reject content after the rule's root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,26 @@ Machine machine = Machine.builder()
     .build();
 ```
 
+#### withTrailingContentIgnored
+Default: false (since 2.2.0)
+
+A rule is one JSON object. Since 2.2.0, `addRule()` and `deleteRule()` reject a rule
+followed by anything other than whitespace — an extra `}` or `]`, a `,`, a bare word, a
+second object — with the parse error, and `RuleCompiler.check()` / `JsonRuleCompiler.check()`
+report it. Releases before 2.2.0 stopped reading at the rule's closing brace and ignored
+whatever came after it.
+
+Set this to true only for a machine rebuilt from rules that were stored while the old
+reading was in force and have not been re-validated yet; it restores that reading for
+`addRule()` and `deleteRule()` on that machine. `check()` is not affected — it always
+rejects trailing content, so it is the right tool for finding such rules in a store:
+
+```java
+Machine machine = Machine.builder()
+    .withTrailingContentIgnored(true)
+    .build();
+```
+
 ### addRule()
 
 All forms of this method have the same first argument, a String which provides

--- a/src/main/software/amazon/event/ruler/GenericMachine.java
+++ b/src/main/software/amazon/event/ruler/GenericMachine.java
@@ -451,9 +451,9 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final String json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -466,9 +466,9 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final Reader json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -481,9 +481,9 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final InputStream json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -496,9 +496,9 @@ public class GenericMachine<T> {
      */
     public void addRule(final T name, final byte[] json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> addPatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> addPatternRule(name, rule));
         } catch (JsonParseException e) {
-            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            addPatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -511,9 +511,9 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final String json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -526,9 +526,9 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final Reader json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -541,9 +541,9 @@ public class GenericMachine<T> {
      */
     public void deleteRule(final T name, final InputStream json) throws IOException {
         try {
-            JsonRuleCompiler.compile(json, configuration.isRuleOverriding()).forEach(rule -> deletePatternRule(name, rule));
+            JsonRuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()).forEach(rule -> deletePatternRule(name, rule));
         } catch (JsonParseException e) {
-            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding()));
+            deletePatternRule(name, RuleCompiler.compile(json, configuration.isRuleOverriding(), configuration.isIgnoreTrailingContent()));
         }
     }
 
@@ -837,6 +837,16 @@ public class GenericMachine<T> {
          */
         private boolean useStructuredMatching = true;
 
+        /**
+         * When true, {@code addRule} and {@code deleteRule} stop reading a rule at its root object's closing
+         * brace and ignore anything after it, as every release before 2.2.0 did. Since 2.2.0 the default
+         * rejects such rules: a trailing brace, bracket, comma, bare word, or second object after the rule
+         * is an error. This option is for a machine rebuilt from a store of rules that were accepted before
+         * 2.2.0 and have not yet been re-validated; new rules should be checked with
+         * {@link JsonRuleCompiler#check(String)}, which always rejects trailing content.
+         */
+        private boolean ignoreTrailingContent = false;
+
         Builder() {}
 
         public Builder<M,T> withAdditionalNameStateReuse(boolean additionalNameStateReuse) {
@@ -854,13 +864,18 @@ public class GenericMachine<T> {
             return this;
         }
 
+        public Builder<M, T> withTrailingContentIgnored(boolean ignoreTrailingContent) {
+            this.ignoreTrailingContent = ignoreTrailingContent;
+            return this;
+        }
+
         public M build() {
             return (M) new GenericMachine<T>(buildConfig());
         }
 
         protected GenericMachineConfiguration buildConfig() {
             return new GenericMachineConfiguration(additionalNameStateReuse, ruleOverriding,
-                    useStructuredMatching);
+                    useStructuredMatching, ignoreTrailingContent);
         }
     }
 }

--- a/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
+++ b/src/main/software/amazon/event/ruler/GenericMachineConfiguration.java
@@ -8,6 +8,7 @@ class GenericMachineConfiguration {
     private final boolean additionalNameStateReuse;
     private final boolean ruleOverriding;
     private final boolean useStructuredMatching;
+    private final boolean ignoreTrailingContent;
 
     GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding) {
         this(additionalNameStateReuse, ruleOverriding, false);
@@ -15,9 +16,15 @@ class GenericMachineConfiguration {
 
     GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding,
                                 boolean useStructuredMatching) {
+        this(additionalNameStateReuse, ruleOverriding, useStructuredMatching, false);
+    }
+
+    GenericMachineConfiguration(boolean additionalNameStateReuse, boolean ruleOverriding,
+                                boolean useStructuredMatching, boolean ignoreTrailingContent) {
         this.additionalNameStateReuse = additionalNameStateReuse;
         this.ruleOverriding = ruleOverriding;
         this.useStructuredMatching = useStructuredMatching;
+        this.ignoreTrailingContent = ignoreTrailingContent;
     }
 
     boolean isAdditionalNameStateReuse() {
@@ -34,6 +41,14 @@ class GenericMachineConfiguration {
      */
     boolean isUseStructuredMatching() {
         return useStructuredMatching;
+    }
+
+    /**
+     * When true, {@code addRule} and {@code deleteRule} stop reading a rule at its root object's closing
+     * brace and ignore anything after it, as every release before 2.2.0 did.
+     */
+    boolean isIgnoreTrailingContent() {
+        return ignoreTrailingContent;
     }
 }
 

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -165,8 +165,21 @@ public class JsonRuleCompiler {
             barf(parser, "Filter is not an object");
         }
         parseObject(rules, path, parser, true, withOverriding);
+        requireEndOfInput(parser);
         parser.close();
         return rules;
+    }
+
+    /**
+     * Rejects any content after the rule's root object. Jackson's streaming parser only reads what it is asked
+     * for, so without this read a trailing brace, comma, bare word, or a whole second object would go unexamined
+     * and the rule would compile as if it were valid. A malformed trailer makes nextToken() throw with Jackson's
+     * own message; a well-formed second value returns a token, which is refused here.
+     */
+    static void requireEndOfInput(final JsonParser parser) throws IOException {
+        if (parser.nextToken() != null) {
+            barf(parser, "Filter must be a single JSON object; found content after it");
+        }
     }
 
     private static void parseObject(final List<Map<String, List<Patterns>>> rules,

--- a/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/JsonRuleCompiler.java
@@ -158,14 +158,46 @@ public class JsonRuleCompiler {
         return compile(source, true);
     }
 
+    /*
+     * The compile entry points GenericMachine uses. ignoreTrailingContent selects the pre-2.2.0 reading
+     * (stop at the rule object's closing brace) for machines rebuilt from rules that were accepted then;
+     * see GenericMachine.Builder#withTrailingContentIgnored. Nothing public ignores trailing content.
+     */
+    static List<Map<String, List<Patterns>>> compile(final String source, boolean withOverriding,
+                                                    boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static List<Map<String, List<Patterns>>> compile(final Reader source, boolean withOverriding,
+                                                    boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static List<Map<String, List<Patterns>>> compile(final byte[] source, boolean withOverriding,
+                                                    boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static List<Map<String, List<Patterns>>> compile(final InputStream source, boolean withOverriding,
+                                                    boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
     private static List<Map<String, List<Patterns>>> doCompile(final JsonParser parser, boolean withOverriding) throws IOException {
+        return doCompile(parser, withOverriding, false);
+    }
+
+    private static List<Map<String, List<Patterns>>> doCompile(final JsonParser parser, boolean withOverriding,
+                                                             boolean ignoreTrailingContent) throws IOException {
         final Path path = new Path();
         final List<Map<String, List<Patterns>>> rules = new ArrayList<>();
         if (parser.nextToken() != JsonToken.START_OBJECT) {
             barf(parser, "Filter is not an object");
         }
         parseObject(rules, path, parser, true, withOverriding);
-        requireEndOfInput(parser);
+        if (!ignoreTrailingContent) {
+            requireEndOfInput(parser);
+        }
         parser.close();
         return rules;
     }

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -181,6 +181,7 @@ public final class RuleCompiler {
             barf(parser, "Filter is not an object");
         }
         parseObject(rule, path, parser, true, withOverriding);
+        JsonRuleCompiler.requireEndOfInput(parser);
         parser.close();
         return rule;
     }
@@ -752,6 +753,7 @@ public final class RuleCompiler {
                 barf(parser, "Filter is not an object");
             }
             parseRuleObject(rule, stack, parser, true);
+            JsonRuleCompiler.requireEndOfInput(parser);
             parser.close();
             return rule;
         }

--- a/src/main/software/amazon/event/ruler/RuleCompiler.java
+++ b/src/main/software/amazon/event/ruler/RuleCompiler.java
@@ -174,14 +174,44 @@ public final class RuleCompiler {
         return compile(source, true);
     }
 
+    /*
+     * The compile entry points GenericMachine uses; ignoreTrailingContent as in JsonRuleCompiler.
+     */
+    static Map<String, List<Patterns>> compile(final String source, final boolean withOverriding,
+                                               final boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static Map<String, List<Patterns>> compile(final Reader source, final boolean withOverriding,
+                                               final boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static Map<String, List<Patterns>> compile(final byte[] source, final boolean withOverriding,
+                                               final boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
+    static Map<String, List<Patterns>> compile(final InputStream source, final boolean withOverriding,
+                                               final boolean ignoreTrailingContent) throws IOException {
+        return doCompile(JSON_FACTORY.createParser(source), withOverriding, ignoreTrailingContent);
+    }
+
     private static Map<String, List<Patterns>> doCompile(final JsonParser parser, final boolean withOverriding) throws IOException {
+        return doCompile(parser, withOverriding, false);
+    }
+
+    private static Map<String, List<Patterns>> doCompile(final JsonParser parser, final boolean withOverriding,
+                                                        final boolean ignoreTrailingContent) throws IOException {
         final Path path = new Path();
         final Map<String, List<Patterns>> rule = new HashMap<>();
         if (parser.nextToken() != JsonToken.START_OBJECT) {
             barf(parser, "Filter is not an object");
         }
         parseObject(rule, path, parser, true, withOverriding);
-        JsonRuleCompiler.requireEndOfInput(parser);
+        if (!ignoreTrailingContent) {
+            JsonRuleCompiler.requireEndOfInput(parser);
+        }
         parser.close();
         return rule;
     }

--- a/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/JsonRuleCompilerTest.java
@@ -727,4 +727,59 @@ public class JsonRuleCompilerTest {
         assertNull("", JsonRuleCompiler.check(jsonComplexRule2));
         assertNull("", JsonRuleCompiler.check(jsonComplexRule2, false));
     }
+
+    private static final String VALID_RULE = "{\"orderId\":[{\"exists\":true}]}";
+
+    // Every trailer here is invalid JSON after the rule object, or a second value; Jackson would reject each
+    // one on the next read, so the compiler has to make that read.
+    private static final String[] TRAILING_CONTENT = {
+            VALID_RULE + "}",
+            VALID_RULE + "]",
+            VALID_RULE + ",",
+            VALID_RULE + " garbage",
+            VALID_RULE + "{\"x\":[1]}",
+            VALID_RULE + "}}}}}}",
+            VALID_RULE + " // comment",
+            VALID_RULE + " \"tail\"",
+    };
+
+    @Test
+    public void testContentAfterRuleObjectIsRejected() throws Exception {
+        for (String rule : TRAILING_CONTENT) {
+            assertNotNull("check must reject: " + rule, JsonRuleCompiler.check(rule));
+            assertNotNull("check(Reader) must reject: " + rule, JsonRuleCompiler.check(new StringReader(rule)));
+            assertNotNull("check(byte[]) must reject: " + rule,
+                    JsonRuleCompiler.check(rule.getBytes(StandardCharsets.UTF_8)));
+            try {
+                JsonRuleCompiler.compile(rule);
+                fail("compile must reject: " + rule);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
+            try {
+                new Machine().addRule("r", rule);
+                fail("addRule must reject: " + rule);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testSecondValueAfterRuleObjectNamesTheProblem() {
+        String message = JsonRuleCompiler.check(VALID_RULE + "{\"x\":[1]}");
+        assertNotNull(message);
+        assertTrue(message, message.contains("single JSON object"));
+    }
+
+    @Test
+    public void testWhitespaceAfterRuleObjectStaysValid() throws Exception {
+        for (String rule : new String[] { VALID_RULE, VALID_RULE + " ", VALID_RULE + "\n\t \n" }) {
+            assertNull("check must accept: " + rule, JsonRuleCompiler.check(rule));
+            assertEquals(1, JsonRuleCompiler.compile(rule).size());
+            Machine m = new Machine();
+            m.addRule("r", rule);
+            assertEquals(1, m.rulesForJSONEvent("{\"orderId\": \"abc\"}").size());
+        }
+    }
 }

--- a/src/test/software/amazon/event/ruler/MachineTest.java
+++ b/src/test/software/amazon/event/ruler/MachineTest.java
@@ -3314,4 +3314,58 @@ public class MachineTest {
             assertEquals("event: " + event, expected, new HashSet<>(shared.rulesForJSONEvent(event)));
         }
     }
+
+    @Test
+    public void testTrailingContentIgnoredOnlyWhenConfigured() throws Exception {
+        String event = "{\"orderId\": \"abc\"}";
+        String rule = "{\"orderId\":[{\"exists\":true}]}";
+        String[] withTrailer = { rule + "}", rule + "]", rule + ",", rule + " garbage", rule + "{\"x\":[1]}" };
+
+        // The default reading is strict, for String, Reader, InputStream and byte[] alike.
+        Machine strict = Machine.builder().build();
+        for (String bad : withTrailer) {
+            try {
+                strict.addRule("r", bad);
+                fail("default machine must reject: " + bad);
+            } catch (IOException expected) {
+                assertNotNull(expected.getMessage());
+            }
+            try {
+                strict.addRule("r", new StringReader(bad));
+                fail("default machine (Reader) must reject: " + bad);
+            } catch (IOException expected) {
+                assertNotNull(expected.getMessage());
+            }
+            try {
+                strict.addRule("r", new ByteArrayInputStream(bad.getBytes(StandardCharsets.UTF_8)));
+                fail("default machine (InputStream) must reject: " + bad);
+            } catch (IOException expected) {
+                assertNotNull(expected.getMessage());
+            }
+            try {
+                strict.addRule("r", bad.getBytes(StandardCharsets.UTF_8));
+                fail("default machine (byte[]) must reject: " + bad);
+            } catch (IOException expected) {
+                assertNotNull(expected.getMessage());
+            }
+        }
+        assertTrue(strict.isEmpty());
+
+        // The option restores the pre-2.2.0 reading: the rule before the trailer is what gets added.
+        Machine lenient = Machine.builder().withTrailingContentIgnored(true).build();
+        for (String bad : withTrailer) {
+            lenient.addRule("r", bad);
+            assertEquals(Collections.singletonList("r"), lenient.rulesForJSONEvent(event));
+            lenient.deleteRule("r", bad);
+            assertTrue("deleteRule must accept the same trailer: " + bad, lenient.isEmpty());
+        }
+        lenient.addRule("r", new StringReader(rule + "}"));
+        lenient.addRule("r", new ByteArrayInputStream((rule + "}").getBytes(StandardCharsets.UTF_8)));
+        lenient.addRule("r", (rule + "}").getBytes(StandardCharsets.UTF_8));
+        assertEquals(Collections.singletonList("r"), lenient.rulesForJSONEvent(event));
+
+        // The validators do not take the option: check() rejects the same input whatever a machine is configured to do.
+        assertNotNull(JsonRuleCompiler.check(rule + "}"));
+        assertNotNull(RuleCompiler.check(rule + "}"));
+    }
 }

--- a/src/test/software/amazon/event/ruler/RuleCompilerTest.java
+++ b/src/test/software/amazon/event/ruler/RuleCompilerTest.java
@@ -694,4 +694,43 @@ public class RuleCompilerTest {
         }
 
     }
+
+    private static final String VALID_RULE = "{\"orderId\":[{\"exists\":true}]}";
+
+    private static final String[] TRAILING_CONTENT = {
+            VALID_RULE + "}",
+            VALID_RULE + "]",
+            VALID_RULE + ",",
+            VALID_RULE + " garbage",
+            VALID_RULE + "{\"x\":[1]}",
+    };
+
+    @Test
+    public void testContentAfterRuleObjectIsRejected() throws Exception {
+        for (String rule : TRAILING_CONTENT) {
+            assertNotNull("check must reject: " + rule, RuleCompiler.check(rule));
+            assertNotNull("check(Reader) must reject: " + rule, RuleCompiler.check(new StringReader(rule)));
+            try {
+                RuleCompiler.compile(rule);
+                fail("compile must reject: " + rule);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
+            try {
+                RuleCompiler.ListBasedRuleCompiler.flattenRule(rule);
+                fail("flattenRule must reject: " + rule);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testWhitespaceAfterRuleObjectStaysValid() throws Exception {
+        for (String rule : new String[] { VALID_RULE, VALID_RULE + " ", VALID_RULE + "\n\t \n" }) {
+            assertNull("check must accept: " + rule, RuleCompiler.check(rule));
+            assertEquals(1, RuleCompiler.compile(rule).size());
+            assertEquals(1, RuleCompiler.ListBasedRuleCompiler.flattenRule(rule).size());
+        }
+    }
 }

--- a/src/test/software/amazon/event/ruler/RulerTest.java
+++ b/src/test/software/amazon/event/ruler/RulerTest.java
@@ -1,5 +1,6 @@
 package software.amazon.event.ruler;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -13,6 +14,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RulerTest {
 
@@ -650,6 +652,28 @@ public class RulerTest {
 
         for (int i = 0; i< events.length; i++) {
             assertEquals(events[i], result[i], Ruler.matchesRule(events[i], rule));
+        }
+    }
+
+    @Test
+    public void testRuleWithContentAfterItsObjectIsRejected() throws Exception {
+        String event = "{\"orderId\": \"abc\"}";
+        String rule = "{\"orderId\":[{\"exists\":true}]}";
+        assertTrue(Ruler.matchesRule(event, rule));
+        assertTrue(Ruler.matches(event, rule));
+        for (String bad : new String[] { rule + "}", rule + "{\"x\":[1]}" }) {
+            try {
+                Ruler.matchesRule(event, bad);
+                fail("matchesRule must reject: " + bad);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
+            try {
+                Ruler.matches(event, bad);
+                fail("matches must reject: " + bad);
+            } catch (JsonParseException e) {
+                assertNotNull(e.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #276.

`JsonRuleCompiler.doCompile`, `RuleCompiler.doCompile` and `ListBasedRuleCompiler.doFlattenRule` all read the rule's root object and then close the parser. Jackson's streaming parser tokenizes only what it is asked for, so the bytes after the root object were never examined: a trailing `}`, `]`, `,`, a bare word, or a whole second `{...}` compiled as if the rule were valid, and `Machine.addRule` / `Ruler.matchesRule` accepted and matched such rules.

**Commit 1 — the fix.** One package-private helper, `JsonRuleCompiler.requireEndOfInput(parser)`, called from the three sites after the root object is consumed: the next token must be end-of-input. A malformed trailer makes `nextToken()` throw Jackson's own `JsonParseException` (`Unexpected close marker '}': no open Object to close`, and so on); a second well-formed value returns a token and is refused with `Filter must be a single JSON object; found content after it`. Trailing whitespace stays valid — it is part of a JSON text per RFC 8259 and carries nothing.

**Commit 2 — a migration option for machines built from a legacy store.** `Machine.builder().withTrailingContentIgnored(true)` makes `addRule` and `deleteRule` read a rule the way releases before 2.2.0 did (stop at the root object's closing brace). It exists because a consumer that rebuilds a machine from stored rules may hold rules that were accepted under the old reading, and a rejected stored rule fails the whole machine build; the option lets such a consumer keep serving while it re-validates the store. The default is strict, and `check()` never takes the option, so `check()` is the tool for finding those rules. README documents the option beside `withStructuredMatching`.

**Tests.** Commit 1: five new tests across `JsonRuleCompilerTest`, `RuleCompilerTest` and `RulerTest` — every `check()` overload, `compile()`, `flattenRule`, `Machine.addRule`, `Ruler.matchesRule` and `Ruler.matches` reject each trailer shape; the second-value case carries the compiler's message; whitespace-only trailers still compile and match. Against unmodified `main` (b877fa9) the four rejection tests fail with `check must reject: {"orderId":[{"exists":true}]}}` / `matchesRule must reject: ...` and the whitespace tests pass. Commit 2: `MachineTest.testTrailingContentIgnoredOnlyWhenConfigured` — the default machine rejects every trailer through all four `addRule` input types and stays empty; the configured machine adds, matches, and deletes the same rules; `check()` rejects regardless. With the option wired but the compilers ignoring it, that test fails on the first lenient `addRule`. `mvn verify` on this branch: 804 tests green, checkstyle included.

**Compatibility.** This narrows the accepted input. A rule that was stored with trailing content compiles today and fails to compile after this change unless the machine is built with the option above, so a consumer that rebuilds machines from stored rules should scan the store with the new `check()` before upgrading, and use the option only for the window in which it does. Release notes should call this out; I lean toward a minor bump (2.2.0) for that reason.
