### PR TITLE
feat: Let the complexity evaluator ignore machines behind absent keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,29 @@ public class Validate {
 }
 ```
 
+**Machines behind absent-key patterns.** Since 2.1.0, the evaluator counts the machines a rule reaches only
+through an absent-key pattern (`{"exists": false}`). Matching always traversed those machines at their full
+cost, but releases before 2.1.0 left them out of the evaluation: the rule below evaluated to 0 while costing
+exactly what the same wildcard costs without the `aaa` key. Since 2.1.0 it evaluates to 7, like that wildcard
+alone.
+
+```javascript
+{ "aaa": [ { "exists": false } ], "zzz": [ { "wildcard": "*a*a*a*" } ] }
+```
+
+An application that limits complexity may hold rules that were admitted under the earlier evaluation.
+Calling `withComplexityBehindAbsentKeysIgnored(true)` on an evaluator returns a second evaluator, with the same
+cap, that evaluates the way releases before 2.1.0 did; the application can keep applying it to the rules
+admitted then while it re-validates them under the default. New rules must be evaluated with the default: a
+rule can place any wildcard pattern behind an absent-key pattern and evaluate to 0 under the earlier
+evaluation, so a cap applied through that evaluator bounds nothing for such a rule. Matching is not affected;
+the setting is read only while evaluating complexity.
+
+```java
+MachineComplexityEvaluator evaluator = new MachineComplexityEvaluator(maxComplexity)
+    .withComplexityBehindAbsentKeysIgnored(true);
+```
+
 The main class you'll interact with implements state-machine based rule
 matching.  The interesting methods are:
 

--- a/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
+++ b/src/main/software/amazon/event/ruler/MachineComplexityEvaluator.java
@@ -1,5 +1,6 @@
 package software.amazon.event.ruler;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,12 +29,56 @@ public class MachineComplexityEvaluator {
      */
     private final int maxComplexity;
 
+    /**
+     * When true, a machine reachable only through an absent-key pattern ({@code {"exists": false}}) is left out of
+     * the evaluation, as releases before 2.1.0 left it out. See
+     * {@link #withComplexityBehindAbsentKeysIgnored(boolean)}.
+     */
+    private final boolean complexityBehindAbsentKeysIgnored;
+
     public MachineComplexityEvaluator(int maxComplexity) {
+        this(maxComplexity, false);
+    }
+
+    /**
+     * @param maxComplexity Cap evaluation of complexity at this threshold.
+     * @param complexityBehindAbsentKeysIgnored Whether machines reachable only through an absent-key pattern are left
+     *                                          out of the evaluation; see
+     *                                          {@link #withComplexityBehindAbsentKeysIgnored(boolean)}.
+     */
+    protected MachineComplexityEvaluator(int maxComplexity, boolean complexityBehindAbsentKeysIgnored) {
         this.maxComplexity = maxComplexity;
+        this.complexityBehindAbsentKeysIgnored = complexityBehindAbsentKeysIgnored;
+    }
+
+    /**
+     * Returns an evaluator with the same cap and the given setting. With {@code true} it evaluates machines the way
+     * releases before 2.1.0 did: a machine reachable only through an absent-key pattern ({@code {"exists": false}}) is
+     * left out of the evaluation, so the complexity it adds is not counted. Matching traverses such a machine like
+     * any other, so the complexity the default evaluator reports is the one matching pays. The earlier evaluation
+     * exists for an application that limits complexity and still holds rules admitted under it: the application can
+     * keep applying it to those rules while it re-validates them under the default. Do not admit new rules with it: a
+     * rule can place any wildcard pattern behind an absent-key pattern and evaluate to 0 under the earlier
+     * evaluation, so a cap applied through that evaluator bounds nothing for such a rule. Matching is not affected;
+     * the setting is read only while evaluating complexity.
+     *
+     * @param ignored true to leave the complexity behind absent-key patterns out of the evaluation; false, the
+     *                default, to count it like any other.
+     * @return A new, plain {@code MachineComplexityEvaluator} with this evaluator's cap and the given setting. This
+     *         evaluator is unchanged, and a subclass's overrides do not carry over: a subclass constructs its own
+     *         through the protected constructor.
+     */
+    @CheckReturnValue
+    public MachineComplexityEvaluator withComplexityBehindAbsentKeysIgnored(boolean ignored) {
+        return new MachineComplexityEvaluator(maxComplexity, ignored);
     }
 
     int getMaxComplexity() {
         return maxComplexity;
+    }
+
+    boolean isComplexityBehindAbsentKeysIgnored() {
+        return complexityBehindAbsentKeysIgnored;
     }
 
     /**

--- a/src/main/software/amazon/event/ruler/NameState.java
+++ b/src/main/software/amazon/event/ruler/NameState.java
@@ -308,7 +308,11 @@ class NameState {
         }
         // An absent-key pattern ({"exists": false}) leads to its next NameState through a NameMatcher instead of a
         // ByteMachine. The machines behind that NameState are traversed by matching just like any other, so they
-        // count toward complexity just like any other.
+        // by default count toward complexity just like any other. An evaluator told to ignore them evaluates the
+        // machine the way releases before 2.1.0 did, which never followed these edges.
+        if (evaluator.isComplexityBehindAbsentKeysIgnored()) {
+            return complexity;
+        }
         for (NameMatcher<NameState> nameMatcher : mustNotExistMatchers.values()) {
             NameState nextNameState = nameMatcher.getNextState();
             if (nextNameState != null) {

--- a/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
+++ b/src/test/software/amazon/event/ruler/MachineComplexityEvaluatorTest.java
@@ -3,6 +3,7 @@ package software.amazon.event.ruler;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +11,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermutations;
@@ -23,6 +26,12 @@ import static software.amazon.event.ruler.PermutationsGenerator.generateAllPermu
 public class MachineComplexityEvaluatorTest {
 
     private static final int MAX_COMPLEXITY = 100;
+
+    /**
+     * "aaa" is matched by 7 prefixes of this pattern: "*", "*a", "*a*", "*a*a", "*a*a*", "*a*a*a" and "*a*a*a*".
+     */
+    private static final String WILDCARD_OF_COMPLEXITY_7 = "{\"wildcard\": \"*a*a*a*\"}";
+
     private MachineComplexityEvaluator evaluator;
 
     @Before
@@ -583,10 +592,140 @@ public class MachineComplexityEvaluatorTest {
         assertEquals(2, machine.evaluateComplexity(new MachineComplexityEvaluator(2)));
     }
 
+    @Test
+    public void testComplexityBehindAbsentKeysIsCountedByDefault() {
+        assertFalse(new MachineComplexityEvaluator(MAX_COMPLEXITY).isComplexityBehindAbsentKeysIgnored());
+    }
+
+    @Test
+    public void testWithComplexityBehindAbsentKeysIgnoredReturnsNewEvaluatorWithSameCap() {
+        MachineComplexityEvaluator strict = new MachineComplexityEvaluator(5);
+        MachineComplexityEvaluator ignoring = strict.withComplexityBehindAbsentKeysIgnored(true);
+        assertNotSame(strict, ignoring);
+        assertFalse(strict.isComplexityBehindAbsentKeysIgnored());
+        assertTrue(ignoring.isComplexityBehindAbsentKeysIgnored());
+        assertEquals(5, ignoring.getMaxComplexity());
+        assertFalse(ignoring.withComplexityBehindAbsentKeysIgnored(false).isComplexityBehindAbsentKeysIgnored());
+    }
+
+    @Test
+    public void testSubclassTakesComplexityBehindAbsentKeysIgnoredThroughProtectedConstructor() throws Exception {
+        MachineComplexityEvaluator subclassIgnoring = new MachineComplexityEvaluator(MAX_COMPLEXITY, true) { };
+        assertTrue(subclassIgnoring.isComplexityBehindAbsentKeysIgnored());
+        String rule = "{\"aaa\": [{\"exists\": false}], \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}";
+        for (boolean additionalNameStateReuse : new boolean[] { false, true }) {
+            assertEquals("subclass ignoring, additionalNameStateReuse=" + additionalNameStateReuse, 0,
+                    complexityOfRule(rule, additionalNameStateReuse, subclassIgnoring));
+        }
+    }
+
+    @Test
+    public void testComplexityBehindAbsentKeysIgnoredRestoresPreviousEvaluation() throws Exception {
+        // Keys sort as aaa, zzz, so the wildcard machine on zzz sits behind aaa's absent-key pattern: the default
+        // evaluation counts it, the pre-2.1.0 evaluation never reached it.
+        assertComplexityUnderBothReadings(evaluator,
+                "{\"aaa\": [{\"exists\": false}], \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 0);
+        // "abcdef" is matched by 2 wildcard prefixes: "abc*" and "abc*def".
+        assertComplexityUnderBothReadings(evaluator,
+                "{\"aaa\": [{\"exists\": false}], \"zzz\": [{\"wildcard\": \"abc*def\"}]}", 2, 0);
+        assertComplexityUnderBothReadings(evaluator,
+                "{\"aaa\": {\"inner\": [{\"exists\": false}]}, \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 0);
+        // Without an absent-key pattern both evaluations walk the same machines.
+        assertComplexityUnderBothReadings(evaluator, "{\"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 7);
+        // The absent key sorts after the wildcard key, so the machine sits ahead of the edge the evaluations differ on.
+        assertComplexityUnderBothReadings(evaluator,
+                "{\"zzz\": [{\"exists\": false}], \"aaa\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 7);
+        // A wildcard machine on each side of the absent key: the pre-2.1.0 evaluation stops at the absent-key edge
+        // and reports the machine ahead of it ("aa" is matched by "*", "*a", "*a*"); the default walks past the edge.
+        assertComplexityUnderBothReadings(evaluator, "{\"aaa\": [{\"wildcard\": \"*a*\"}], "
+                + "\"mmm\": [{\"exists\": false}], \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 3);
+        // Only machines reachable through nothing but an absent-key edge are ignored: aaa is absent OR "x" here, so
+        // the machine on zzz is also reachable through aaa's value and both evaluations count it.
+        assertComplexityUnderBothReadings(evaluator,
+                "{\"aaa\": [\"x\", {\"exists\": false}], \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}", 7, 7);
+    }
+
+    @Test
+    public void testComplexityBehindAbsentKeysIgnoredRespectsMaxComplexity() throws Exception {
+        // "aaaaaa" is matched by 13 prefixes of "*a*a*a*a*a*a*"; a cap of 11 stops the walk at 11.
+        String wildcardOfComplexity13 = "{\"wildcard\": \"*a*a*a*a*a*a*\"}";
+        MachineComplexityEvaluator cappedAt11 = new MachineComplexityEvaluator(11);
+        assertComplexityUnderBothReadings(cappedAt11,
+                "{\"aaa\": [{\"exists\": false}], \"zzz\": [" + wildcardOfComplexity13 + "]}", 11, 0);
+        assertComplexityUnderBothReadings(cappedAt11, "{\"zzz\": [" + wildcardOfComplexity13 + "]}", 11, 11);
+    }
+
+    @Test
+    public void testComplexityBehindAbsentKeysIgnoredDoesNotAffectMatching() throws Exception {
+        // The setting lives on the evaluator and is read only while evaluating complexity, so matching cannot depend
+        // on it; this pins that evaluating a machine under either evaluation leaves its matches unchanged.
+        String[] rules = {
+                "{\"aaa\": [{\"exists\": false}], \"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}",
+                "{\"zzz\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}",
+                "{\"aaa\": [{\"exists\": false}], \"zzz\": [{\"wildcard\": \"abc*def\"}]}",
+                "{\"zzz\": [{\"exists\": false}], \"aaa\": [" + WILDCARD_OF_COMPLEXITY_7 + "]}",
+        };
+        String[] events = {
+                "{\"zzz\": \"aaa\"}",
+                "{\"aaa\": 1, \"zzz\": \"aaa\"}",
+                "{\"zzz\": \"abcdef\"}",
+                "{\"aaa\": \"aaa\"}",
+                "{\"aaa\": \"aaa\", \"zzz\": 1}",
+        };
+        // Which events each rule matches, in the order of the events above.
+        boolean[][] expectedMatches = {
+                { true, false, false, false, false },
+                { true, true, false, false, false },
+                { false, false, true, false, false },
+                { false, false, false, true, false },
+        };
+        for (int i = 0; i < rules.length; i++) {
+            Machine machine = Machine.builder().build();
+            machine.addRule("rule", rules[i]);
+            List<Boolean> before = matches(machine, events);
+            for (int j = 0; j < events.length; j++) {
+                assertEquals(rules[i] + " on " + events[j], expectedMatches[i][j], before.get(j));
+            }
+            machine.evaluateComplexity(evaluator);
+            machine.evaluateComplexity(evaluator.withComplexityBehindAbsentKeysIgnored(true));
+            assertEquals("matches after evaluating " + rules[i], before, matches(machine, events));
+        }
+    }
+
+    private static List<Boolean> matches(Machine machine, String[] events) throws Exception {
+        List<Boolean> matches = new ArrayList<>();
+        for (String event : events) {
+            matches.add(!machine.rulesForJSONEvent(event).isEmpty());
+        }
+        return matches;
+    }
+
+    /**
+     * Asserts the complexity of a single-rule machine under the given evaluator and under the same evaluator with the
+     * complexity behind absent keys ignored, in both additionalNameStateReuse configurations.
+     */
+    private void assertComplexityUnderBothReadings(MachineComplexityEvaluator base, String rule,
+                                                   int expectedByDefault, int expectedWhenIgnored) throws Exception {
+        MachineComplexityEvaluator ignoring = base.withComplexityBehindAbsentKeysIgnored(true);
+        for (boolean additionalNameStateReuse : new boolean[] { false, true }) {
+            String configuration = " (cap " + base.getMaxComplexity() + ", additionalNameStateReuse="
+                    + additionalNameStateReuse + ")";
+            assertEquals("default evaluation of " + rule + configuration, expectedByDefault,
+                    complexityOfRule(rule, additionalNameStateReuse, base));
+            assertEquals("complexity behind absent keys ignored for " + rule + configuration, expectedWhenIgnored,
+                    complexityOfRule(rule, additionalNameStateReuse, ignoring));
+        }
+    }
+
     private int complexityOfRule(String rule, boolean additionalNameStateReuse) throws Exception {
+        return complexityOfRule(rule, additionalNameStateReuse, evaluator);
+    }
+
+    private int complexityOfRule(String rule, boolean additionalNameStateReuse,
+                                 MachineComplexityEvaluator complexityEvaluator) throws Exception {
         Machine machine = new Machine.Builder().withAdditionalNameStateReuse(additionalNameStateReuse).build();
         machine.addRule("rule", rule);
-        return machine.evaluateComplexity(evaluator);
+        return machine.evaluateComplexity(complexityEvaluator);
     }
 
     private void testPatternPermutations(int expectedComplexity, Patterns ... patterns) {


### PR DESCRIPTION
Since 2.1.0 (#270), complexity evaluation counts the machines a rule reaches only through an absent-key pattern (`{"exists": false}`). Releases before it never followed those edges: a wildcard machine behind an absent key that sorts ahead of it evaluated to 0 while matching traversed it at full cost. That correction stays the default. An application that limits complexity may still hold rules admitted under the earlier evaluation, though, and evaluating those under the corrected one can reject rules it already serves. This PR adds the migration option for that window, in the shape #277 adds `withTrailingContentIgnored` for the trailing-content fix.

**The option.** `MachineComplexityEvaluator.withComplexityBehindAbsentKeysIgnored(true)` returns an evaluator with the same cap that evaluates machines the pre-2.1.0 way: `NameState.evaluateComplexity` stops at the absent-key edges instead of walking them. The default is unchanged — edges followed, every value identical to 2.1.0. Matching is not affected: the setting is read only while evaluating complexity, and a machine is built and matches the same way under both evaluations. There is no static path to exempt — `check()` and `compile()` never evaluate complexity, and `evaluateComplexity` is the setting's only reader. The method is annotated `@CheckReturnValue` because, unlike the `with…` setters on `Machine.Builder`, it returns a new evaluator and leaves its receiver unchanged (this repo's own SpotBugs check fails a discarded call with `RV_RETURN_VALUE_IGNORED`); a subclass sets the flag through the new `protected` constructor. The javadoc and README name the hazard of the earlier evaluation — a rule can place any wildcard pattern behind an absent-key pattern and evaluate to 0 under it, so it must not be used to admit new rules.

**Why the evaluator and not `Machine.Builder`.** Unlike the trailing-content option, nothing about the machine changes here; only how it is measured differs, and the evaluator already carries the other parameter of a measurement, the cap. The walk's only input is the evaluator (`NameState.evaluateComplexity` → `ByteMachine.evaluateComplexity` → `MachineComplexityEvaluator.evaluate` → `evaluateNextNameStates` → `NameState.evaluateComplexity`), so a builder flag would have to be threaded through four signatures or copied onto a derived evaluator inside `GenericMachine.evaluateComplexity`. The evaluator placement also lets one machine be evaluated both ways — `machine.evaluateComplexity(strict)` beside `machine.evaluateComplexity(strict.withComplexityBehindAbsentKeysIgnored(true))` — which is how an application finds the rules whose verdict the corrected evaluation changes.

**Tests.** Six new tests in `MachineComplexityEvaluatorTest`, each rule under both `additionalNameStateReuse` settings:

| rule | default | ignored |
|---|---|---|
| `{"aaa":[{"exists":false}], "zzz":[{"wildcard":"*a*a*a*"}]}` | 7 | 0 |
| `{"aaa":[{"exists":false}], "zzz":[{"wildcard":"abc*def"}]}` | 2 | 0 |
| `{"aaa":{"inner":[{"exists":false}]}, "zzz":[{"wildcard":"*a*a*a*"}]}` | 7 | 0 |
| `{"zzz":[{"wildcard":"*a*a*a*"}]}` | 7 | 7 |
| `{"zzz":[{"exists":false}], "aaa":[{"wildcard":"*a*a*a*"}]}` — the absent key sorts after the wildcard | 7 | 7 |
| `{"aaa":[{"wildcard":"*a*"}], "mmm":[{"exists":false}], "zzz":[{"wildcard":"*a*a*a*"}]}` | 7 | 3 |
| `{"aaa":["x", {"exists":false}], "zzz":[{"wildcard":"*a*a*a*"}]}` — `aaa` valued or absent, so the machine is also reachable through a value | 7 | 7 |
| the first rule with `*a*a*a*a*a*a*` (complexity 13) under a cap of 11 | 11 | 0 |

Also pinned: the default evaluator has the setting off; `withComplexityBehindAbsentKeysIgnored` returns a new evaluator with the same cap and leaves the original unchanged; a subclass takes the setting through the protected constructor (an anonymous subclass reads 0 for the first rule); evaluating a machine either way leaves its match results unchanged (four rules, five events each).

With the option wired but `NameState.evaluateComplexity` not consulting it, three tests fail: `complexity behind absent keys ignored for {"aaa": [{"exists": false}], "zzz": [{"wildcard": "*a*a*a*"}]} (cap 100, additionalNameStateReuse=false) expected:<0> but was:<7>`, the same for the capped rule (`expected:<0> but was:<11>`), and the subclass test. An implementation that skipped the ByteMachine of a key carrying both a value and an absent-key pattern fails exactly the valued-or-absent case (`expected:<7> but was:<0>`). Against unmodified `main` (b877fa9) the test file does not compile, since the method does not exist there. `mvn verify` on this branch: 803 tests green (main: 797), checkstyle and spotbugs clean.

**Compatibility.** Additive: one new public method, one new protected constructor; the existing constructor and every default are unchanged. Fits the next minor. Against #277: this PR edits `README.md` in a different place (the complexity guidance, before `### Configuration`) and none of #277's Java files, so whichever merges second rebases without a real conflict.